### PR TITLE
ppu registers  cgram refac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 name = "ppu"
 version = "0.1.0"
 dependencies = [
+ "common",
  "sdl2",
 ]
 

--- a/ppu/Cargo.toml
+++ b/ppu/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+common = { path = "../common" }
 sdl2 = "0.38"

--- a/ppu/src/cgram.rs
+++ b/ppu/src/cgram.rs
@@ -1,10 +1,30 @@
 use crate::constants::CGRAM_SIZE;
 
+/// Helper enum to keep track of the byte phase in the CGRAM
+#[derive(Debug, PartialEq, Eq)]
+enum BytePhase {
+    /// Next read/write affects the low byte of the addressed word
+    Low,
+
+    /// Next read/write affects the high byte of the addressed word
+    High,
+}
+use BytePhase::*;
+
+impl BytePhase {
+    fn flip(&mut self) {
+        *self = match self {
+            Low => High,
+            High => Low,
+        };
+    }
+}
+
 pub struct CGRAM {
     pub memory: [u8; CGRAM_SIZE],
 
     byte_addr: u16, // Internal 9-bit byte address (0–511)
-    byte_phase: u8, // 0 = low byte phase, 1 = high byte phase
+    byte_phase: BytePhase,
     write_latch: u8,
 
     pub ppu_open_bus: u8, // bit 7 used during high-byte read
@@ -15,7 +35,7 @@ impl CGRAM {
         Self {
             memory: [0; CGRAM_SIZE],
             byte_addr: 0,
-            byte_phase: 0,
+            byte_phase: Low,
             write_latch: 0,
             ppu_open_bus: 0,
         }
@@ -27,7 +47,7 @@ impl CGRAM {
 
     pub fn write_addr(&mut self, value: u8) {
         self.byte_addr = ((value as u16) << 1) & 0x1FF;
-        self.byte_phase = 0;
+        self.byte_phase = Low;
     }
 
     // ============================================================
@@ -35,7 +55,7 @@ impl CGRAM {
     // ============================================================
 
     pub fn write_data(&mut self, value: u8) {
-        if self.byte_phase == 0 {
+        if self.byte_phase == Low {
             self.write_latch = value;
             self.byte_addr = (self.byte_addr + 1) & 0x1FF;
         } else {
@@ -43,7 +63,7 @@ impl CGRAM {
             self.memory[self.byte_addr as usize] = value & 0x7F;
             self.byte_addr = (self.byte_addr + 1) & 0x1FF;
         }
-        self.byte_phase ^= 1;
+        self.byte_phase.flip();
         self.ppu_open_bus = value;
     }
 
@@ -55,12 +75,12 @@ impl CGRAM {
         let addr = self.byte_addr & 0x1FF;
         let mut value = self.memory[addr as usize];
 
-        if self.byte_phase == 1 {
+        if self.byte_phase == High {
             // High byte read -> bit 7 comes from PPU open bus
             value = (value & 0x7F) | (self.ppu_open_bus & 0x80);
         }
         self.byte_addr = (self.byte_addr + 1) & 0x1FF;
-        self.byte_phase ^= 1;
+        self.byte_phase.flip();
         self.ppu_open_bus = value;
 
         value
@@ -94,7 +114,7 @@ mod tests {
         cgram.write_addr(5);
 
         assert_eq!(cgram.byte_addr, 10); // 5 << 1
-        assert_eq!(cgram.byte_phase, 0);
+        assert_eq!(cgram.byte_phase, Low);
     }
 
     // ============================================================
@@ -135,7 +155,7 @@ mod tests {
         let mut cgram = CGRAM::new();
 
         cgram.byte_addr = 0x1FF;
-        cgram.byte_phase = 0;
+        cgram.byte_phase = Low;
 
         cgram.write_data(0x11);
 

--- a/ppu/src/cgram.rs
+++ b/ppu/src/cgram.rs
@@ -1,4 +1,5 @@
 use crate::constants::CGRAM_SIZE;
+use common::u16_split::U16Split;
 
 /// Helper enum to keep track of the byte phase in the CGRAM
 #[derive(Debug, PartialEq, Eq)]
@@ -21,9 +22,9 @@ impl BytePhase {
 }
 
 pub struct CGRAM {
-    pub memory: [u8; CGRAM_SIZE],
+    pub memory: [u16; CGRAM_SIZE],
 
-    byte_addr: u16, // Internal 9-bit byte address (0–511)
+    word_addr: u8, // Internal 8-bit word address (0–255)
     byte_phase: BytePhase,
     write_latch: u8,
 
@@ -34,7 +35,7 @@ impl CGRAM {
     pub fn new() -> Self {
         Self {
             memory: [0; CGRAM_SIZE],
-            byte_addr: 0,
+            word_addr: 0,
             byte_phase: Low,
             write_latch: 0,
             ppu_open_bus: 0,
@@ -46,7 +47,7 @@ impl CGRAM {
     // ============================================================
 
     pub fn write_addr(&mut self, value: u8) {
-        self.byte_addr = ((value as u16) << 1) & 0x1FF;
+        self.word_addr = value;
         self.byte_phase = Low;
     }
 
@@ -57,11 +58,10 @@ impl CGRAM {
     pub fn write_data(&mut self, value: u8) {
         if self.byte_phase == Low {
             self.write_latch = value;
-            self.byte_addr = (self.byte_addr + 1) & 0x1FF;
         } else {
-            self.memory[(self.byte_addr - 1) as usize & 0x1FF] = self.write_latch;
-            self.memory[self.byte_addr as usize] = value & 0x7F;
-            self.byte_addr = (self.byte_addr + 1) & 0x1FF;
+            let word = (self.write_latch as u16) | (((value & 0x7F) as u16) << 8);
+            self.memory[self.word_addr as usize] = word;
+            self.word_addr = self.word_addr.wrapping_add(1);
         }
         self.byte_phase.flip();
         self.ppu_open_bus = value;
@@ -72,14 +72,16 @@ impl CGRAM {
     // ============================================================
 
     pub fn read_data(&mut self) -> u8 {
-        let addr = self.byte_addr & 0x1FF;
-        let mut value = self.memory[addr as usize];
+        let word = self.memory[self.word_addr as usize];
+        let value = match self.byte_phase {
+            Low => *word.lo(),
+            // bit 7 of high byte comes from open bus
+            High => *word.hi() | (self.ppu_open_bus & 0x80),
+        };
 
         if self.byte_phase == High {
-            // High byte read -> bit 7 comes from PPU open bus
-            value = (value & 0x7F) | (self.ppu_open_bus & 0x80);
+            self.word_addr = self.word_addr.wrapping_add(1);
         }
-        self.byte_addr = (self.byte_addr + 1) & 0x1FF;
         self.byte_phase.flip();
         self.ppu_open_bus = value;
 
@@ -90,11 +92,8 @@ impl CGRAM {
     // Helpers
     // ============================================================
 
-    pub fn current_word(&self, word_index: u8) -> u16 {
-        let base = ((word_index as u16) << 1) & 0x1FF;
-        let low = self.memory[base as usize] as u16;
-        let high = self.memory[(base + 1) as usize] as u16;
-        (high << 8) | low
+    pub fn read(&self, word_index: u8) -> u16 {
+        self.memory[word_index as usize]
     }
 }
 
@@ -108,12 +107,14 @@ mod tests {
 
     // This test verifies that writing to CGADD correctly sets the byte address and resets the byte phase.
     #[test]
-    fn test_write_addr_sets_byte_address() {
+    fn test_write_addr_sets_word_address() {
         let mut cgram = CGRAM::new();
+
+        cgram.byte_phase = High;
 
         cgram.write_addr(5);
 
-        assert_eq!(cgram.byte_addr, 10); // 5 << 1
+        assert_eq!(cgram.word_addr, 5);
         assert_eq!(cgram.byte_phase, Low);
     }
 
@@ -131,8 +132,7 @@ mod tests {
         cgram.write_data(0x34); // low
         cgram.write_data(0x12); // high
 
-        assert_eq!(cgram.memory[4], 0x34);
-        assert_eq!(cgram.memory[5], 0x12 & 0x7F);
+        assert_eq!(cgram.memory[2], 0x1234 & 0x7FFF);
     }
 
     // This test verifies that the high byte write masks out bit 7 (unused bit 15).
@@ -145,21 +145,21 @@ mod tests {
         cgram.write_data(0xAA);
         cgram.write_data(0xFF); // bit 7 should be masked
 
-        assert_eq!(cgram.memory[0], 0xAA);
-        assert_eq!(cgram.memory[1], 0x7F);
+        assert_eq!(cgram.memory[0], 0x7FAA);
     }
 
-    // This test verifies that the internal byte address wraps correctly at the 9-bit boundary.
+    // This test verifies that the internal word address wraps
+    // correctly at the 8-bit boundary.
     #[test]
-    fn test_byte_addr_wraps_9bit() {
+    fn test_word_addr_wraps_8bit() {
         let mut cgram = CGRAM::new();
 
-        cgram.byte_addr = 0x1FF;
-        cgram.byte_phase = Low;
+        cgram.word_addr = 0xFF;
+        cgram.byte_phase = High;
 
         cgram.write_data(0x11);
 
-        assert_eq!(cgram.byte_addr, 0);
+        assert_eq!(cgram.word_addr, 0);
     }
 
     // ============================================================
@@ -171,8 +171,7 @@ mod tests {
     fn test_read_data_low_high_sequence() {
         let mut cgram = CGRAM::new();
 
-        cgram.memory[0] = 0x78;
-        cgram.memory[1] = 0x56;
+        cgram.memory[0] = 0x5678;
 
         cgram.write_addr(0);
 
@@ -203,18 +202,18 @@ mod tests {
     // OTHERS
     // ============================================================
 
-    // This test verifies that current_word correctly reconstructs a 16-bit value from CGRAM.
-    #[test]
-    fn test_current_word_reads_correct_value() {
-        let mut cgram = CGRAM::new();
-
-        cgram.memory[10] = 0xCD;
-        cgram.memory[11] = 0xAB;
-
-        let word = cgram.current_word(5);
-
-        assert_eq!(word, 0xABCD);
-    }
+    // // This test verifies that current_word correctly reconstructs a 16-bit value from CGRAM.
+    // #[test]
+    // fn test_current_word_reads_correct_value() {
+    //     let mut cgram = CGRAM::new();
+    //
+    //     cgram.memory[10] = 0xCD;
+    //     cgram.memory[11] = 0xAB;
+    //
+    //     let word = cgram.current_word(5);
+    //
+    //     assert_eq!(word, 0xABCD);
+    // }
 
     // $2121 & $2122
     // This test verifies that sequential writes correctly store multiple words in memory.
@@ -230,9 +229,7 @@ mod tests {
         cgram.write_data(0x33);
         cgram.write_data(0x44);
 
-        assert_eq!(cgram.memory[0], 0x11);
-        assert_eq!(cgram.memory[1], 0x22 & 0x7F);
-        assert_eq!(cgram.memory[2], 0x33);
-        assert_eq!(cgram.memory[3], 0x44 & 0x7F);
+        assert_eq!(cgram.memory[0], 0x2211 & 0x7FFF);
+        assert_eq!(cgram.memory[1], 0x4433 & 0x7FFF);
     }
 }

--- a/ppu/src/constants.rs
+++ b/ppu/src/constants.rs
@@ -1,5 +1,5 @@
 pub const VRAM_SIZE: usize = 64 * 1024; // 64 KB
-pub const CGRAM_SIZE: usize = 256 * 2; // 512 octets
+pub const CGRAM_SIZE: usize = 256; // 512 octets
 
 pub const SCREEN_WIDTH: usize = 256;
 pub const SCREEN_HEIGHT: usize = 224;

--- a/ppu/src/renderer.rs
+++ b/ppu/src/renderer.rs
@@ -114,7 +114,7 @@ impl Renderer {
             // ============================================================
             // Get color from CGRAM and apply brightness
             // ============================================================
-            let color = ppu.cgram.current_word(palette_entry);
+            let color = ppu.cgram.read(palette_entry);
 
             let mut r5 = (color & 0x1F) as u16;
             let mut g5 = ((color >> 5) & 0x1F) as u16;


### PR DESCRIPTION
Some improvement suggestions for #57, specifically in the CGRAM
- use a custom enum of u8 to keep track of byte phase
- switch from `[u8]` to `[u16]`

I think this overall makes things easier to understand, and it was simpler to just do it than try to explain how to do it

These are just suggestions, feel free to tell me if anything feels wrong to you.

I think similar changes can be done in the VRAM, but i'm not sure yet, i'll have to read it in more detail
