### PR TITLE
U16Split

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod snes_address;
+pub mod u16_split;

--- a/common/src/u16_split.rs
+++ b/common/src/u16_split.rs
@@ -1,0 +1,87 @@
+pub trait U16Split {
+    fn split<'a>(&'a self) -> SplitU16<'a>;
+    fn split_mut<'a>(&'a mut self) -> SplitU16Mut<'a>;
+
+    fn lo<'a>(&'a self) -> &'a u8 {
+        self.split().lo
+    }
+    fn hi<'a>(&'a self) -> &'a u8 {
+        self.split().hi
+    }
+
+    fn lo_mut<'a>(&'a mut self) -> &'a mut u8 {
+        self.split_mut().lo
+    }
+    fn hi_mut<'a>(&'a mut self) -> &'a mut u8 {
+        self.split_mut().hi
+    }
+}
+
+pub struct SplitU16<'a> {
+    pub lo: &'a u8,
+    pub hi: &'a u8,
+}
+pub struct SplitU16Mut<'a> {
+    pub lo: &'a mut u8,
+    pub hi: &'a mut u8,
+}
+
+impl U16Split for u16 {
+    fn split<'a>(&'a self) -> SplitU16<'a> {
+        let first_byte_ptr = self as *const u16 as *const u8;
+        let second_byte_ptr = unsafe { first_byte_ptr.add(1) };
+        if cfg!(target_endian = "little") {
+            return unsafe { SplitU16 {lo: &*first_byte_ptr, hi: &*second_byte_ptr }};
+        } else {
+            return unsafe { SplitU16 {lo: &*second_byte_ptr, hi: &*first_byte_ptr }};
+        }
+    }
+
+    fn split_mut<'a>(&'a mut self) -> SplitU16Mut<'a> {
+        let first_byte_ptr = self as *mut u16 as *mut u8;
+        let second_byte_ptr = unsafe { first_byte_ptr.add(1) };
+        if cfg!(target_endian = "little") {
+            return unsafe { SplitU16Mut {lo: &mut *first_byte_ptr, hi: &mut *second_byte_ptr }};
+        } else {
+            return unsafe { SplitU16Mut {lo: &mut *second_byte_ptr, hi: &mut *first_byte_ptr }};
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_split_u16() {
+        let my_u16: u16 = 0x1234;
+
+        let byte_refs = my_u16.split();
+
+        println!("lo: {:#x}, hi: {:#x}", byte_refs.lo, byte_refs.hi);
+        assert_eq!(*byte_refs.hi, 0x12);
+        assert_eq!(*byte_refs.lo, 0x34);
+
+        assert_eq!(my_u16, 0x1234);
+    }
+
+    #[test]
+    fn test_split_u16_mut() {
+        let mut my_u16: u16 = 0x1234;
+
+        let byte_refs = my_u16.split_mut();
+
+        assert_eq!(*byte_refs.hi, 0x12);
+        assert_eq!(*byte_refs.lo, 0x34);
+
+        *byte_refs.lo = 0xee;
+
+        // drop(byte_refs) // byte_refs is implicitly dropped as we start
+        //                    reading from my_u16 again
+        assert_eq!(my_u16, 0x12ee);
+
+        // we can also assign directly from the method call
+        *my_u16.hi_mut() = 0xaa;
+        assert_eq!(my_u16, 0xaaee);
+    }
+}

--- a/common/src/u16_split.rs
+++ b/common/src/u16_split.rs
@@ -1,28 +1,49 @@
+/// Extension trait for [`u16`] which defines additional methods
+/// allowing to "split" references (mutable or not) to a [`u16`] into
+/// two separate references to its individual bytes (as [`u8`]s)
 pub trait U16Split {
+    /// Split an immutable reference to a [`u16`] into two
+    /// immutable references to its bytes (as [`u8`]s)
     fn split<'a>(&'a self) -> SplitU16<'a>;
+    /// Split a mutable reference to a [`u16`] into two
+    /// mutable references to its bytes (as [`u8`]s)
     fn split_mut<'a>(&'a mut self) -> SplitU16Mut<'a>;
 
+    /// Get an immutable reference to the least significant byte of a [`u16`]
     fn lo<'a>(&'a self) -> &'a u8 {
         self.split().lo
     }
+    /// Get an immutable reference to the most significant byte of a [`u16`]
     fn hi<'a>(&'a self) -> &'a u8 {
         self.split().hi
     }
 
+    /// Get an mutable reference to the least significant byte of a [`u16`]
     fn lo_mut<'a>(&'a mut self) -> &'a mut u8 {
         self.split_mut().lo
     }
+    /// Get an mutable reference to the most significant byte of a [`u16`]
     fn hi_mut<'a>(&'a mut self) -> &'a mut u8 {
         self.split_mut().hi
     }
 }
 
+/// Helper struct which contains two immutable references
+/// to the individual bytes of a [`u16`]
 pub struct SplitU16<'a> {
