### PR TITLE
:sparkles: Init CPU meta-language

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "ppu",
     "cpu",
     "apu",
+    "cpu/instr_metalang_procmacro"
 ]
 
 [dependencies]

--- a/cpu/instr_metalang_procmacro/Cargo.toml
+++ b/cpu/instr_metalang_procmacro/Cargo.toml
@@ -12,4 +12,4 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 prettyplease = "0.2.37"
-syn = "2.0"
+syn = { version = "2.0", features = ["full", "extra-traits"]}

--- a/cpu/instr_metalang_procmacro/Cargo.toml
+++ b/cpu/instr_metalang_procmacro/Cargo.toml
@@ -1,0 +1,11 @@
+[lib]
+proc-macro = true
+
+[package]
+name = "instr_metalang_procmacro"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/cpu/instr_metalang_procmacro/Cargo.toml
+++ b/cpu/instr_metalang_procmacro/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2024"
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[dev-dependencies]
+prettyplease = "0.2.37"
+syn = "2.0"

--- a/cpu/instr_metalang_procmacro/src/lib.rs
+++ b/cpu/instr_metalang_procmacro/src/lib.rs
@@ -37,3 +37,41 @@ pub(crate) fn cpu_instr2(input: TokenStream) -> TokenStream {
 pub fn cpu_instr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     cpu_instr2(input.into()).into()
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_inx() {
+        let input = quote!(instr_inx {
+            cpu.registers.X = cpu.registers.X.wrapping_add(1);
+            cpu.registers.P.Z = cpu.registers.X == 0;
+            cpu.registers.P.N = cpu.registers.X > 0x7fff;
+
+            meta END_INSTR Internal;
+        });
+
+        let output = cpu_instr2(input);
+
+        print!("{}", prettyplease::unparse(&syn::parse2(output).unwrap()))
+    }
+
+    #[test]
+    fn test_some_instr() {
+        let input = quote!(some_instr {
+            some_function1(cpu);
+            meta END_CYCLE Internal;
+
+            some_function2(cpu);
+            meta END_CYCLE Read;
+
+            some_function3(cpu);
+            meta END_INSTR Write;
+        });
+
+        let output = cpu_instr2(input);
+
+        print!("{}", prettyplease::unparse(&syn::parse2(output).unwrap()))
+    }
+}

--- a/cpu/instr_metalang_procmacro/src/lib.rs
+++ b/cpu/instr_metalang_procmacro/src/lib.rs
@@ -1,0 +1,39 @@
+mod parser;
+
+use parser::{Cycle, Instr};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+pub(crate) fn cpu_instr2(input: TokenStream) -> TokenStream {
+    let Instr { name, cycles } = match parser::Instr::try_from(input) {
+        Ok(instr) => instr,
+        Err(msg) => panic!("{}", msg),
+    };
+
+    let cycle_funcs = cycles
+        .iter()
+        .enumerate()
+        .map(|(i, Cycle { body, cyc_type })| {
+            let func_name = format_ident!("{}_cyc{}", name, i + 1);
+            let next_func_name = if i != cycles.len() - 1 {
+                format_ident!("{}_cyc{}", name, i + 2)
+            } else {
+                format_ident!("opcode_fetch")
+            };
+
+            quote! {
+                pub(crate) fn #func_name(cpu: &mut CPU) -> (CycleResult, InstrCycle) {
+                    #body
+
+                    (CycleResult::#cyc_type, InstrCycle(#next_func_name))
+                }
+            }
+        });
+
+    TokenStream::from_iter(cycle_funcs)
+}
+
+#[proc_macro]
+pub fn cpu_instr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    cpu_instr2(input.into()).into()
+}

