### PR TITLE
Add SnesAddress struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [workspace]
 members = [
+    "common",
     "ppu",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "common"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod snes_address;

--- a/common/src/snes_address.rs
+++ b/common/src/snes_address.rs
@@ -1,0 +1,79 @@
+/// Common struct used to represent memory addresses in the global
+/// SNES adddress space.
+///
+/// The address space is split in 256 64Mo banks.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct SnesAddress {
+    /// The bank number of the address
+    bank: u8,
+
+    /// The memory address within the bank
+    addr: u16,
+}
+
+impl SnesAddress {
+    /// Increment the memory address stored in [`self`]
+    ///
+    /// Returns whether the increment caused a bank change.
+    pub fn increment(&mut self) -> bool {
+        self.addr = self.addr.wrapping_add(1);
+
+        if self.addr != 0 {
+            return false;
+        }
+        self.bank = self.bank.wrapping_add(1);
+        true
+    }
+
+    /// Decrement the memory address stored in [`self`]
+    ///
+    /// Returns whether the decrement caused a bank change.
+    pub fn decrement(&mut self) -> bool {
+        self.addr = self.addr.wrapping_sub(1);
+
+        if self.addr != u16::MAX {
+            return false;
+        }
+        self.bank = self.bank.wrapping_sub(1);
+        true
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::u16;
+
+    use super::*;
+
+    #[test]
+    fn test_simple_increment() {
+        let mut addr = SnesAddress { bank: 0, addr: 1 };
+        assert!(!addr.increment());
+
+        assert_eq!(addr, SnesAddress { bank: 0, addr: 2 });
+    }
+
+    #[test]
+    fn test_simple_decrement() {
+        let mut addr = SnesAddress { bank: 0, addr: 1 };
+        assert!(!addr.decrement());
+
+        assert_eq!(addr, SnesAddress { bank: 0, addr: 0 });
+    }
+
+    #[test]
+    fn test_wrapping_increment() {
+        let mut addr = SnesAddress { bank: 3, addr: u16::MAX };
+        assert!(addr.increment());
+
+        assert_eq!(addr, SnesAddress { bank: 4, addr: 0 });
+    }
+
+    #[test]
+    fn test_wrapping_decrement() {
+        let mut addr = SnesAddress { bank: 3, addr: 0 };
+        assert!(addr.decrement());
+
+        assert_eq!(addr, SnesAddress { bank: 2, addr: u16::MAX });
+    }
+}


### PR DESCRIPTION
Adds a `SnesAddress` struct which we should use in all our crates when referencing addresses in the global SNES address space, instead of passing a tuple `(u8, u16)` for the bank number and address within the bank.

There are also methods to increment/decrement addresses, automatically changing bank numbers when necessary, and returning whether the bank number changed.

Tests ensure correct behaviour