+    /// Ref to the least signicant byte
     pub lo: &'a u8,
+    /// Ref to the most significant byte
     pub hi: &'a u8,
+
 }
+
+/// Helper struct which contains two immutable references
+/// to the individual bytes of a [`u16`]
 pub struct SplitU16Mut<'a> {
+    /// Mut ref to the least significant byte
     pub lo: &'a mut u8,
+    /// Mut ref to the most significant byte
     pub hi: &'a mut u8,
 }
 

--- a/common/src/u16_split.rs
+++ b/common/src/u16_split.rs
@@ -35,7 +35,6 @@ pub struct SplitU16<'a> {
     pub lo: &'a u8,
     /// Ref to the most significant byte
     pub hi: &'a u8,
-
 }
 
 /// Helper struct which contains two immutable references
@@ -51,21 +50,23 @@ impl U16Split for u16 {
     fn split<'a>(&'a self) -> SplitU16<'a> {
         let first_byte_ptr = self as *const u16 as *const u8;
         let second_byte_ptr = unsafe { first_byte_ptr.add(1) };
-        if cfg!(target_endian = "little") {
-            return unsafe { SplitU16 {lo: &*first_byte_ptr, hi: &*second_byte_ptr }};
+        let (lo, hi) = if cfg!(target_endian = "little") {
+            unsafe { (&*first_byte_ptr, &*second_byte_ptr) }
         } else {
-            return unsafe { SplitU16 {lo: &*second_byte_ptr, hi: &*first_byte_ptr }};
-        }
+            unsafe { (&*second_byte_ptr, &*first_byte_ptr) }
+        };
+        SplitU16 { lo, hi }
     }
 
     fn split_mut<'a>(&'a mut self) -> SplitU16Mut<'a> {
         let first_byte_ptr = self as *mut u16 as *mut u8;
         let second_byte_ptr = unsafe { first_byte_ptr.add(1) };
-        if cfg!(target_endian = "little") {
-            return unsafe { SplitU16Mut {lo: &mut *first_byte_ptr, hi: &mut *second_byte_ptr }};
+        let (lo, hi) = if cfg!(target_endian = "little") {
+            unsafe { (&mut *first_byte_ptr, &mut *second_byte_ptr) }
         } else {
-            return unsafe { SplitU16Mut {lo: &mut *second_byte_ptr, hi: &mut *first_byte_ptr }};
-        }
+            unsafe { (&mut *second_byte_ptr, &mut *first_byte_ptr) }
+        };
+        SplitU16Mut { lo, hi }
     }
 }
 


### PR DESCRIPTION
Simple PR which adds a utility in our `common` crate: `u16_split`

It allows splitting (immutable/mutable) references to a `u16` into two references to its individual bytes (as references to `u8`s).

The implementation required to use `unsafe` to make use of raw pointers to create references to `u8`. I believe I respected the constraints of `unsafe` which makes these functions safe to use.

---

I also tested tested whether the compiler was able to optimise the use of these functions when accessing a single byte of a `u16`, and when enabling enough optimisations (from `-C opt-level=2` onwards IIRC): the two following functions compile to the same assembly code (so the compiler *is* indeed able to optimise out the abstractions properly).
```
#[inline(never)]
pub fn set_hi1(mut x: u16) -> u16 {
    *x.hi_mut() = 0xfe;
    x
}
#[inline(never)]
pub fn set_hi2(x: u16) -> u16 {
    (x & 0x00ff) | 0xfe00
}
```
(i had to use `#[inline(never)]` because from opt level 2 the compiler decided to always inline the functions and stopped producing assembly code for them when compiling them by themselves)
(actually even better than producing the same assembly code, the compiler made one function an alias of the other (from what I understand of the following assembly)):
```s
	.intel_syntax noprefix
	.file	"test1.8159662b3423405c-cgu.0"
	.section	.text._ZN5test17set_hi117had2caf20830d439cE,"ax",@progbits
	.globl	_ZN5test17set_hi117had2caf20830d439cE
	.p2align	4
	.type	_ZN5test17set_hi117had2caf20830d439cE,@function
_ZN5test17set_hi117had2caf20830d439cE:
	.cfi_startproc
	movzx	eax, dil
	or	eax, 65024
	ret
.Lfunc_end0:
	.size	_ZN5test17set_hi117had2caf20830d439cE, .Lfunc_end0-_ZN5test17set_hi117had2caf20830d439cE
	.cfi_endproc

	.globl	_ZN5test17set_hi217h305aee47e557012eE
	.type	_ZN5test17set_hi217h305aee47e557012eE,@function
.set _ZN5test17set_hi217h305aee47e557012eE, _ZN5test17set_hi117had2caf20830d439cE
	.ident	"rustc version 1.89.0 (29483883e 2025-08-04) (built from a source tarball)"
	.section	".note.GNU-stack","",@progbits
```