--- a/cpu/instr_metalang_procmacro/src/parser.rs
+++ b/cpu/instr_metalang_procmacro/src/parser.rs
@@ -1,0 +1,116 @@
+use pm2::{Ident, TokenStream, TokenTree};
+use proc_macro2 as pm2;
+
+pub(crate) enum MetaInstruction {
+    EndCycle(Ident),
+    EndInstr(Ident),
+}
+
+impl MetaInstruction {
+    fn is_end_instr(&self) -> bool {
+        match self {
+            Self::EndInstr(_) => true,
+            _ => false,
+        }
+    }
+}
+
+impl MetaInstruction {
+    fn try_from<I: IntoIterator<Item = TokenTree>>(value: I) -> Result<Self, &'static str> {
+        let mut it = value.into_iter();
+
+        let Some(TokenTree::Ident(meta_kw)) = it.next() else {
+            Err("Expecting a meta-keyword")?
+        };
+        let ret = match meta_kw.to_string().as_str() {
+            "END_CYCLE" => {
+                let Some(TokenTree::Ident(cyc_type)) = it.next() else {
+                    Err("END_CYCLE expects an identifier operand (cycle type)")?
+                };
+                MetaInstruction::EndCycle(cyc_type)
+            }
+
+            "END_INSTR" => {
+                let Some(TokenTree::Ident(cyc_type)) = it.next() else {
+                    Err("INSTR expects an identifier operand (cycle type)")?
+                };
+                MetaInstruction::EndInstr(cyc_type)
+            }
+
+            _ => Err("Unknown meta-keyword")?,
+        };
+        if it.next().is_some() {
+            Err("Unexpected token after end of meta-instruction")?
+        }
+        Ok(ret)
+    }
+}
+
+pub(crate) struct Instr {
+    pub name: Ident,
+    pub cycles: Vec<Cycle>,
+}
+
+impl Instr {
+    fn new(name: Ident) -> Self {
+        Self {
+            name,
+            cycles: vec![],
+        }
+    }
+}
+
+impl TryFrom<TokenStream> for Instr {
+    fn try_from(stream: TokenStream) -> Result<Self, Self::Error> {
+        let mut it = stream.into_iter();
+        let Some(TokenTree::Ident(name)) = it.next() else {
+            Err("Expecting the instruction name")?
+        };
+        let Some(TokenTree::Group(body)) = it.next() else {
+            Err("Expecting the instruction body")?
+        };
+        if it.next().is_some() {
+            Err("Unexpected token after the instruction body")?
+        }
+
+        let mut it = body.stream().into_iter().peekable();
+        let mut ret = Instr::new(name);
+        loop {
+            let it = it.by_ref();
+            let cycle_body = it.take_while(|token| token.to_string() != "meta");
+            let body_tok_stream = TokenStream::from_iter(cycle_body);
+            let meta_instr = MetaInstruction::try_from(it.take_while(|token| {
+                let TokenTree::Punct(p) = token else {
+                    return true;
+                };
+                return p.as_char() != ';';
+            }))?;
+
+            if it.peek().is_none() && !meta_instr.is_end_instr() {
+                Err("Instructions must end by an END_INSTR meta instruction")?
+            }
+
+            match meta_instr {
+                MetaInstruction::EndCycle(c) => ret.cycles.push(Cycle::new(body_tok_stream, c)),
+                MetaInstruction::EndInstr(c) => ret.cycles.push(Cycle::new(body_tok_stream, c)),
+            }
+
+            if it.peek().is_none() {
+                break;
+            }
+        }
+        Ok(ret)
+    }
+    type Error = &'static str;
+}
+
+pub(crate) struct Cycle {
+    pub body: TokenStream,
+    pub cyc_type: Ident,
+}
+
+impl Cycle {
+    fn new(body: TokenStream, cyc_type: Ident) -> Self {
+        Self { body, cyc_type }
+    }
+}


### PR DESCRIPTION
"Simple" PR for the issue mentioned below.
This PR implements a Rust procedural macro that will help me write
CPU instructions in a concise way. It's very likely that I will
change many things in the code added by this PR in the near future,
but I feel like it's good to let you review the early version which
already works and can be unit-tested properly.

Feel free to ask any question about weird things I do with the token
stream manipulation functions, a lot of this can be unintuitive.

closes EpitechPromo2027/G-EIP-600-NAN-6-1-eip-florent.charpentier#23
