### PR TITLE
Handle IO Memory Zone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,8 +169,11 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 name = "bus"
 version = "0.1.0"
 dependencies = [
+ "apu",
  "common",
+ "cpu",
  "duplicate",
+ "ppu",
  "strum",
  "strum_macros",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ version = "0.1.0"
 dependencies = [
  "apu",
  "bus",
+ "common",
  "cpu",
  "ppu",
  "rfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,6 @@ version = "0.1.0"
 dependencies = [
  "apu",
  "common",
- "cpu",
  "duplicate",
  "ppu",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 ]
 
 [dependencies]
+common = { version = "0.1.0", path = "./common"}
 bus = { version = "0.1.0", path = "./bus"}
 cpu = { version = "0.1.0", path = "./cpu"}
 ppu = { version = "0.1.0", path = "./ppu"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ sdl2 = { version = "0.38.0", features = ["bundled"] }
 
 [target.'cfg(unix)'.dependencies]
 sdl2 = { version = "0.38.0"}
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/bus/Cargo.toml
+++ b/bus/Cargo.toml
@@ -11,8 +11,6 @@ apu = { version = "0.1.0", path = "../apu"}
 duplicate = "2.0.0"
 strum = "0.27.2"
 strum_macros = "0.27.2"
-
-[dev-dependencies]
 tempfile = "3.23.0"
 
 [lints.rust]

--- a/bus/Cargo.toml
+++ b/bus/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 
 [dependencies]
 common = { version = "0.1.0", path = "../common"}
+cpu = { version = "0.1.0", path = "../cpu"}
+ppu = { version = "0.1.0", path = "../ppu"}
+apu = { version = "0.1.0", path = "../apu"}
 duplicate = "2.0.0"
 strum = "0.27.2"
 strum_macros = "0.27.2"

--- a/bus/Cargo.toml
+++ b/bus/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 common = { version = "0.1.0", path = "../common"}
-cpu = { version = "0.1.0", path = "../cpu"}
 ppu = { version = "0.1.0", path = "../ppu"}
 apu = { version = "0.1.0", path = "../apu"}
 duplicate = "2.0.0"

--- a/bus/src/bin/main.rs
+++ b/bus/src/bin/main.rs
@@ -1,12 +1,14 @@
 use bus::bus::Bus;
 use std::{env, error::Error};
 
+#[cfg(not(tarpaulin_include))]
 fn main() {
     if let Err(e) = run() {
         eprintln!("Error: {}", e);
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 fn run() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     let bus = Bus::new(&args[1])?;

--- a/bus/src/bin/main.rs
+++ b/bus/src/bin/main.rs
@@ -1,14 +1,12 @@
 use bus::bus::Bus;
 use std::{env, error::Error};
 
-#[cfg(not(tarpaulin_include))]
 fn main() {
     if let Err(e) = run() {
         eprintln!("Error: {}", e);
     }
 }
 
-#[cfg(not(tarpaulin_include))]
 fn run() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     let bus = Bus::new(&args[1])?;

--- a/bus/src/bus.rs
+++ b/bus/src/bus.rs
@@ -1,8 +1,10 @@
 use crate::io::Io;
-use crate::memory_region::MemoryRegion;
 use crate::rom::Rom;
 use crate::wram::Wram;
+use apu::Apu;
 use common::snes_address::SnesAddress;
+use cpu::cpu::CPU;
+use ppu::ppu::PPU;
 use std::error::Error;
 use std::path::Path;
 
@@ -29,11 +31,11 @@ impl Bus {
             [ read ]    [ &self, addr: SnesAddress ]                    [ u8 ]          [ addr ];
             [ write ]   [ &mut self, addr: SnesAddress, value: u8 ]     [ () ]          [ addr, value ];
         ]
-        pub fn DUP_method(DUP_parameters) -> DUP_return_t {
+        pub fn DUP_method(DUP_parameters, cpu: &mut CPU, ppu: &mut PPU, apu: &mut Apu) -> DUP_return_t {
             match addr.bank {
                 0x00..=0x3F | 0x80..=0xBF => match addr.addr {
                     0x0000..0x2000 => self.wram.DUP_method(DUP_method_param),
-                    0x2000..0x6000 => self.io.DUP_method(DUP_method_param),
+                    0x2000..0x6000 => self.io.DUP_method(DUP_method_param, cpu, ppu, apu),
                     0x6000..0x8000 => self.rom.DUP_method(DUP_method_param), // TODO : Expansion port
                     0x8000..=0xFFFF => self.rom.DUP_method(DUP_method_param),
                 },
@@ -44,77 +46,77 @@ impl Bus {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::rom::test_rom::*;
-    use common::snes_address::snes_addr;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crate::rom::test_rom::*;
+//     use common::snes_address::snes_addr;
 
-    #[test]
-    fn test_wram_read_write_through_bus() {
-        let rom_data = create_valid_lorom(0x20000);
-        let (rom_path, _dir) = create_temp_rom(&rom_data);
-        let mut bus = Bus::new(&rom_path).unwrap();
+//     #[test]
+//     fn test_wram_read_write_through_bus() {
+//         let rom_data = create_valid_lorom(0x20000);
+//         let (rom_path, _dir) = create_temp_rom(&rom_data);
+//         let mut bus = Bus::new(&rom_path).unwrap();
 
-        let addr = snes_addr!(0:0x0010);
-        bus.write(addr, 0x42);
-        assert_eq!(bus.read(addr), 0x42);
+//         let addr = snes_addr!(0:0x0010);
+//         bus.write(addr, 0x42);
+//         assert_eq!(bus.read(addr), 0x42);
 
-        let addr_mirror = snes_addr!(0x80:0x0010);
-        assert_eq!(bus.read(addr), 0x42);
-        assert_eq!(bus.read(addr_mirror), 0x42);
+//         let addr_mirror = snes_addr!(0x80:0x0010);
+//         assert_eq!(bus.read(addr), 0x42);
+//         assert_eq!(bus.read(addr_mirror), 0x42);
 
-        let real_addr = snes_addr!(0x7E:0x0010);
-        assert_eq!(bus.read(real_addr), 0x42);
+//         let real_addr = snes_addr!(0x7E:0x0010);
+//         assert_eq!(bus.read(real_addr), 0x42);
 
-        bus.write(real_addr, 0x21);
-        assert_eq!(bus.read(real_addr), 0x21);
-        assert_eq!(bus.read(addr), 0x21);
-        assert_eq!(bus.read(addr_mirror), 0x21);
-    }
+//         bus.write(real_addr, 0x21);
+//         assert_eq!(bus.read(real_addr), 0x21);
+//         assert_eq!(bus.read(addr), 0x21);
+//         assert_eq!(bus.read(addr_mirror), 0x21);
+//     }
 
-    #[test]
-    fn test_io_read_write_through_bus() {
-        let rom_data = create_valid_lorom(0x20000);
-        let (rom_path, _dir) = create_temp_rom(&rom_data);
-        let mut bus = Bus::new(&rom_path).unwrap();
+//     #[test]
+//     fn test_io_read_write_through_bus() {
+//         let rom_data = create_valid_lorom(0x20000);
+//         let (rom_path, _dir) = create_temp_rom(&rom_data);
+//         let mut bus = Bus::new(&rom_path).unwrap();
 
-        let addr = snes_addr!(0:0x2345);
-        bus.write(addr, 0x77);
-        assert_eq!(bus.read(addr), 0x77);
+//         let addr = snes_addr!(0:0x2345);
+//         bus.write(addr, 0x77);
+//         assert_eq!(bus.read(addr), 0x77);
 
-        let addr_mirror = snes_addr!(0x9E:0x2345);
-        assert_eq!(bus.read(addr), 0x77);
-        assert_eq!(bus.read(addr_mirror), 0x77);
-    }
+//         let addr_mirror = snes_addr!(0x9E:0x2345);
+//         assert_eq!(bus.read(addr), 0x77);
+//         assert_eq!(bus.read(addr_mirror), 0x77);
+//     }
 
-    #[test]
-    fn test_rom_read_write_through_bus() {
-        let mut rom_data = create_valid_lorom(0x100000 * 0x40);
-        rom_data[0x0001] = 0x42;
-        let (rom_path, _dir) = create_temp_rom(&rom_data);
-        let mut bus = Bus::new(&rom_path).unwrap();
+//     #[test]
+//     fn test_rom_read_write_through_bus() {
+//         let mut rom_data = create_valid_lorom(0x100000 * 0x40);
+//         rom_data[0x0001] = 0x42;
+//         let (rom_path, _dir) = create_temp_rom(&rom_data);
+//         let mut bus = Bus::new(&rom_path).unwrap();
 
-        let addr = snes_addr!(0:0x8001);
-        assert_eq!(bus.read(addr), 0x42);
-        bus.write(addr, 0x21);
-        assert_eq!(bus.read(addr), 0x42);
+//         let addr = snes_addr!(0:0x8001);
+//         assert_eq!(bus.read(addr), 0x42);
+//         bus.write(addr, 0x21);
+//         assert_eq!(bus.read(addr), 0x42);
 
-        let other_addr = snes_addr!(0x40:0x8001);
-        assert_eq!(bus.read(other_addr), 0);
-        bus.write(other_addr, 0x21);
-        assert_eq!(bus.read(other_addr), 0);
-    }
+//         let other_addr = snes_addr!(0x40:0x8001);
+//         assert_eq!(bus.read(other_addr), 0);
+//         bus.write(other_addr, 0x21);
+//         assert_eq!(bus.read(other_addr), 0);
+//     }
 
-    #[test]
-    #[should_panic(expected = "ERROR: Couldn't extract value from ROM")]
-    fn test_rom_read_out_of_range_panics() {
-        let rom_data = create_valid_lorom(0x20000);
-        let (rom_path, _dir) = create_temp_rom(&rom_data);
-        let bus = Bus::new(&rom_path).unwrap();
+//     #[test]
+//     #[should_panic(expected = "ERROR: Couldn't extract value from ROM")]
+//     fn test_rom_read_out_of_range_panics() {
+//         let rom_data = create_valid_lorom(0x20000);
+//         let (rom_path, _dir) = create_temp_rom(&rom_data);
+//         let bus = Bus::new(&rom_path).unwrap();
 
-        // Create an address mapped to an offset beyond the 128 KiB dummy ROM.
-        let addr = snes_addr!(0x7D:0xFFFF);
-        bus.rom.read(addr);
-    }
-}
+//         // Create an address mapped to an offset beyond the 128 KiB dummy ROM.
+//         let addr = snes_addr!(0x7D:0xFFFF);
+//         bus.rom.read(addr);
+//     }
+// }

--- a/bus/src/bus.rs
+++ b/bus/src/bus.rs
@@ -28,7 +28,7 @@ impl Bus {
     duplicate! {
         [
             DUP_method  DUP_parameters                                  DUP_return_t    DUP_method_param;
-            [ read ]    [ &self, addr: SnesAddress ]                    [ u8 ]          [ addr ];
+            [ read ]    [ &mut self, addr: SnesAddress ]                    [ u8 ]          [ addr ];
             [ write ]   [ &mut self, addr: SnesAddress, value: u8 ]     [ () ]          [ addr, value ];
         ]
         pub fn DUP_method(DUP_parameters, cpu: &mut CPU, ppu: &mut PPU, apu: &mut Apu) -> DUP_return_t {

--- a/bus/src/bus.rs
+++ b/bus/src/bus.rs
@@ -46,77 +46,91 @@ impl Bus {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::rom::test_rom::*;
-//     use common::snes_address::snes_addr;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rom::test_rom::*;
+    use common::snes_address::snes_addr;
 
-//     #[test]
-//     fn test_wram_read_write_through_bus() {
-//         let rom_data = create_valid_lorom(0x20000);
-//         let (rom_path, _dir) = create_temp_rom(&rom_data);
-//         let mut bus = Bus::new(&rom_path).unwrap();
+    fn init_extern_components() -> (CPU, PPU, Apu) {
+        let cpu = CPU::poweron();
+        let ppu = PPU::new();
+        let apu = Apu::new();
 
-//         let addr = snes_addr!(0:0x0010);
-//         bus.write(addr, 0x42);
-//         assert_eq!(bus.read(addr), 0x42);
+        (cpu, ppu, apu)
+    }
 
-//         let addr_mirror = snes_addr!(0x80:0x0010);
-//         assert_eq!(bus.read(addr), 0x42);
-//         assert_eq!(bus.read(addr_mirror), 0x42);
+    #[test]
+    fn test_wram_read_write_through_bus() {
+        let (mut cpu, mut ppu, mut apu) = init_extern_components();
+        let rom_data = create_valid_lorom(0x20000);
+        let (rom_path, _dir) = create_temp_rom(&rom_data);
+        let mut bus = Bus::new(&rom_path).unwrap();
 
-//         let real_addr = snes_addr!(0x7E:0x0010);
-//         assert_eq!(bus.read(real_addr), 0x42);
+        let addr = snes_addr!(0:0x0010);
+        bus.write(addr, 0x42, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x42);
 
-//         bus.write(real_addr, 0x21);
-//         assert_eq!(bus.read(real_addr), 0x21);
-//         assert_eq!(bus.read(addr), 0x21);
-//         assert_eq!(bus.read(addr_mirror), 0x21);
-//     }
+        let addr_mirror = snes_addr!(0x80:0x0010);
+        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x42);
+        assert_eq!(bus.read(addr_mirror, &mut cpu, &mut ppu, &mut apu), 0x42);
 
-//     #[test]
-//     fn test_io_read_write_through_bus() {
-//         let rom_data = create_valid_lorom(0x20000);
-//         let (rom_path, _dir) = create_temp_rom(&rom_data);
-//         let mut bus = Bus::new(&rom_path).unwrap();
+        let real_addr = snes_addr!(0x7E:0x0010);
+        assert_eq!(bus.read(real_addr, &mut cpu, &mut ppu, &mut apu), 0x42);
 
-//         let addr = snes_addr!(0:0x2345);
-//         bus.write(addr, 0x77);
-//         assert_eq!(bus.read(addr), 0x77);
+        bus.write(real_addr, 0x21, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(bus.read(real_addr, &mut cpu, &mut ppu, &mut apu), 0x21);
+        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x21);
+        assert_eq!(bus.read(addr_mirror, &mut cpu, &mut ppu, &mut apu), 0x21);
+    }
 
-//         let addr_mirror = snes_addr!(0x9E:0x2345);
-//         assert_eq!(bus.read(addr), 0x77);
-//         assert_eq!(bus.read(addr_mirror), 0x77);
-//     }
+    #[test]
+    fn test_io_read_write_through_bus() {
+        let (mut cpu, mut ppu, mut apu) = init_extern_components();
+        let rom_data = create_valid_lorom(0x20000);
+        let (rom_path, _dir) = create_temp_rom(&rom_data);
+        let mut bus = Bus::new(&rom_path).unwrap();
 
-//     #[test]
-//     fn test_rom_read_write_through_bus() {
-//         let mut rom_data = create_valid_lorom(0x100000 * 0x40);
-//         rom_data[0x0001] = 0x42;
-//         let (rom_path, _dir) = create_temp_rom(&rom_data);
-//         let mut bus = Bus::new(&rom_path).unwrap();
+        cpu.data_bus = 0x20;
+        let addr = snes_addr!(0:0x5000);
+        let read_value = bus.read(addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(read_value, 0x20);
 
-//         let addr = snes_addr!(0:0x8001);
-//         assert_eq!(bus.read(addr), 0x42);
-//         bus.write(addr, 0x21);
-//         assert_eq!(bus.read(addr), 0x42);
+        bus.write(addr, 0x40, &mut cpu, &mut ppu, &mut apu);
+        let read_value = bus.read(addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(read_value, 0x20);
+    }
 
-//         let other_addr = snes_addr!(0x40:0x8001);
-//         assert_eq!(bus.read(other_addr), 0);
-//         bus.write(other_addr, 0x21);
-//         assert_eq!(bus.read(other_addr), 0);
-//     }
+    #[test]
+    fn test_rom_read_write_through_bus() {
+        let (mut cpu, mut ppu, mut apu) = init_extern_components();
+        let mut rom_data = create_valid_lorom(0x100000 * 0x40);
+        rom_data[0x0001] = 0x42;
+        let (rom_path, _dir) = create_temp_rom(&rom_data);
+        let mut bus = Bus::new(&rom_path).unwrap();
 
-//     #[test]
-//     #[should_panic(expected = "ERROR: Couldn't extract value from ROM")]
-//     fn test_rom_read_out_of_range_panics() {
-//         let rom_data = create_valid_lorom(0x20000);
-//         let (rom_path, _dir) = create_temp_rom(&rom_data);
-//         let bus = Bus::new(&rom_path).unwrap();
+        let addr = snes_addr!(0:0x8001);
+        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x42);
+        bus.write(addr, 0x21, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x42);
 
-//         // Create an address mapped to an offset beyond the 128 KiB dummy ROM.
-//         let addr = snes_addr!(0x7D:0xFFFF);
-//         bus.rom.read(addr);
-//     }
-// }
+        let other_addr = snes_addr!(0x40:0x8001);
+        assert_eq!(bus.read(other_addr, &mut cpu, &mut ppu, &mut apu), 0);
+        bus.write(other_addr, 0x21, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(bus.read(other_addr, &mut cpu, &mut ppu, &mut apu), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "ERROR: Couldn't extract value from ROM")]
+    fn test_rom_read_out_of_range_panics() {
+        let (mut cpu, mut ppu, mut apu) = init_extern_components();
+        let rom_data = create_valid_lorom(0x20000);
+        let (rom_path, _dir) = create_temp_rom(&rom_data);
+        let mut bus = Bus::new(&rom_path).unwrap();
+
+        // Create an address mapped to an offset beyond the 128 KiB dummy ROM.
+        let addr = snes_addr!(0x7D:0xFFFF);
+        bus.read(addr, &mut cpu, &mut ppu, &mut apu);
+        // bus.rom.read(addr);
+    }
+}

--- a/bus/src/bus.rs
+++ b/bus/src/bus.rs
@@ -21,7 +21,7 @@ impl Bus {
         Ok(Self {
             rom: Rom::load_from_file(rom_path)?,
             wram: Wram::new(),
-            io: Io::new(),
+            io: Io::default(),
         })
     }
 

--- a/bus/src/bus.rs
+++ b/bus/src/bus.rs
@@ -28,7 +28,7 @@ impl Bus {
     duplicate! {
         [
             DUP_method  DUP_parameters                                  DUP_return_t    DUP_method_param;
-            [ read ]    [ &mut self, addr: SnesAddress ]                    [ u8 ]          [ addr ];
+            [ read ]    [ &mut self, addr: SnesAddress ]                [ u8 ]          [ addr ];
             [ write ]   [ &mut self, addr: SnesAddress, value: u8 ]     [ () ]          [ addr, value ];
         ]
         pub fn DUP_method(DUP_parameters, cpu: &mut CPU, ppu: &mut PPU, apu: &mut Apu) -> DUP_return_t {

--- a/bus/src/bus.rs
+++ b/bus/src/bus.rs
@@ -94,11 +94,11 @@ mod tests {
         cpu.data_bus = 0x20;
         let addr = snes_addr!(0:0x5000);
         let read_value = bus.read(addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(read_value, 0x20);
+        assert_eq!(read_value, 0);
 
         bus.write(addr, 0x40, &mut cpu, &mut ppu, &mut apu);
         let read_value = bus.read(addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(read_value, 0x20);
+        assert_eq!(read_value, 0x40);
     }
 
     #[test]

--- a/bus/src/bus.rs
+++ b/bus/src/bus.rs
@@ -3,7 +3,6 @@ use crate::rom::Rom;
 use crate::wram::Wram;
 use apu::Apu;
 use common::snes_address::SnesAddress;
-use cpu::cpu::CPU;
 use ppu::ppu::PPU;
 use std::error::Error;
 use std::path::Path;
@@ -31,11 +30,11 @@ impl Bus {
             [ read ]    [ &mut self, addr: SnesAddress ]                [ u8 ]          [ addr ];
             [ write ]   [ &mut self, addr: SnesAddress, value: u8 ]     [ () ]          [ addr, value ];
         ]
-        pub fn DUP_method(DUP_parameters, cpu: &mut CPU, ppu: &mut PPU, apu: &mut Apu) -> DUP_return_t {
+        pub fn DUP_method(DUP_parameters, ppu: &mut PPU, apu: &mut Apu) -> DUP_return_t {
             match addr.bank {
                 0x00..=0x3F | 0x80..=0xBF => match addr.addr {
                     0x0000..0x2000 => self.wram.DUP_method(DUP_method_param),
-                    0x2000..0x6000 => self.io.DUP_method(DUP_method_param, cpu, ppu, apu),
+                    0x2000..0x6000 => self.io.DUP_method(DUP_method_param, ppu, apu),
                     0x6000..0x8000 => self.rom.DUP_method(DUP_method_param), // TODO : Expansion port
                     0x8000..=0xFFFF => self.rom.DUP_method(DUP_method_param),
                 },
@@ -52,85 +51,84 @@ mod tests {
     use crate::rom::test_rom::*;
     use common::snes_address::snes_addr;
 
-    fn init_extern_components() -> (CPU, PPU, Apu) {
-        let cpu = CPU::poweron();
+    fn init_extern_components() -> (PPU, Apu) {
         let ppu = PPU::new();
         let apu = Apu::new();
 
-        (cpu, ppu, apu)
+        (ppu, apu)
     }
 
     #[test]
     fn test_wram_read_write_through_bus() {
-        let (mut cpu, mut ppu, mut apu) = init_extern_components();
+        let (mut ppu, mut apu) = init_extern_components();
         let rom_data = create_valid_lorom(0x20000);
         let (rom_path, _dir) = create_temp_rom(&rom_data);
         let mut bus = Bus::new(&rom_path).unwrap();
 
         let addr = snes_addr!(0:0x0010);
-        bus.write(addr, 0x42, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x42);
+        bus.write(addr, 0x42, &mut ppu, &mut apu);
+        assert_eq!(bus.read(addr, &mut ppu, &mut apu), 0x42);
 
         let addr_mirror = snes_addr!(0x80:0x0010);
-        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x42);
-        assert_eq!(bus.read(addr_mirror, &mut cpu, &mut ppu, &mut apu), 0x42);
+        assert_eq!(bus.read(addr, &mut ppu, &mut apu), 0x42);
+        assert_eq!(bus.read(addr_mirror, &mut ppu, &mut apu), 0x42);
 
         let real_addr = snes_addr!(0x7E:0x0010);
-        assert_eq!(bus.read(real_addr, &mut cpu, &mut ppu, &mut apu), 0x42);
+        assert_eq!(bus.read(real_addr, &mut ppu, &mut apu), 0x42);
 
-        bus.write(real_addr, 0x21, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(bus.read(real_addr, &mut cpu, &mut ppu, &mut apu), 0x21);
-        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x21);
-        assert_eq!(bus.read(addr_mirror, &mut cpu, &mut ppu, &mut apu), 0x21);
+        bus.write(real_addr, 0x21, &mut ppu, &mut apu);
+        assert_eq!(bus.read(real_addr, &mut ppu, &mut apu), 0x21);
+        assert_eq!(bus.read(addr, &mut ppu, &mut apu), 0x21);
+        assert_eq!(bus.read(addr_mirror, &mut ppu, &mut apu), 0x21);
     }
 
     #[test]
     fn test_io_read_write_through_bus() {
-        let (mut cpu, mut ppu, mut apu) = init_extern_components();
+        let (mut ppu, mut apu) = init_extern_components();
         let rom_data = create_valid_lorom(0x20000);
         let (rom_path, _dir) = create_temp_rom(&rom_data);
         let mut bus = Bus::new(&rom_path).unwrap();
 
-        cpu.data_bus = 0x20;
+        bus.io.open_bus = 0x20;
         let addr = snes_addr!(0:0x5000);
-        let read_value = bus.read(addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(read_value, 0);
+        let read_value = bus.read(addr, &mut ppu, &mut apu);
+        assert_eq!(read_value, 0x20);
 
-        bus.write(addr, 0x40, &mut cpu, &mut ppu, &mut apu);
-        let read_value = bus.read(addr, &mut cpu, &mut ppu, &mut apu);
+        bus.write(addr, 0x40, &mut ppu, &mut apu);
+        let read_value = bus.read(addr, &mut ppu, &mut apu);
         assert_eq!(read_value, 0x40);
     }
 
     #[test]
     fn test_rom_read_write_through_bus() {
-        let (mut cpu, mut ppu, mut apu) = init_extern_components();
+        let (mut ppu, mut apu) = init_extern_components();
         let mut rom_data = create_valid_lorom(0x100000 * 0x40);
         rom_data[0x0001] = 0x42;
         let (rom_path, _dir) = create_temp_rom(&rom_data);
         let mut bus = Bus::new(&rom_path).unwrap();
 
         let addr = snes_addr!(0:0x8001);
-        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x42);
-        bus.write(addr, 0x21, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(bus.read(addr, &mut cpu, &mut ppu, &mut apu), 0x42);
+        assert_eq!(bus.read(addr, &mut ppu, &mut apu), 0x42);
+        bus.write(addr, 0x21, &mut ppu, &mut apu);
+        assert_eq!(bus.read(addr, &mut ppu, &mut apu), 0x42);
 
         let other_addr = snes_addr!(0x40:0x8001);
-        assert_eq!(bus.read(other_addr, &mut cpu, &mut ppu, &mut apu), 0);
-        bus.write(other_addr, 0x21, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(bus.read(other_addr, &mut cpu, &mut ppu, &mut apu), 0);
+        assert_eq!(bus.read(other_addr, &mut ppu, &mut apu), 0);
+        bus.write(other_addr, 0x21, &mut ppu, &mut apu);
+        assert_eq!(bus.read(other_addr, &mut ppu, &mut apu), 0);
     }
 
     #[test]
     #[should_panic(expected = "ERROR: Couldn't extract value from ROM")]
     fn test_rom_read_out_of_range_panics() {
-        let (mut cpu, mut ppu, mut apu) = init_extern_components();
+        let (mut ppu, mut apu) = init_extern_components();
         let rom_data = create_valid_lorom(0x20000);
         let (rom_path, _dir) = create_temp_rom(&rom_data);
         let mut bus = Bus::new(&rom_path).unwrap();
 
         // Create an address mapped to an offset beyond the 128 KiB dummy ROM.
         let addr = snes_addr!(0x7D:0xFFFF);
-        bus.read(addr, &mut cpu, &mut ppu, &mut apu);
+        bus.read(addr, &mut ppu, &mut apu);
         // bus.rom.read(addr);
     }
 }

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -96,10 +96,10 @@ impl Io {
             0x2140..0x2180 => {
                 let reg_nb = addr.addr % 4;
                 match reg_nb {
-                    0 => 0, // Handle read of APU register nb°0
-                    1 => 0, // Handle read of APU register nb°1
-                    2 => 0, // Handle read of APU register nb°2
-                    3 => 0, // Handle read of APU register nb°3
+                    0 => todo!("{} : Implement APU channel n°1 reads", addr.addr),
+                    1 => todo!("{} : Implement APU channel n°2 reads", addr.addr),
+                    2 => todo!("{} : Implement APU channel n°3 reads", addr.addr),
+                    3 => todo!("{} : Implement APU channel n°4 reads", addr.addr),
                     _ => unreachable!(),
                 }
             }
@@ -160,14 +160,13 @@ impl Io {
     fn write_cpu(&mut self, value: u8, addr: SnesAddress, _cpu: &mut CPU) {
         match addr.addr {
             // Data-to-APU register
-            // TODO : Link with the actual apu component
             0x2140..0x2180 => {
                 let reg_nb = addr.addr % 4;
                 match reg_nb {
-                    0 => {} // Handle write to APU register nb°0
-                    1 => {} // Handle write to APU register nb°1
-                    2 => {} // Handle write to APU register nb°2
-                    3 => {} // Handle write to APU register nb°3
+                    0 => todo!("{} : Implement APU channel n°1 writes", addr.addr),
+                    1 => todo!("{} : Implement APU channel n°2 writes", addr.addr),
+                    2 => todo!("{} : Implement APU channel n°3 writes", addr.addr),
+                    3 => todo!("{} : Implement APU channel n°4 writes", addr.addr),
                     _ => unreachable!(),
                 }
             }
@@ -210,10 +209,10 @@ impl Io {
                 }
             }
 
-            // Screen timer target values - Horizontal Register
+            // Screen timer Horizontal target values
             0x4207 => self.htimel = value,
             0x4208 => self.htimeh = value & 1,
-            // Screen timer target values - Vertical Register
+            // Screen timer Vertical target values
             0x4209 => self.vtimel = value,
             0x420A => self.vtimeh = value & 1,
 

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -39,7 +39,6 @@ pub struct Io {
     rdnmi: u8,
     timeup: u8,
     hvbjoy: u8,
-    rdio: u8,
 
     joy1: u16,
     joy2: u16,
@@ -75,7 +74,6 @@ impl Io {
             rdnmi: 0,
             timeup: 0,
             hvbjoy: 0,
-            rdio: 0,
 
             joy1: 0,
             joy2: 0,
@@ -133,8 +131,8 @@ impl Io {
             // TODO : Implement open bus on unused bits
             0x4212 => self.hvbjoy,
 
-            // UNUSED : manual controller reading not implemented
-            0x4213 => self.rdio,
+            // RDIO : manual controller reading not implemented
+            0x4213 => todo!("0x4213 : Implement RDIO register read"),
 
             // Divison result register
             0x4214 => self.rddiv as u8,

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -755,6 +755,41 @@ mod tests {
     }
 
     #[test]
+    fn test_register_division_by_zero() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let wrdivl_addr = snes_addr!(0:0x4204);
+        let wrdivh_addr = snes_addr!(0:0x4205);
+        let wrdivb_addr = snes_addr!(0:0x4206);
+        let rddivl_addr = snes_addr!(0:0x4214);
+        let rddivh_addr = snes_addr!(0:0x4215);
+        let rdmpyl_addr = snes_addr!(0:0x4216);
+        let rdmpyh_addr = snes_addr!(0:0x4217);
+        let value_wrdivl = 0x10;
+        let value_wrdivh = 0x25;
+        let value_wrdiv: u16 = 0x2510;
+        let value_wrdivb = 0x00;
+        io.write(wrdivl_addr, value_wrdivl, &mut cpu, &mut ppu, &mut apu);
+        io.write(wrdivh_addr, value_wrdivh, &mut cpu, &mut ppu, &mut apu);
+        io.write(wrdivb_addr, value_wrdivb, &mut cpu, &mut ppu, &mut apu);
+
+        assert_eq!(io.wrdivl, value_wrdivl);
+        assert_eq!(io.wrdivh, value_wrdivh);
+        assert_eq!(io.wrdivb, value_wrdivb);
+        assert_eq!(io.rddiv, 0xFFFF);
+        assert_eq!(io.rdmpy, value_wrdiv);
+
+        let rdmpyl_value = io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu);
+        let rdmpyh_value = io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(rdmpyl_value, value_wrdivl);
+        assert_eq!(rdmpyh_value, value_wrdivh);
+        let rddivl_value = io.read(rddivl_addr, &mut cpu, &mut ppu, &mut apu);
+        let rddivh_value = io.read(rddivh_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(rddivl_value, 0xFF);
+        assert_eq!(rddivh_value, 0xFF);
+    }
+
+    #[test]
     fn test_dma_registers() {
         let (mut io, mut cpu, mut ppu, mut apu) = init_all();
         let cpu_open_bus_value = 0xE4;

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -109,6 +109,19 @@ impl Io {
 
     fn read_cpu(&mut self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
         match addr.addr {
+            // Data-from-APU register
+            // TODO : Link with the actual apu component
+            0x2140..0x2180 => {
+                let reg_nb = addr.addr % 4;
+                match reg_nb {
+                    0 => 0, // Handle read of APU register nb°0
+                    1 => 0, // Handle read of APU register nb°1
+                    2 => 0, // Handle read of APU register nb°2
+                    3 => 0, // Handle read of APU register nb°3
+                    _ => unreachable!(),
+                }
+            }
+
             // WRAM Data Registers - Seems to be mainly used with DMA
             0x2180 => self.wmdata,
 
@@ -164,6 +177,19 @@ impl Io {
 
     fn write_cpu(&mut self, value: u8, addr: SnesAddress, _cpu: &mut CPU) {
         match addr.addr {
+            // Data-to-APU register
+            // TODO : Link with the actual apu component
+            0x2140..0x2180 => {
+                let reg_nb = addr.addr % 4;
+                match reg_nb {
+                    0 => {} // Handle write to APU register nb°0
+                    1 => {} // Handle write to APU register nb°1
+                    2 => {} // Handle write to APU register nb°2
+                    3 => {} // Handle write to APU register nb°3
+                    _ => unreachable!(),
+                }
+            }
+
             // WRAM Data Registers - Seems to be mainly used with DMA
             0x2180 => {
                 self.wmdata = value;

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -14,14 +14,83 @@ use ppu::ppu::PPU;
 /// For example, the addresses `0x004000` and `0x9E4000` both refer to the
 /// same memory location.
 pub struct Io {
-    // TODO : Implement real CPU, PPU, APU, etc... memoriy behaviors.
-    data: Box<[u8; IO_SIZE]>,
+    // ---------- $4016-$4017 ----------
+    joyser0: u8,
+    joyser1: u8,
+
+    // ---------- $4200-$420D ----------
+    nmitimen: u8,
+    wrio: u8,
+
+    wrmpya: u8,
+    wrmpyb: u8,
+
+    wrdivl: u8,
+    wrdivh: u8,
+    wrdivb: u8,
+
+    htimel: u8,
+    htimeh: u8,
+    vtimel: u8,
+    vtimeh: u8,
+
+    mdmaen: u8,
+    hdmaen: u8,
+    memsel: u8,
+
+    // ---------- math results ----------
+    rddiv: u16,
+    rdmpy: u16,
+
+    // ---------- status ----------
+    rdnmi: u8,
+    timeup: u8,
+    hvbjoy: u8,
+    rdio: u8,
+
+    // ---------- joypads ----------
+    joy: [u16; 4],
+
+    // ---------- DMA registers ----------
+    dma: [[u8; 0x10]; 8],
 }
 
 impl Io {
     pub fn new() -> Self {
         Self {
-            data: Box::new([0; IO_SIZE]),
+            joyser0: 0,
+            joyser1: 0,
+
+            nmitimen: 0,
+            wrio: 0xFF,
+
+            wrmpya: 0xFF,
+            wrmpyb: 0xFF,
+
+            wrdivl: 0xFF,
+            wrdivh: 0xFF,
+            wrdivb: 0xFF,
+
+            htimel: 0xFF,
+            htimeh: 1,
+            vtimel: 0xFF,
+            vtimeh: 1,
+
+            mdmaen: 0,
+            hdmaen: 0,
+            memsel: 0,
+
+            rddiv: 0,
+            rdmpy: 0,
+
+            rdnmi: 0,
+            timeup: 0,
+            hvbjoy: 0,
+            rdio: 0,
+
+            joy: [0; 4],
+
+            dma: [[0xFF; 0x10]; 8],
         }
     }
 
@@ -32,22 +101,80 @@ impl Io {
         );
     }
 
-    /// Converts a `SnesAddress` into an internal I/O offset.
-    ///
-    /// Maps addresses between 0x2000–0x5FFF and mirrored across banks
-    /// 0x00–0x3F and 0x80–0xBF.
-    ///
-    /// # Panics
-    /// Panics if the address is outside the valid I/O memory zone range.
-    fn to_offset(addr: SnesAddress) -> usize {
-        match addr.bank {
-            0x00..=0x3F | 0x80..=0xBF
-                if addr.addr >= IO_START_ADDRESS && addr.addr < IO_END_ADDRESS =>
-            {
-                addr.addr as usize
-            }
-            _ => Self::panic_invalid_addr(addr),
+    fn read_cpu(&self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
+        match addr.addr {
+            // Open Bus
+            _ => cpu.data_bus,
         }
+    }
+
+    fn write_cpu(&mut self, value: u8, addr: SnesAddress, _cpu: &mut CPU) {
+        match addr.addr {
+            // UNUSED : manual controller reading not implemented
+            0x4016 => self.joyser0 = value,
+
+            // Register for enabling NMI, H/V-Blank, and joypad auto-read
+            0x4200 => self.nmitimen = value,
+
+            // UNUSED : manual controller reading not implemented
+            0x4201 => self.wrio = value,
+
+            // Multiplication registers
+            // TODO : Make the actual multiplication take 8 CPU cycles
+            0x4202 => self.wrmpya = value,
+            0x4203 => {
+                self.wrmpyb = value;
+                self.rdmpy = (self.wrmpya as u16) * (self.wrmpyb as u16);
+            }
+
+            // Division registers
+            // TODO : Make the actual division take 16 CPU cycles
+            0x4204 => self.wrdivl = value,
+            0x4205 => self.wrdivh = value,
+            0x4206 => {
+                self.wrdivb = value;
+
+                let dividend = ((self.wrdivh as u16) << 8) | self.wrdivl as u16;
+
+                if value != 0 {
+                    self.rddiv = dividend / value as u16;
+                    self.rdmpy = dividend % value as u16;
+                } else {
+                    self.rddiv = 0xFFFF;
+                    self.rdmpy = dividend;
+                }
+            }
+
+            // Screen timer target values - Horizontal Register
+            0x4207 => self.htimel = value,
+            0x4208 => self.htimeh = value & 1,
+            // Screen timer target values - Vertical Register
+            0x4209 => self.vtimel = value,
+            0x420A => self.vtimeh = value & 1,
+
+            // DMA and HDMA registers
+            // TODO : Implement real DMA and HDMA behaviors
+            0x420B => self.mdmaen = value,
+            0x420C => self.hdmaen = value,
+
+            // ROM access speed register
+            0x420D => self.memsel = value,
+
+            _ => {}
+        }
+    }
+
+    fn read_ppu(&self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
+        0
+    }
+    fn write_ppu(&mut self, value: u8, addr: SnesAddress, cpu: &mut CPU) -> u8 {
+        0
+    }
+    fn read_apu(&self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
+        0
+    }
+    fn write_apu(&mut self, value: u8, addr: SnesAddress, cpu: &mut CPU) -> u8 {
+        0
     }
 }
 
@@ -58,13 +185,18 @@ impl Io {
     ///
     /// # Panics
     /// Panics if the address does not map to a valid I/O memory location.
-    pub fn read(&self, addr: SnesAddress, cpu: &mut CPU, ppu: &mut PPU, apu: &mut Apu) -> u8 {
-        let offset = Self::to_offset(addr);
-
-        return *self.data.get(offset).expect(&format!(
-            "ERROR: Couldn't extract value from IO at address: {:06X}",
-            usize::from(addr)
-        ));
+    pub fn read(&mut self, addr: SnesAddress, cpu: &mut CPU, ppu: &mut PPU, apu: &mut Apu) -> u8 {
+        match addr.bank {
+            0x00..=0x3F | 0x80..=0xBF
+                if addr.addr >= IO_START_ADDRESS && addr.addr < IO_END_ADDRESS =>
+            {
+                match addr.addr {
+                    0x2140..0x4300 => self.read_cpu(addr, cpu),
+                    _ => Self::panic_invalid_addr(addr),
+                }
+            }
+            _ => Self::panic_invalid_addr(addr),
+        }
     }
 
     /// Writes a byte to the I/O memory zone at the given `SnesAddress`.
@@ -81,14 +213,17 @@ impl Io {
         ppu: &mut PPU,
         apu: &mut Apu,
     ) {
-        let offset = Self::to_offset(addr);
-
-        if offset < self.data.len() {
-            self.data[offset] = value;
-        } else {
-            // Shouldn't come here, panics just in case
-            Self::panic_invalid_addr(addr);
-        }
+        match addr.bank {
+            0x00..=0x3F | 0x80..=0xBF
+                if addr.addr >= IO_START_ADDRESS && addr.addr < IO_END_ADDRESS =>
+            {
+                match addr.addr {
+                    0x2140..0x4300 => self.write_cpu(value, addr, cpu),
+                    _ => Self::panic_invalid_addr(addr),
+                }
+            }
+            _ => Self::panic_invalid_addr(addr),
+        };
     }
 }
 

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -1,7 +1,8 @@
-use common::snes_address::SnesAddress;
-
 use crate::constants::{IO_END_ADDRESS, IO_SIZE, IO_START_ADDRESS};
-use crate::memory_region::MemoryRegion;
+use apu::Apu;
+use common::snes_address::SnesAddress;
+use cpu::cpu::CPU;
+use ppu::ppu::PPU;
 
 /// I/O Registers – 0x4000 bytes (mirrored)
 ///
@@ -50,14 +51,14 @@ impl Io {
     }
 }
 
-impl MemoryRegion for Io {
+impl Io {
     /// Reads a byte from the I/O memory zone at the given `SnesAddress`.
     ///
     /// The address is translated to an internal I/O offset using `to_offset`.
     ///
     /// # Panics
     /// Panics if the address does not map to a valid I/O memory location.
-    fn read(&self, addr: SnesAddress) -> u8 {
+    pub fn read(&self, addr: SnesAddress, cpu: &mut CPU, ppu: &mut PPU, apu: &mut Apu) -> u8 {
         let offset = Self::to_offset(addr);
 
         return *self.data.get(offset).expect(&format!(
@@ -72,7 +73,14 @@ impl MemoryRegion for Io {
     ///
     /// # Panics
     /// Panics if the address does not map to a valid I/O memory location.
-    fn write(&mut self, addr: SnesAddress, value: u8) {
+    pub fn write(
+        &mut self,
+        addr: SnesAddress,
+        value: u8,
+        cpu: &mut CPU,
+        ppu: &mut PPU,
+        apu: &mut Apu,
+    ) {
         let offset = Self::to_offset(addr);
 
         if offset < self.data.len() {
@@ -84,59 +92,59 @@ impl MemoryRegion for Io {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use common::snes_address::snes_addr;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use common::snes_address::snes_addr;
 
-    #[test]
-    fn test_good_map_addr() {
-        for bank in (0x00..=0x3F).chain(0x80..=0xBF) {
-            for addr in IO_START_ADDRESS..IO_END_ADDRESS {
-                let address: SnesAddress = snes_addr!(bank:addr);
-                assert_eq!(Io::to_offset(address), addr as usize);
-            }
-        }
-    }
+//     #[test]
+//     fn test_good_map_addr() {
+//         for bank in (0x00..=0x3F).chain(0x80..=0xBF) {
+//             for addr in IO_START_ADDRESS..IO_END_ADDRESS {
+//                 let address: SnesAddress = snes_addr!(bank:addr);
+//                 assert_eq!(Io::to_offset(address), addr as usize);
+//             }
+//         }
+//     }
 
-    #[test]
-    #[should_panic]
-    fn test_bad_map_addr_panics() {
-        Io::to_offset(snes_addr!(0:IO_START_ADDRESS - 0x0321));
-    }
+//     #[test]
+//     #[should_panic]
+//     fn test_bad_map_addr_panics() {
+//         Io::to_offset(snes_addr!(0:IO_START_ADDRESS - 0x0321));
+//     }
 
-    #[test]
-    #[should_panic]
-    fn test_bad_map_addr_panics2() {
-        Io::to_offset(snes_addr!(0x0F:IO_END_ADDRESS + 0x34EF));
-    }
+//     #[test]
+//     #[should_panic]
+//     fn test_bad_map_addr_panics2() {
+//         Io::to_offset(snes_addr!(0x0F:IO_END_ADDRESS + 0x34EF));
+//     }
 
-    #[test]
-    #[should_panic(expected = "Incorrect access to the IO at address: E32345")]
-    fn test_bad_map_addr_panic_message_read() {
-        let io = Io::new();
+//     #[test]
+//     #[should_panic(expected = "Incorrect access to the IO at address: E32345")]
+//     fn test_bad_map_addr_panic_message_read() {
+//         let io = Io::new();
 
-        io.read(snes_addr!(0xE3:0x2345));
-    }
+//         io.read(snes_addr!(0xE3:0x2345));
+//     }
 
-    #[test]
-    #[should_panic(expected = "Incorrect access to the IO at address: E32345")]
-    fn test_bad_map_addr_panic_message_write() {
-        let mut io = Io::new();
+//     #[test]
+//     #[should_panic(expected = "Incorrect access to the IO at address: E32345")]
+//     fn test_bad_map_addr_panic_message_write() {
+//         let mut io = Io::new();
 
-        io.write(snes_addr!(0xE3:0x2345), 0x43);
-    }
+//         io.write(snes_addr!(0xE3:0x2345), 0x43);
+//     }
 
-    #[test]
-    fn test_simple_read_write() {
-        let mut wram = Io::new();
-        let first_addr = snes_addr!(0:IO_START_ADDRESS);
-        let second_addr = snes_addr!(0x9F:IO_START_ADDRESS);
+//     #[test]
+//     fn test_simple_read_write() {
+//         let mut wram = Io::new();
+//         let first_addr = snes_addr!(0:IO_START_ADDRESS);
+//         let second_addr = snes_addr!(0x9F:IO_START_ADDRESS);
 
-        wram.write(first_addr, 0x43);
-        assert_eq!(wram.read(first_addr), 0x43);
+//         wram.write(first_addr, 0x43);
+//         assert_eq!(wram.read(first_addr), 0x43);
 
-        wram.write(second_addr, 0x43);
-        assert_eq!(wram.read(second_addr), 0x43);
-    }
-}
+//         wram.write(second_addr, 0x43);
+//         assert_eq!(wram.read(second_addr), 0x43);
+//     }
+// }

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -144,6 +144,7 @@ impl Io {
         match addr.addr {
             // Data-from-APU register
             // TODO : Link with the actual apu component
+            #[cfg(not(tarpaulin_include))]
             0x2140..0x2180 => {
                 let reg_nb = addr.addr % 4;
                 match reg_nb {
@@ -156,10 +157,13 @@ impl Io {
             }
 
             // S-WRAM Data Registers (Expansion port not implemented yet)
+            #[cfg(not(tarpaulin_include))]
             0x2180 => todo!("0x2180-0x2183 : Implement Rom S-WRAM reads"),
 
             // JOYSER0/JOYSER1 - manual controller reading not implemented
+            #[cfg(not(tarpaulin_include))]
             0x4016 => todo!("0x4016 : Implement JOYSER0 register read"),
+            #[cfg(not(tarpaulin_include))]
             0x4017 => todo!("0x4017 : Implement JOYSER1 register read"),
 
             // Vblank flag and CPU version register
@@ -183,6 +187,7 @@ impl Io {
             0x4212 => self.hvbjoy,
 
             // RDIO : manual controller reading not implemented
+            #[cfg(not(tarpaulin_include))]
             0x4213 => todo!("0x4213 : Implement RDIO register read"),
 
             // Divison result register
@@ -235,6 +240,7 @@ impl Io {
     fn write_cpu(&mut self, value: u8, addr: SnesAddress, cpu: &mut CPU, apu: &mut Apu) {
         match addr.addr {
             // Data-to-APU register
+            #[cfg(not(tarpaulin_include))]
             0x2140..0x2180 => {
                 let reg_nb = addr.addr % 4;
                 match reg_nb {
@@ -247,9 +253,11 @@ impl Io {
             }
 
             // S-WRAM Data Registers (Expansion port not implemented yet)
+            #[cfg(not(tarpaulin_include))]
             0x2180..=0x2183 => todo!("0x2180-0x2183 : Implement Rom S-WRAM writes"),
 
             // JOYOUT - manual controller reading not implemented
+            #[cfg(not(tarpaulin_include))]
             0x4016 => todo!("0x4016 : Implement JOYOUT register write"),
 
             // Register for enabling NMI, H/V-Blank, and joypad auto-read
@@ -463,6 +471,7 @@ impl Io {
                 // 0x2000..0x6000 => self.io.DUP_method(DUP_method_param, cpu, ppu, apu),
                 match addr.addr {
                     0x2000..0x2100 => cpu.data_bus,
+                    #[cfg(not(tarpaulin_include))]
                     0x2100..0x2140 => self.read_ppu(addr, ppu),
                     0x2140..0x4380 => self.read_cpu(addr, cpu, apu),
                     0x4380..0x6000 => cpu.data_bus,
@@ -494,6 +503,7 @@ impl Io {
             {
                 match addr.addr {
                     0x2000..0x2100 => {}
+                    #[cfg(not(tarpaulin_include))]
                     0x2100..0x2140 => self.write_ppu(value, addr, ppu),
                     0x2140..0x4380 => self.write_cpu(value, addr, cpu, apu),
                     0x4380..0x6000 => {}
@@ -511,13 +521,32 @@ mod tests {
     use super::*;
     use common::snes_address::snes_addr;
 
+    fn init_all() -> (Io, CPU, PPU, Apu) {
+        let io = Io::new();
+        let cpu = CPU::poweron();
+        let ppu = PPU::new();
+        let apu = Apu::new();
+
+        (io, cpu, ppu, apu)
+    }
+
     #[test]
-    fn test_good_map_addr() {
-        for bank in (0x00..=0x3F).chain(0x80..=0xBF) {
-            for addr in IO_START_ADDRESS..IO_END_ADDRESS {
-                let address: SnesAddress = snes_addr!(bank:addr);
-                assert_eq!(Io::to_offset(address), addr as usize);
-            }
-        }
+    fn test_write_to_open_bus() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        // Write to an open bus address
+        let open_bus_addr = snes_addr!(0:0x5000);
+        io.write(open_bus_addr, 0xAB, &mut cpu, &mut ppu, &mut apu);
+    }
+
+    #[test]
+    fn test_nmiten_register() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let nmiten_addr = snes_addr!(0:0x4200);
+        let writen_value = 0x11;
+        io.write(nmiten_addr, writen_value, &mut cpu, &mut ppu, &mut apu);
+
+        assert_eq!(io.nmitimen, writen_value);
     }
 }

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -14,9 +14,6 @@ use ppu::ppu::PPU;
 /// For example, the addresses `0x004000` and `0x9E4000` both refer to the
 /// same memory location.
 pub struct Io {
-    joyser0: u8,
-    joyser1: u8,
-
     nmitimen: u8,
     wrio: u8,
 
@@ -53,9 +50,6 @@ pub struct Io {
 impl Io {
     pub fn new() -> Self {
         Self {
-            joyser0: 0,
-            joyser1: 0,
-
             nmitimen: 0,
             wrio: 0xFF,
 
@@ -113,11 +107,11 @@ impl Io {
             }
 
             // S-WRAM Data Registers (Expansion port not implemented yet)
-            0x2180..=0x2183 => todo!("Implement Rom S-WRAM reads"),
+            0x2180 => todo!("0x2180-0x2183 : Implement Rom S-WRAM reads"),
 
-            // UNUSED : manual controller reading not implemented
-            0x4016 => self.joyser0,
-            0x4017 => self.joyser1,
+            // JOYSER0/JOYSER1 - manual controller reading not implemented
+            0x4016 => todo!("0x4016 : Implement JOYSER0 register read"),
+            0x4017 => todo!("0x4017 : Implement JOYSER1 register read"),
 
             // Vblank flag and CPU version register
             // TODO : Implement open bus on unused bits
@@ -181,10 +175,10 @@ impl Io {
             }
 
             // S-WRAM Data Registers (Expansion port not implemented yet)
-            0x2180..=0x2183 => todo!("Implement Rom S-WRAM writes"),
+            0x2180..=0x2183 => todo!("0x2180-0x2183 : Implement Rom S-WRAM writes"),
 
-            // UNUSED : manual controller reading not implemented
-            0x4016 => self.joyser0 = value,
+            // JOYOUT - manual controller reading not implemented
+            0x4016 => todo!("0x4016 : Implement JOYOUT register write"),
 
             // Register for enabling NMI, H/V-Blank, and joypad auto-read
             0x4200 => self.nmitimen = value,

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -753,4 +753,76 @@ mod tests {
         let joy4h_value = io.read(joy4h_addr, &mut cpu, &mut ppu, &mut apu);
         assert_eq!(joy4h_value, (value_joy4 >> 8) as u8);
     }
+
+    #[test]
+    fn test_dma_registers() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let cpu_open_bus_value = 0xE4;
+        cpu.data_bus = cpu_open_bus_value;
+
+        let mut value_inc = 0;
+        for channel_nb in (0..8) {
+            let channel_addr = snes_addr!(0:0x4300 + 0x10 * channel_nb);
+
+            for dma_reg in (0x0..=0xF) {
+                let reg_addr = snes_addr!(0:channel_addr.addr + dma_reg);
+
+                io.write(reg_addr, value_inc, &mut cpu, &mut ppu, &mut apu);
+                let read_value = io.read(reg_addr, &mut cpu, &mut ppu, &mut apu);
+                match dma_reg {
+                    0x0 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].dmap, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0x1 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].bbad, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0x2 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].a1tl, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0x3 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].a1th, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0x4 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].a1b, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0x5 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].dasl, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0x6 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].dash, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0x7 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].dasb, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0x8 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].a2al, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0x9 => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].a2ah, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0xA => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].nltr, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    0xB | 0xF => {
+                        assert_eq!(io.dma_channels[channel_nb as usize].unused, value_inc);
+                        assert_eq!(read_value, value_inc);
+                    }
+                    _ => assert_eq!(read_value, cpu_open_bus_value),
+                }
+
+                value_inc += 1;
+            }
+        }
+    }
 }

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -1,4 +1,4 @@
-use crate::constants::{IO_END_ADDRESS, IO_SIZE, IO_START_ADDRESS};
+use crate::constants::{IO_END_ADDRESS, IO_START_ADDRESS};
 use apu::Apu;
 use common::snes_address::SnesAddress;
 use cpu::cpu::CPU;
@@ -140,7 +140,7 @@ impl Io {
         );
     }
 
-    fn read_cpu(&mut self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
+    fn read_cpu(&mut self, addr: SnesAddress, cpu: &mut CPU, apu: &mut Apu) -> u8 {
         match addr.addr {
             // Data-from-APU register
             // TODO : Link with the actual apu component
@@ -232,7 +232,7 @@ impl Io {
         }
     }
 
-    fn write_cpu(&mut self, value: u8, addr: SnesAddress, cpu: &mut CPU) {
+    fn write_cpu(&mut self, value: u8, addr: SnesAddress, cpu: &mut CPU, apu: &mut Apu) {
         match addr.addr {
             // Data-to-APU register
             0x2140..0x2180 => {
@@ -326,6 +326,7 @@ impl Io {
         }
     }
 
+    #[cfg(not(tarpaulin_include))]
     fn read_ppu(&mut self, addr: SnesAddress, ppu: &mut PPU) -> u8 {
         match addr.addr {
             // MPY result (24-bit)
@@ -359,6 +360,7 @@ impl Io {
         }
     }
 
+    #[cfg(not(tarpaulin_include))]
     fn write_ppu(&mut self, value: u8, addr: SnesAddress, ppu: &mut PPU) {
         match addr.addr {
             // Display / OBJ
@@ -458,8 +460,13 @@ impl Io {
             0x00..=0x3F | 0x80..=0xBF
                 if addr.addr >= IO_START_ADDRESS && addr.addr < IO_END_ADDRESS =>
             {
+                // 0x2000..0x6000 => self.io.DUP_method(DUP_method_param, cpu, ppu, apu),
                 match addr.addr {
-                    0x2140..0x4300 => self.read_cpu(addr, cpu),
+                    0x2000..0x2100 => cpu.data_bus,
+                    0x2100..0x2140 => self.read_ppu(addr, ppu),
+                    0x2140..0x4380 => self.read_cpu(addr, cpu, apu),
+                    0x4380..0x6000 => cpu.data_bus,
+
                     _ => Self::panic_invalid_addr(addr),
                 }
             }
@@ -486,7 +493,11 @@ impl Io {
                 if addr.addr >= IO_START_ADDRESS && addr.addr < IO_END_ADDRESS =>
             {
                 match addr.addr {
-                    0x2140..0x4300 => self.write_cpu(value, addr, cpu),
+                    0x2000..0x2100 => {}
+                    0x2100..0x2140 => self.write_ppu(value, addr, ppu),
+                    0x2140..0x4380 => self.write_cpu(value, addr, cpu, apu),
+                    0x4380..0x6000 => {}
+
                     _ => Self::panic_invalid_addr(addr),
                 }
             }

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -14,60 +14,60 @@ use ppu::ppu::PPU;
 /// For example, the addresses `0x004000` and `0x9E4000` both refer to the
 /// same memory location.
 pub struct Io {
-    nmitimen: u8,
-    wrio: u8,
+    pub nmitimen: u8,
+    pub wrio: u8,
 
-    wrmpya: u8,
-    wrmpyb: u8,
+    pub wrmpya: u8,
+    pub wrmpyb: u8,
 
-    wrdivl: u8,
-    wrdivh: u8,
-    wrdivb: u8,
+    pub wrdivl: u8,
+    pub wrdivh: u8,
+    pub wrdivb: u8,
 
-    htimel: u8,
-    htimeh: u8,
-    vtimel: u8,
-    vtimeh: u8,
+    pub htimel: u8,
+    pub htimeh: u8,
+    pub vtimel: u8,
+    pub vtimeh: u8,
 
-    mdmaen: u8,
-    hdmaen: u8,
-    memsel: u8,
+    pub mdmaen: u8,
+    pub hdmaen: u8,
+    pub memsel: u8,
 
-    rddiv: u16,
-    rdmpy: u16,
+    pub rddiv: u16,
+    pub rdmpy: u16,
 
-    rdnmi: u8,
-    timeup: u8,
-    hvbjoy: u8,
+    pub rdnmi: u8,
+    pub timeup: u8,
+    pub hvbjoy: u8,
 
-    joy1: u16,
-    joy2: u16,
-    joy3: u16,
-    joy4: u16,
+    pub joy1: u16,
+    pub joy2: u16,
+    pub joy3: u16,
+    pub joy4: u16,
 
-    dma_channels: [DMAChannel; 8],
+    pub dma_channels: [DMAChannel; 8],
 }
 
 #[derive(Copy, Clone)]
 pub struct DMAChannel {
-    dmap: u8,
+    pub dmap: u8,
 
-    bbad: u8,
+    pub bbad: u8,
 
-    a1tl: u8,
-    a1th: u8,
-    a1b: u8,
+    pub a1tl: u8,
+    pub a1th: u8,
+    pub a1b: u8,
 
-    dasl: u8,
-    dash: u8,
-    dasb: u8,
+    pub dasl: u8,
+    pub dash: u8,
+    pub dasb: u8,
 
-    a2al: u8,
-    a2ah: u8,
+    pub a2al: u8,
+    pub a2ah: u8,
 
-    nltr: u8,
+    pub nltr: u8,
 
-    unused: u8,
+    pub unused: u8,
 }
 
 impl DMAChannel {
@@ -506,59 +506,18 @@ impl Io {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use common::snes_address::snes_addr;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::snes_address::snes_addr;
 
-//     #[test]
-//     fn test_good_map_addr() {
-//         for bank in (0x00..=0x3F).chain(0x80..=0xBF) {
-//             for addr in IO_START_ADDRESS..IO_END_ADDRESS {
-//                 let address: SnesAddress = snes_addr!(bank:addr);
-//                 assert_eq!(Io::to_offset(address), addr as usize);
-//             }
-//         }
-//     }
-
-//     #[test]
-//     #[should_panic]
-//     fn test_bad_map_addr_panics() {
-//         Io::to_offset(snes_addr!(0:IO_START_ADDRESS - 0x0321));
-//     }
-
-//     #[test]
-//     #[should_panic]
-//     fn test_bad_map_addr_panics2() {
-//         Io::to_offset(snes_addr!(0x0F:IO_END_ADDRESS + 0x34EF));
-//     }
-
-//     #[test]
-//     #[should_panic(expected = "Incorrect access to the IO at address: E32345")]
-//     fn test_bad_map_addr_panic_message_read() {
-//         let io = Io::new();
-
-//         io.read(snes_addr!(0xE3:0x2345));
-//     }
-
-//     #[test]
-//     #[should_panic(expected = "Incorrect access to the IO at address: E32345")]
-//     fn test_bad_map_addr_panic_message_write() {
-//         let mut io = Io::new();
-
-//         io.write(snes_addr!(0xE3:0x2345), 0x43);
-//     }
-
-//     #[test]
-//     fn test_simple_read_write() {
-//         let mut wram = Io::new();
-//         let first_addr = snes_addr!(0:IO_START_ADDRESS);
-//         let second_addr = snes_addr!(0x9F:IO_START_ADDRESS);
-
-//         wram.write(first_addr, 0x43);
-//         assert_eq!(wram.read(first_addr), 0x43);
-
-//         wram.write(second_addr, 0x43);
-//         assert_eq!(wram.read(second_addr), 0x43);
-//     }
-// }
+    #[test]
+    fn test_good_map_addr() {
+        for bank in (0x00..=0x3F).chain(0x80..=0xBF) {
+            for addr in IO_START_ADDRESS..IO_END_ADDRESS {
+                let address: SnesAddress = snes_addr!(bank:addr);
+                assert_eq!(Io::to_offset(address), addr as usize);
+            }
+        }
+    }
+}

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -44,6 +44,55 @@ pub struct Io {
     joy2: u16,
     joy3: u16,
     joy4: u16,
+
+    dma_channels: [DMAChannel; 8],
+}
+
+#[derive(Copy, Clone)]
+pub struct DMAChannel {
+    dmap: u8,
+
+    bbad: u8,
+
+    a1tl: u8,
+    a1th: u8,
+    a1b: u8,
+
+    dasl: u8,
+    dash: u8,
+    dasb: u8,
+
+    a2al: u8,
+    a2ah: u8,
+
+    nltr: u8,
+
+    unused: u8,
+}
+
+impl DMAChannel {
+    pub fn new() -> Self {
+        Self {
+            dmap: 0xFF,
+
+            bbad: 0xFF,
+
+            a1tl: 0xFF,
+            a1th: 0xFF,
+            a1b: 0xFF,
+
+            dasl: 0xFF,
+            dash: 0xFF,
+            dasb: 0xFF,
+
+            a2al: 0xFF,
+            a2ah: 0xFF,
+
+            nltr: 0xFF,
+
+            unused: 0xFF,
+        }
+    }
 }
 
 impl Io {
@@ -79,6 +128,8 @@ impl Io {
             joy2: 0,
             joy3: 0,
             joy4: 0,
+
+            dma_channels: [DMAChannel::new(); 8],
         }
     }
 
@@ -152,12 +203,35 @@ impl Io {
             0x421E => self.joy4 as u8,
             0x421F => (self.joy4 >> 8) as u8,
 
+            0x4300..0x4380 => {
+                let channel_nb = (addr.addr - 0x4300) / 0x10;
+                let reg_nb = (addr.addr - 0x4300) % 0x10;
+
+                let channel = &mut self.dma_channels[channel_nb as usize];
+                match reg_nb {
+                    0x0 => channel.dmap,
+                    0x1 => channel.bbad,
+                    0x2 => channel.a1tl,
+                    0x3 => channel.a1th,
+                    0x4 => channel.a1b,
+                    0x5 => channel.dasl,
+                    0x6 => channel.dash,
+                    0x7 => channel.dasb,
+                    0x8 => channel.a2al,
+                    0x9 => channel.a2ah,
+                    0xA => channel.nltr,
+                    0xB | 0xF => channel.unused,
+
+                    _ => cpu.data_bus, // Open bus I believe, but not sure if this is the correct behavior
+                }
+            }
+
             // Open Bus
             _ => cpu.data_bus,
         }
     }
 
-    fn write_cpu(&mut self, value: u8, addr: SnesAddress, _cpu: &mut CPU) {
+    fn write_cpu(&mut self, value: u8, addr: SnesAddress, cpu: &mut CPU) {
         match addr.addr {
             // Data-to-APU register
             0x2140..0x2180 => {
@@ -216,13 +290,35 @@ impl Io {
             0x4209 => self.vtimel = value,
             0x420A => self.vtimeh = value & 1,
 
-            // DMA and HDMA registers
+            // DMA and HDMA enable registers
             // TODO : Implement real DMA and HDMA behaviors
             0x420B => self.mdmaen = value,
             0x420C => self.hdmaen = value,
 
             // ROM access speed register
             0x420D => self.memsel = value,
+
+            0x4300..0x4380 => {
+                let channel_nb = (addr.addr - 0x4300) / 0x10;
+                let reg_nb = (addr.addr - 0x4300) % 0x10;
+
+                let channel = &mut self.dma_channels[channel_nb as usize];
+                match reg_nb {
+                    0x0 => channel.dmap = value,
+                    0x1 => channel.bbad = value,
+                    0x2 => channel.a1tl = value,
+                    0x3 => channel.a1th = value,
+                    0x4 => channel.a1b = value,
+                    0x5 => channel.dasl = value,
+                    0x6 => channel.dash = value,
+                    0x7 => channel.dasb = value,
+                    0x8 => channel.a2al = value,
+                    0x9 => channel.a2ah = value,
+                    0xA => channel.nltr = value,
+                    0xB | 0xF => channel.unused = value,
+                    _ => {}
+                }
+            }
 
             _ => {}
         }

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -468,7 +468,6 @@ impl Io {
             0x00..=0x3F | 0x80..=0xBF
                 if addr.addr >= IO_START_ADDRESS && addr.addr < IO_END_ADDRESS =>
             {
-                // 0x2000..0x6000 => self.io.DUP_method(DUP_method_param, cpu, ppu, apu),
                 match addr.addr {
                     0x2000..0x2100 => cpu.data_bus,
                     #[cfg(not(tarpaulin_include))]
@@ -476,7 +475,8 @@ impl Io {
                     0x2140..0x4380 => self.read_cpu(addr, cpu, apu),
                     0x4380..0x6000 => cpu.data_bus,
 
-                    _ => Self::panic_invalid_addr(addr),
+                    #[cfg(not(tarpaulin_include))]
+                    _ => unreachable!(),
                 }
             }
             _ => Self::panic_invalid_addr(addr),
@@ -508,7 +508,8 @@ impl Io {
                     0x2140..0x4380 => self.write_cpu(value, addr, cpu, apu),
                     0x4380..0x6000 => {}
 
-                    _ => Self::panic_invalid_addr(addr),
+                    #[cfg(not(tarpaulin_include))]
+                    _ => unreachable!(),
                 }
             }
             _ => Self::panic_invalid_addr(addr),
@@ -531,12 +532,46 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Incorrect access to the IO at address: 00A000")]
+    fn test_out_of_bounds_read() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let addr = snes_addr!(0:0xA000);
+        io.read(addr, &mut cpu, &mut ppu, &mut apu);
+    }
+
+    #[test]
+    #[should_panic(expected = "Incorrect access to the IO at address: 00A000")]
+    fn test_out_of_bounds_write() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let addr = snes_addr!(0:0xA000);
+        io.write(addr, 0xAB, &mut cpu, &mut ppu, &mut apu);
+    }
+
+    #[test]
     fn test_write_to_open_bus() {
         let (mut io, mut cpu, mut ppu, mut apu) = init_all();
 
-        // Write to an open bus address
         let open_bus_addr = snes_addr!(0:0x5000);
         io.write(open_bus_addr, 0xAB, &mut cpu, &mut ppu, &mut apu);
+        let open_bus_addr = snes_addr!(0:0x4250);
+        io.write(open_bus_addr, 0xAB, &mut cpu, &mut ppu, &mut apu);
+    }
+
+    #[test]
+    fn test_read_from_open_bus() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        cpu.data_bus = 0x20;
+        let open_bus_addr = snes_addr!(0:0x5000);
+        let read_value = io.read(open_bus_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(read_value, 0x20);
+
+        cpu.data_bus = 0x40;
+        let open_bus_addr = snes_addr!(0:0x4250);
+        let read_value = io.read(open_bus_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(read_value, 0x40);
     }
 
     #[test]

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -294,10 +294,10 @@ impl Io {
 
             // Screen timer Horizontal target values
             0x4207 => self.htimel = value,
-            0x4208 => self.htimeh = value & 1,
+            0x4208 => self.htimeh = value,
             // Screen timer Vertical target values
             0x4209 => self.vtimel = value,
-            0x420A => self.vtimeh = value & 1,
+            0x420A => self.vtimeh = value,
 
             // DMA and HDMA enable registers
             // TODO : Implement real DMA and HDMA behaviors
@@ -540,7 +540,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nmiten_register() {
+    fn test_nmiten_register_write() {
         let (mut io, mut cpu, mut ppu, mut apu) = init_all();
 
         let nmiten_addr = snes_addr!(0:0x4200);
@@ -548,5 +548,209 @@ mod tests {
         io.write(nmiten_addr, writen_value, &mut cpu, &mut ppu, &mut apu);
 
         assert_eq!(io.nmitimen, writen_value);
+    }
+
+    #[test]
+    fn test_wrio_register_write() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let wrio_addr = snes_addr!(0:0x4201);
+        let writen_value = 0x11;
+        io.write(wrio_addr, writen_value, &mut cpu, &mut ppu, &mut apu);
+
+        assert_eq!(io.wrio, writen_value);
+    }
+
+    #[test]
+    fn test_wrmpya_wrmpyb_register_write() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let wrmpya_addr = snes_addr!(0:0x4202);
+        let wrmpyb_addr = snes_addr!(0:0x4203);
+        let rdmpyl_addr = snes_addr!(0:0x4216);
+        let rdmpyh_addr = snes_addr!(0:0x4217);
+        let value_wrmpya = 0x10;
+        let value_wrmpyb = 0x25;
+        io.write(wrmpya_addr, value_wrmpya, &mut cpu, &mut ppu, &mut apu);
+        io.write(wrmpyb_addr, value_wrmpyb, &mut cpu, &mut ppu, &mut apu);
+
+        assert_eq!(io.wrmpya, value_wrmpya);
+        assert_eq!(io.wrmpyb, value_wrmpyb);
+        assert_eq!(io.rdmpy, (io.wrmpya as u16) * (io.wrmpyb as u16));
+
+        let rdmpyl_value = io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu);
+        let rdmpyh_value = io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(rdmpyl_value, (io.rdmpy as u8));
+        assert_eq!(rdmpyh_value, (io.rdmpy >> 8) as u8);
+    }
+
+    #[test]
+    fn test_wrdiv_wrdivb_register_write() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let wrdivl_addr = snes_addr!(0:0x4204);
+        let wrdivh_addr = snes_addr!(0:0x4205);
+        let wrdivb_addr = snes_addr!(0:0x4206);
+        let rddivl_addr = snes_addr!(0:0x4214);
+        let rddivh_addr = snes_addr!(0:0x4215);
+        let rdmpyl_addr = snes_addr!(0:0x4216);
+        let rdmpyh_addr = snes_addr!(0:0x4217);
+        let value_wrdivl = 0x10;
+        let value_wrdivh = 0x25;
+        let value_wrdiv: u16 = 0x2510;
+        let value_wrdivb = 0x30;
+        io.write(wrdivl_addr, value_wrdivl, &mut cpu, &mut ppu, &mut apu);
+        io.write(wrdivh_addr, value_wrdivh, &mut cpu, &mut ppu, &mut apu);
+        io.write(wrdivb_addr, value_wrdivb, &mut cpu, &mut ppu, &mut apu);
+
+        assert_eq!(io.wrdivl, value_wrdivl);
+        assert_eq!(io.wrdivh, value_wrdivh);
+        assert_eq!(io.wrdivb, value_wrdivb);
+        assert_eq!(io.rddiv, value_wrdiv / value_wrdivb as u16);
+        assert_eq!(io.rdmpy, value_wrdiv % value_wrdivb as u16);
+
+        let rdmpyl_value = io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu);
+        let rdmpyh_value = io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(rdmpyl_value, (io.rdmpy as u8));
+        assert_eq!(rdmpyh_value, (io.rdmpy >> 8) as u8);
+        let rddivl_value = io.read(rddivl_addr, &mut cpu, &mut ppu, &mut apu);
+        let rddivh_value = io.read(rddivh_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(rddivl_value, (io.rddiv as u8));
+        assert_eq!(rddivh_value, (io.rddiv >> 8) as u8);
+    }
+
+    #[test]
+    fn test_htimel_vtimel_register_write() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let htimel_addr = snes_addr!(0:0x4207);
+        let htimeh_addr = snes_addr!(0:0x4208);
+        let vtimel_addr = snes_addr!(0:0x4209);
+        let vtimeh_addr = snes_addr!(0:0x420A);
+        let value_htimel = 0x10;
+        let value_htimeh = 0x25;
+        let value_vtimel = 0x30;
+        let value_vtimeh = 0x45;
+        io.write(htimel_addr, value_htimel, &mut cpu, &mut ppu, &mut apu);
+        io.write(htimeh_addr, value_htimeh, &mut cpu, &mut ppu, &mut apu);
+        io.write(vtimel_addr, value_vtimel, &mut cpu, &mut ppu, &mut apu);
+        io.write(vtimeh_addr, value_vtimeh, &mut cpu, &mut ppu, &mut apu);
+
+        assert_eq!(io.htimel, value_htimel);
+        assert_eq!(io.htimeh, value_htimeh);
+        assert_eq!(io.vtimel, value_vtimel);
+        assert_eq!(io.vtimeh, value_vtimeh);
+    }
+
+    #[test]
+    fn test_mdmaen_register_write() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let mdmaen_addr = snes_addr!(0:0x420B);
+        let value_mdmaen = 0x10;
+        io.write(mdmaen_addr, value_mdmaen, &mut cpu, &mut ppu, &mut apu);
+
+        assert_eq!(io.mdmaen, value_mdmaen);
+    }
+
+    #[test]
+    fn test_hdmaen_register_write() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let hdmaen_addr = snes_addr!(0:0x420C);
+        let value_hdmaen = 0x10;
+        io.write(hdmaen_addr, value_hdmaen, &mut cpu, &mut ppu, &mut apu);
+
+        assert_eq!(io.hdmaen, value_hdmaen);
+    }
+
+    #[test]
+    fn test_memsel_register_write() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let memsel_addr = snes_addr!(0:0x420D);
+        let value_memsel = 0x10;
+        io.write(memsel_addr, value_memsel, &mut cpu, &mut ppu, &mut apu);
+
+        assert_eq!(io.memsel, value_memsel);
+    }
+
+    #[test]
+    fn test_rdnmi_register_read() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let rdnmi_addr = snes_addr!(0:0x4210);
+        let value_rdnmi = 0xFF;
+        io.rdnmi = value_rdnmi;
+
+        let read_value = io.read(rdnmi_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(read_value, value_rdnmi);
+        let second_read_value = io.read(rdnmi_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(second_read_value, 0b0111_1111);
+    }
+
+    #[test]
+    fn test_timeup_register_read() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let timeup_addr = snes_addr!(0:0x4211);
+        let value_timeup = 0xFF;
+        io.timeup = value_timeup;
+
+        let read_value = io.read(timeup_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(read_value, value_timeup);
+        let second_read_value = io.read(timeup_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(second_read_value, 0b0111_1111);
+    }
+
+    #[test]
+    fn test_hvbjoy_register_read() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let hvbjoy_addr = snes_addr!(0:0x4212);
+        let value_hvbjoy = 0xFF;
+        io.hvbjoy = value_hvbjoy;
+
+        let read_value = io.read(hvbjoy_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(read_value, value_hvbjoy);
+    }
+
+    #[test]
+    fn test_joy_autoread_result_register_read() {
+        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+
+        let joy1l_addr = snes_addr!(0:0x4218);
+        let joy1h_addr = snes_addr!(0:0x4219);
+        let joy2l_addr = snes_addr!(0:0x421A);
+        let joy2h_addr = snes_addr!(0:0x421B);
+        let joy3l_addr = snes_addr!(0:0x421C);
+        let joy3h_addr = snes_addr!(0:0x421D);
+        let joy4l_addr = snes_addr!(0:0x421E);
+        let joy4h_addr = snes_addr!(0:0x421F);
+        let value_joy1: u16 = 0xF00F;
+        let value_joy2: u16 = 0xE00E;
+        let value_joy3: u16 = 0xD00D;
+        let value_joy4: u16 = 0xC00C;
+        io.joy1 = value_joy1;
+        io.joy2 = value_joy2;
+        io.joy3 = value_joy3;
+        io.joy4 = value_joy4;
+
+        let joy1l_value = io.read(joy1l_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(joy1l_value, value_joy1 as u8);
+        let joy1h_value = io.read(joy1h_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(joy1h_value, (value_joy1 >> 8) as u8);
+        let joy2l_value = io.read(joy2l_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(joy2l_value, value_joy2 as u8);
+        let joy2h_value = io.read(joy2h_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(joy2h_value, (value_joy2 >> 8) as u8);
+        let joy3l_value = io.read(joy3l_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(joy3l_value, value_joy3 as u8);
+        let joy3h_value = io.read(joy3h_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(joy3h_value, (value_joy3 >> 8) as u8);
+        let joy4l_value = io.read(joy4l_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(joy4l_value, value_joy4 as u8);
+        let joy4h_value = io.read(joy4h_addr, &mut cpu, &mut ppu, &mut apu);
+        assert_eq!(joy4h_value, (value_joy4 >> 8) as u8);
     }
 }

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -14,6 +14,11 @@ use ppu::ppu::PPU;
 /// For example, the addresses `0x004000` and `0x9E4000` both refer to the
 /// same memory location.
 pub struct Io {
+    wmdata: u8,
+    wmaddl: u8,
+    wmaddm: u8,
+    wmaddh: u8,
+
     // ---------- $4016-$4017 ----------
     joyser0: u8,
     joyser1: u8,
@@ -58,6 +63,11 @@ pub struct Io {
 impl Io {
     pub fn new() -> Self {
         Self {
+            wmdata: 0,
+            wmaddl: 0,
+            wmaddm: 0,
+            wmaddh: 0,
+
             joyser0: 0,
             joyser1: 0,
 
@@ -103,6 +113,9 @@ impl Io {
 
     fn read_cpu(&self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
         match addr.addr {
+            // WRAM Data Registers - Seems to be mainly used with DMA
+            0x2180 => self.wmdata,
+
             // Open Bus
             _ => cpu.data_bus,
         }
@@ -110,6 +123,15 @@ impl Io {
 
     fn write_cpu(&mut self, value: u8, addr: SnesAddress, _cpu: &mut CPU) {
         match addr.addr {
+            // WRAM Data Registers - Seems to be mainly used with DMA
+            0x2180 => {
+                self.wmdata = value;
+                self.wmdata += 1; // TODO : Check if this behavior is really intended and if it should wrap around at 0xFF or not
+            }
+            0x2181 => self.wmaddl = value,
+            0x2182 => self.wmaddm = value,
+            0x2183 => self.wmaddh = value,
+
             // UNUSED : manual controller reading not implemented
             0x4016 => self.joyser0 = value,
 

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -19,11 +19,9 @@ pub struct Io {
     wmaddm: u8,
     wmaddh: u8,
 
-    // ---------- $4016-$4017 ----------
     joyser0: u8,
     joyser1: u8,
 
-    // ---------- $4200-$420D ----------
     nmitimen: u8,
     wrio: u8,
 
@@ -43,21 +41,18 @@ pub struct Io {
     hdmaen: u8,
     memsel: u8,
 
-    // ---------- math results ----------
     rddiv: u16,
     rdmpy: u16,
 
-    // ---------- status ----------
     rdnmi: u8,
     timeup: u8,
     hvbjoy: u8,
     rdio: u8,
 
-    // ---------- joypads ----------
-    joy: [u16; 4],
-
-    // ---------- DMA registers ----------
-    dma: [[u8; 0x10]; 8],
+    joy1: u16,
+    joy2: u16,
+    joy3: u16,
+    joy4: u16,
 }
 
 impl Io {
@@ -98,9 +93,10 @@ impl Io {
             hvbjoy: 0,
             rdio: 0,
 
-            joy: [0; 4],
-
-            dma: [[0xFF; 0x10]; 8],
+            joy1: 0,
+            joy2: 0,
+            joy3: 0,
+            joy4: 0,
         }
     }
 
@@ -111,10 +107,55 @@ impl Io {
         );
     }
 
-    fn read_cpu(&self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
+    fn read_cpu(&mut self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
         match addr.addr {
             // WRAM Data Registers - Seems to be mainly used with DMA
             0x2180 => self.wmdata,
+
+            // UNUSED : manual controller reading not implemented
+            0x4016 => self.joyser0,
+            0x4017 => self.joyser1,
+
+            // Vblank flag and CPU version register
+            // TODO : Implement open bus on unused bits
+            0x4210 => {
+                let value = self.rdnmi;
+                self.rdnmi = self.rdnmi & 0x7F; // Reset V-Blank flag
+                value
+            }
+
+            // Timer flag register
+            // TODO : Implement open bus on unused bits
+            0x4211 => {
+                let value = self.timeup;
+                self.timeup = self.timeup & 0x7F; // Reset Timer flag
+                value
+            }
+
+            // Screen and Joypad status register
+            // TODO : Implement open bus on unused bits
+            0x4212 => self.hvbjoy,
+
+            // UNUSED : manual controller reading not implemented
+            0x4213 => self.rdio,
+
+            // Divison result register
+            0x4214 => self.rddiv as u8,
+            0x4215 => (self.rddiv >> 8) as u8,
+
+            // Multiplication result / Division remainder register
+            0x4216 => self.rdmpy as u8,
+            0x4217 => (self.rdmpy >> 8) as u8,
+
+            // Joypad data registers
+            0x4218 => self.joy1 as u8,
+            0x4219 => (self.joy1 >> 8) as u8,
+            0x421A => self.joy2 as u8,
+            0x421B => (self.joy2 >> 8) as u8,
+            0x421C => self.joy3 as u8,
+            0x421D => (self.joy3 >> 8) as u8,
+            0x421E => self.joy4 as u8,
+            0x421F => (self.joy4 >> 8) as u8,
 
             // Open Bus
             _ => cpu.data_bus,

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -203,6 +203,7 @@ impl Io {
             0x421E => self.joy4 as u8,
             0x421F => (self.joy4 >> 8) as u8,
 
+            // DMA and HDMA channel registers
             0x4300..0x4380 => {
                 let channel_nb = (addr.addr - 0x4300) / 0x10;
                 let reg_nb = (addr.addr - 0x4300) % 0x10;
@@ -298,6 +299,7 @@ impl Io {
             // ROM access speed register
             0x420D => self.memsel = value,
 
+            // DMA and HDMA channel registers
             0x4300..0x4380 => {
                 let channel_nb = (addr.addr - 0x4300) / 0x10;
                 let reg_nb = (addr.addr - 0x4300) % 0x10;
@@ -324,17 +326,123 @@ impl Io {
         }
     }
 
-    fn read_ppu(&self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
-        0
+    fn read_ppu(&mut self, addr: SnesAddress, ppu: &mut PPU) -> u8 {
+        match addr.addr {
+            // MPY result (24-bit)
+            0x2134 => todo!("0x2134 : MPYL read"),
+            0x2135 => todo!("0x2135 : MPYM read"),
+            0x2136 => todo!("0x2136 : MPYH read"),
+
+            // Latch H/V counter
+            0x2137 => todo!("0x2137 : SLHV read"),
+
+            // OAM read
+            0x2138 => todo!("0x2138 : OAMDATAREAD"),
+
+            // VRAM read
+            0x2139 => todo!("0x2139 : VMDATALREAD"),
+            0x213A => todo!("0x213A : VMDATAHREAD"),
+
+            // CGRAM read (2-step)
+            0x213B => todo!("0x213B : CGDATAREAD"),
+
+            // H/V counters (2-step reads)
+            0x213C => todo!("0x213C : OPHCT read"),
+            0x213D => todo!("0x213D : OPVCT read"),
+
+            // Status registers
+            0x213E => todo!("0x213E : STAT77 read"),
+            0x213F => todo!("0x213F : STAT78 read"),
+
+            // Open bus, may need to have a custom ppu open bus
+            _ => 0,
+        }
     }
-    fn write_ppu(&mut self, value: u8, addr: SnesAddress, cpu: &mut CPU) -> u8 {
-        0
-    }
-    fn read_apu(&self, addr: SnesAddress, cpu: &mut CPU) -> u8 {
-        0
-    }
-    fn write_apu(&mut self, value: u8, addr: SnesAddress, cpu: &mut CPU) -> u8 {
-        0
+
+    fn write_ppu(&mut self, value: u8, addr: SnesAddress, ppu: &mut PPU) {
+        match addr.addr {
+            // Display / OBJ
+            0x2100 => todo!("0x2100 : INIDISP write"),
+            0x2101 => todo!("0x2101 : OBJSEL write"),
+
+            // OAM
+            0x2102 => todo!("0x2102 : OAMADDL write"),
+            0x2103 => todo!("0x2103 : OAMADDH write"),
+            0x2104 => todo!("0x2104 : OAMDATA write"),
+
+            // BG mode / mosaic
+            0x2105 => todo!("0x2105 : BGMODE write"),
+            0x2106 => todo!("0x2106 : MOSAIC write"),
+
+            // BG tilemap
+            0x2107 => todo!("0x2107 : BG1SC write"),
+            0x2108 => todo!("0x2108 : BG2SC write"),
+            0x2109 => todo!("0x2109 : BG3SC write"),
+            0x210A => todo!("0x210A : BG4SC write"),
+
+            // BG CHR base
+            0x210B => todo!("0x210B : BG12NBA write"),
+            0x210C => todo!("0x210C : BG34NBA write"),
+
+            // Scroll registers (W8x2)
+            0x210D => todo!("0x210D : BG1HOFS / M7HOFS write"),
+            0x210E => todo!("0x210E : BG1VOFS / M7VOFS write"),
+            0x210F => todo!("0x210F : BG2HOFS write"),
+            0x2110 => todo!("0x2110 : BG2VOFS write"),
+            0x2111 => todo!("0x2111 : BG3HOFS write"),
+            0x2112 => todo!("0x2112 : BG3VOFS write"),
+            0x2113 => todo!("0x2113 : BG4HOFS write"),
+            0x2114 => todo!("0x2114 : BG4VOFS write"),
+
+            // VRAM access
+            0x2115 => todo!("0x2115 : VMAIN write"),
+            0x2116 => todo!("0x2116 : VMADDL write"),
+            0x2117 => todo!("0x2117 : VMADDH write"),
+            0x2118 => todo!("0x2118 : VMDATAL write"),
+            0x2119 => todo!("0x2119 : VMDATAH write"),
+
+            // Mode 7
+            0x211A => todo!("0x211A : M7SEL write"),
+            0x211B => todo!("0x211B : M7A write"),
+            0x211C => todo!("0x211C : M7B write"),
+            0x211D => todo!("0x211D : M7C write"),
+            0x211E => todo!("0x211E : M7D write"),
+            0x211F => todo!("0x211F : M7X write"),
+            0x2120 => todo!("0x2120 : M7Y write"),
+
+            // CGRAM
+            0x2121 => todo!("0x2121 : CGADD write"),
+            0x2122 => todo!("0x2122 : CGDATA write"),
+
+            // Window registers
+            0x2123 => todo!("0x2123 : W12SEL write"),
+            0x2124 => todo!("0x2124 : W34SEL write"),
+            0x2125 => todo!("0x2125 : WOBJSEL write"),
+            0x2126 => todo!("0x2126 : WH0 write"),
+            0x2127 => todo!("0x2127 : WH1 write"),
+            0x2128 => todo!("0x2128 : WH2 write"),
+            0x2129 => todo!("0x2129 : WH3 write"),
+
+            // Window logic
+            0x212A => todo!("0x212A : WBGLOG write"),
+            0x212B => todo!("0x212B : WOBJLOG write"),
+
+            // Screen enable
+            0x212C => todo!("0x212C : TM write"),
+            0x212D => todo!("0x212D : TS write"),
+            0x212E => todo!("0x212E : TMW write"),
+            0x212F => todo!("0x212F : TSW write"),
+
+            // Color math
+            0x2130 => todo!("0x2130 : CGWSEL write"),
+            0x2131 => todo!("0x2131 : CGADSUB write"),
+            0x2132 => todo!("0x2132 : COLDATA write"),
+
+            // Screen settings
+            0x2133 => todo!("0x2133 : SETINI write"),
+
+            _ => {}
+        }
     }
 }
 

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -14,11 +14,6 @@ use ppu::ppu::PPU;
 /// For example, the addresses `0x004000` and `0x9E4000` both refer to the
 /// same memory location.
 pub struct Io {
-    wmdata: u8,
-    wmaddl: u8,
-    wmaddm: u8,
-    wmaddh: u8,
-
     joyser0: u8,
     joyser1: u8,
 
@@ -58,11 +53,6 @@ pub struct Io {
 impl Io {
     pub fn new() -> Self {
         Self {
-            wmdata: 0,
-            wmaddl: 0,
-            wmaddm: 0,
-            wmaddh: 0,
-
             joyser0: 0,
             joyser1: 0,
 
@@ -122,8 +112,8 @@ impl Io {
                 }
             }
 
-            // WRAM Data Registers - Seems to be mainly used with DMA
-            0x2180 => self.wmdata,
+            // S-WRAM Data Registers (Expansion port not implemented yet)
+            0x2180..=0x2183 => todo!("Implement Rom S-WRAM reads"),
 
             // UNUSED : manual controller reading not implemented
             0x4016 => self.joyser0,
@@ -190,14 +180,8 @@ impl Io {
                 }
             }
 
-            // WRAM Data Registers - Seems to be mainly used with DMA
-            0x2180 => {
-                self.wmdata = value;
-                self.wmdata += 1; // TODO : Check if this behavior is really intended and if it should wrap around at 0xFF or not
-            }
-            0x2181 => self.wmaddl = value,
-            0x2182 => self.wmaddm = value,
-            0x2183 => self.wmaddh = value,
+            // S-WRAM Data Registers (Expansion port not implemented yet)
+            0x2180..=0x2183 => todo!("Implement Rom S-WRAM writes"),
 
             // UNUSED : manual controller reading not implemented
             0x4016 => self.joyser0 = value,

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -1,6 +1,6 @@
 use crate::constants::{IO_END_ADDRESS, IO_START_ADDRESS};
 use apu::Apu;
-use common::snes_address::SnesAddress;
+use common::{snes_addr, snes_address::SnesAddress, u16_split::U16Split};
 use cpu::cpu::CPU;
 use ppu::ppu::PPU;
 
@@ -20,14 +20,11 @@ pub struct Io {
     pub wrmpya: u8,
     pub wrmpyb: u8,
 
-    pub wrdivl: u8,
-    pub wrdivh: u8,
+    pub wrdiv: u16,
     pub wrdivb: u8,
 
-    pub htimel: u8,
-    pub htimeh: u8,
-    pub vtimel: u8,
-    pub vtimeh: u8,
+    pub htime: u16,
+    pub vtime: u16,
 
     pub mdmaen: u8,
     pub hdmaen: u8,
@@ -54,16 +51,12 @@ pub struct DMAChannel {
 
     pub bbad: u8,
 
-    pub a1tl: u8,
-    pub a1th: u8,
-    pub a1b: u8,
+    pub a1t: SnesAddress,
 
-    pub dasl: u8,
-    pub dash: u8,
+    pub das: u16,
     pub dasb: u8,
 
-    pub a2al: u8,
-    pub a2ah: u8,
+    pub a2a: u16,
 
     pub nltr: u8,
 
@@ -77,16 +70,11 @@ impl DMAChannel {
 
             bbad: 0xFF,
 
-            a1tl: 0xFF,
-            a1th: 0xFF,
-            a1b: 0xFF,
-
-            dasl: 0xFF,
-            dash: 0xFF,
+            a1t: snes_addr!(0xFF:0xFFFF),
+            das: 0xFF,
             dasb: 0xFF,
 
-            a2al: 0xFF,
-            a2ah: 0xFF,
+            a2a: 0xFFFF,
 
             nltr: 0xFF,
 
@@ -104,14 +92,11 @@ impl Io {
             wrmpya: 0xFF,
             wrmpyb: 0xFF,
 
-            wrdivl: 0xFF,
-            wrdivh: 0xFF,
+            wrdiv: 0xFFFF,
             wrdivb: 0xFF,
 
-            htimel: 0xFF,
-            htimeh: 1,
-            vtimel: 0xFF,
-            vtimeh: 1,
+            htime: 0x01FF,
+            vtime: 0x01FF,
 
             mdmaen: 0,
             hdmaen: 0,
@@ -217,14 +202,14 @@ impl Io {
                 match reg_nb {
                     0x0 => channel.dmap,
                     0x1 => channel.bbad,
-                    0x2 => channel.a1tl,
-                    0x3 => channel.a1th,
-                    0x4 => channel.a1b,
-                    0x5 => channel.dasl,
-                    0x6 => channel.dash,
+                    0x2 => *channel.a1t.addr.lo(),
+                    0x3 => *channel.a1t.addr.hi(),
+                    0x4 => channel.a1t.bank,
+                    0x5 => *channel.das.lo(),
+                    0x6 => *channel.das.hi(),
                     0x7 => channel.dasb,
-                    0x8 => channel.a2al,
-                    0x9 => channel.a2ah,
+                    0x8 => *channel.a2a.lo(),
+                    0x9 => *channel.a2a.hi(),
                     0xA => channel.nltr,
                     0xB | 0xF => channel.unused,
 
@@ -276,12 +261,12 @@ impl Io {
 
             // Division registers
             // TODO : Make the actual division take 16 CPU cycles
-            0x4204 => self.wrdivl = value,
-            0x4205 => self.wrdivh = value,
+            0x4204 => *self.wrdiv.lo_mut() = value,
+            0x4205 => *self.wrdiv.hi_mut() = value,
             0x4206 => {
                 self.wrdivb = value;
 
-                let dividend = ((self.wrdivh as u16) << 8) | self.wrdivl as u16;
+                let dividend = self.wrdiv;
 
                 if value != 0 {
                     self.rddiv = dividend / value as u16;
@@ -293,11 +278,11 @@ impl Io {
             }
 
             // Screen timer Horizontal target values
-            0x4207 => self.htimel = value,
-            0x4208 => self.htimeh = value,
+            0x4207 => *self.htime.lo_mut() = value,
+            0x4208 => *self.htime.hi_mut() = value,
             // Screen timer Vertical target values
-            0x4209 => self.vtimel = value,
-            0x420A => self.vtimeh = value,
+            0x4209 => *self.vtime.lo_mut() = value,
+            0x420A => *self.vtime.hi_mut() = value,
 
             // DMA and HDMA enable registers
             // TODO : Implement real DMA and HDMA behaviors
@@ -316,14 +301,14 @@ impl Io {
                 match reg_nb {
                     0x0 => channel.dmap = value,
                     0x1 => channel.bbad = value,
-                    0x2 => channel.a1tl = value,
-                    0x3 => channel.a1th = value,
-                    0x4 => channel.a1b = value,
-                    0x5 => channel.dasl = value,
-                    0x6 => channel.dash = value,
+                    0x2 => *channel.a1t.addr.lo_mut() = value,
+                    0x3 => *channel.a1t.addr.hi_mut() = value,
+                    0x4 => channel.a1t.bank = value,
+                    0x5 => *channel.das.lo_mut() = value,
+                    0x6 => *channel.das.hi_mut() = value,
                     0x7 => channel.dasb = value,
-                    0x8 => channel.a2al = value,
-                    0x9 => channel.a2ah = value,
+                    0x8 => *channel.a2a.lo_mut() = value,
+                    0x9 => *channel.a2a.hi_mut() = value,
                     0xA => channel.nltr = value,
                     0xB | 0xF => channel.unused = value,
                     _ => {}
@@ -638,8 +623,8 @@ mod tests {
         io.write(wrdivh_addr, value_wrdivh, &mut cpu, &mut ppu, &mut apu);
         io.write(wrdivb_addr, value_wrdivb, &mut cpu, &mut ppu, &mut apu);
 
-        assert_eq!(io.wrdivl, value_wrdivl);
-        assert_eq!(io.wrdivh, value_wrdivh);
+        assert_eq!(*io.wrdiv.lo(), value_wrdivl);
+        assert_eq!(*io.wrdiv.hi(), value_wrdivh);
         assert_eq!(io.wrdivb, value_wrdivb);
         assert_eq!(io.rddiv, value_wrdiv / value_wrdivb as u16);
         assert_eq!(io.rdmpy, value_wrdiv % value_wrdivb as u16);
@@ -671,10 +656,10 @@ mod tests {
         io.write(vtimel_addr, value_vtimel, &mut cpu, &mut ppu, &mut apu);
         io.write(vtimeh_addr, value_vtimeh, &mut cpu, &mut ppu, &mut apu);
 
-        assert_eq!(io.htimel, value_htimel);
-        assert_eq!(io.htimeh, value_htimeh);
-        assert_eq!(io.vtimel, value_vtimel);
-        assert_eq!(io.vtimeh, value_vtimeh);
+        assert_eq!(*io.htime.lo(), value_htimel);
+        assert_eq!(*io.htime.hi(), value_htimeh);
+        assert_eq!(*io.vtime.lo(), value_vtimel);
+        assert_eq!(*io.vtime.hi(), value_vtimeh);
     }
 
     #[test]
@@ -808,8 +793,8 @@ mod tests {
         io.write(wrdivh_addr, value_wrdivh, &mut cpu, &mut ppu, &mut apu);
         io.write(wrdivb_addr, value_wrdivb, &mut cpu, &mut ppu, &mut apu);
 
-        assert_eq!(io.wrdivl, value_wrdivl);
-        assert_eq!(io.wrdivh, value_wrdivh);
+        assert_eq!(*io.wrdiv.lo(), value_wrdivl);
+        assert_eq!(*io.wrdiv.hi(), value_wrdivh);
         assert_eq!(io.wrdivb, value_wrdivb);
         assert_eq!(io.rddiv, 0xFFFF);
         assert_eq!(io.rdmpy, value_wrdiv);
@@ -849,23 +834,29 @@ mod tests {
                         assert_eq!(read_value, value_inc);
                     }
                     0x2 => {
-                        assert_eq!(io.dma_channels[channel_nb as usize].a1tl, value_inc);
+                        assert_eq!(
+                            *io.dma_channels[channel_nb as usize].a1t.addr.lo(),
+                            value_inc
+                        );
                         assert_eq!(read_value, value_inc);
                     }
                     0x3 => {
-                        assert_eq!(io.dma_channels[channel_nb as usize].a1th, value_inc);
+                        assert_eq!(
+                            *io.dma_channels[channel_nb as usize].a1t.addr.hi(),
+                            value_inc
+                        );
                         assert_eq!(read_value, value_inc);
                     }
                     0x4 => {
-                        assert_eq!(io.dma_channels[channel_nb as usize].a1b, value_inc);
+                        assert_eq!(io.dma_channels[channel_nb as usize].a1t.bank, value_inc);
                         assert_eq!(read_value, value_inc);
                     }
                     0x5 => {
-                        assert_eq!(io.dma_channels[channel_nb as usize].dasl, value_inc);
+                        assert_eq!(*io.dma_channels[channel_nb as usize].das.lo(), value_inc);
                         assert_eq!(read_value, value_inc);
                     }
                     0x6 => {
-                        assert_eq!(io.dma_channels[channel_nb as usize].dash, value_inc);
+                        assert_eq!(*io.dma_channels[channel_nb as usize].das.hi(), value_inc);
                         assert_eq!(read_value, value_inc);
                     }
                     0x7 => {
@@ -873,11 +864,11 @@ mod tests {
                         assert_eq!(read_value, value_inc);
                     }
                     0x8 => {
-                        assert_eq!(io.dma_channels[channel_nb as usize].a2al, value_inc);
+                        assert_eq!(*io.dma_channels[channel_nb as usize].a2a.lo(), value_inc);
                         assert_eq!(read_value, value_inc);
                     }
                     0x9 => {
-                        assert_eq!(io.dma_channels[channel_nb as usize].a2ah, value_inc);
+                        assert_eq!(*io.dma_channels[channel_nb as usize].a2a.hi(), value_inc);
                         assert_eq!(read_value, value_inc);
                     }
                     0xA => {

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -1,7 +1,6 @@
 use crate::constants::{IO_END_ADDRESS, IO_START_ADDRESS};
 use apu::Apu;
 use common::{snes_addr, snes_address::SnesAddress, u16_split::U16Split};
-use cpu::cpu::CPU;
 use ppu::ppu::PPU;
 
 /// I/O register file of the SNES, mapped to `0x2000–0x5FFF` in banks
@@ -313,7 +312,7 @@ impl Io {
         );
     }
 
-    fn read_cpu(&mut self, addr: SnesAddress, cpu: &mut CPU, apu: &mut Apu) -> u8 {
+    fn read_cpu(&mut self, addr: SnesAddress, apu: &mut Apu) -> u8 {
         match addr.addr {
             // Data-from-APU register
             // TODO : Link with the actual apu component
@@ -410,7 +409,7 @@ impl Io {
         }
     }
 
-    fn write_cpu(&mut self, value: u8, addr: SnesAddress, cpu: &mut CPU, apu: &mut Apu) {
+    fn write_cpu(&mut self, value: u8, addr: SnesAddress, apu: &mut Apu) {
         match addr.addr {
             // Data-to-APU register
             #[cfg(not(tarpaulin_include))]
@@ -636,7 +635,7 @@ impl Io {
     ///
     /// # Panics
     /// Panics if the address does not map to a valid I/O memory location.
-    pub fn read(&mut self, addr: SnesAddress, cpu: &mut CPU, ppu: &mut PPU, apu: &mut Apu) -> u8 {
+    pub fn read(&mut self, addr: SnesAddress, ppu: &mut PPU, apu: &mut Apu) -> u8 {
         self.open_bus = match addr.bank {
             0x00..=0x3F | 0x80..=0xBF
                 if addr.addr >= IO_START_ADDRESS && addr.addr < IO_END_ADDRESS =>
@@ -645,7 +644,7 @@ impl Io {
                     0x2000..0x2100 => self.open_bus,
                     #[cfg(not(tarpaulin_include))]
                     0x2100..0x2140 => self.read_ppu(addr, ppu),
-                    0x2140..0x4380 => self.read_cpu(addr, cpu, apu),
+                    0x2140..0x4380 => self.read_cpu(addr, apu),
                     0x4380..0x6000 => self.open_bus,
 
                     #[cfg(not(tarpaulin_include))]
@@ -663,14 +662,7 @@ impl Io {
     ///
     /// # Panics
     /// Panics if the address does not map to a valid I/O memory location.
-    pub fn write(
-        &mut self,
-        addr: SnesAddress,
-        value: u8,
-        cpu: &mut CPU,
-        ppu: &mut PPU,
-        apu: &mut Apu,
-    ) {
+    pub fn write(&mut self, addr: SnesAddress, value: u8, ppu: &mut PPU, apu: &mut Apu) {
         self.open_bus = value;
         match addr.bank {
             0x00..=0x3F | 0x80..=0xBF
@@ -680,7 +672,7 @@ impl Io {
                     0x2000..0x2100 => {}
                     #[cfg(not(tarpaulin_include))]
                     0x2100..0x2140 => self.write_ppu(value, addr, ppu),
-                    0x2140..0x4380 => self.write_cpu(value, addr, cpu, apu),
+                    0x2140..0x4380 => self.write_cpu(value, addr, apu),
                     0x4380..0x6000 => {}
 
                     #[cfg(not(tarpaulin_include))]
@@ -697,83 +689,82 @@ mod tests {
     use super::*;
     use common::snes_address::snes_addr;
 
-    fn init_all() -> (Io, CPU, PPU, Apu) {
+    fn init_all() -> (Io, PPU, Apu) {
         let io = Io::default();
-        let cpu = CPU::poweron();
         let ppu = PPU::new();
         let apu = Apu::new();
 
-        (io, cpu, ppu, apu)
+        (io, ppu, apu)
     }
 
     #[test]
     #[should_panic(expected = "Incorrect access to the IO at address: 00A000")]
     fn test_out_of_bounds_read() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let addr = snes_addr!(0:0xA000);
-        io.read(addr, &mut cpu, &mut ppu, &mut apu);
+        io.read(addr, &mut ppu, &mut apu);
     }
 
     #[test]
     #[should_panic(expected = "Incorrect access to the IO at address: 00A000")]
     fn test_out_of_bounds_write() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let addr = snes_addr!(0:0xA000);
-        io.write(addr, 0xAB, &mut cpu, &mut ppu, &mut apu);
+        io.write(addr, 0xAB, &mut ppu, &mut apu);
     }
 
     #[test]
     fn test_write_to_open_bus() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let open_bus_addr = snes_addr!(0:0x5000);
-        io.write(open_bus_addr, 0xAB, &mut cpu, &mut ppu, &mut apu);
+        io.write(open_bus_addr, 0xAB, &mut ppu, &mut apu);
         let open_bus_addr = snes_addr!(0:0x4250);
-        io.write(open_bus_addr, 0xAB, &mut cpu, &mut ppu, &mut apu);
+        io.write(open_bus_addr, 0xAB, &mut ppu, &mut apu);
     }
 
     #[test]
     fn test_read_from_open_bus() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         io.open_bus = 0x20;
         let open_bus_addr = snes_addr!(0:0x5000);
-        let read_value = io.read(open_bus_addr, &mut cpu, &mut ppu, &mut apu);
+        let read_value = io.read(open_bus_addr, &mut ppu, &mut apu);
         assert_eq!(read_value, 0x20);
 
         io.open_bus = 0x40;
         let open_bus_addr = snes_addr!(0:0x4250);
-        let read_value = io.read(open_bus_addr, &mut cpu, &mut ppu, &mut apu);
+        let read_value = io.read(open_bus_addr, &mut ppu, &mut apu);
         assert_eq!(read_value, 0x40);
     }
 
     #[test]
     fn test_nmiten_register_write() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let nmiten_addr = snes_addr!(0:0x4200);
         let writen_value = 0x11;
-        io.write(nmiten_addr, writen_value, &mut cpu, &mut ppu, &mut apu);
+        io.write(nmiten_addr, writen_value, &mut ppu, &mut apu);
 
         assert_eq!(io.nmitimen, writen_value);
     }
 
     #[test]
     fn test_wrio_register_write() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let wrio_addr = snes_addr!(0:0x4201);
         let writen_value = 0x11;
-        io.write(wrio_addr, writen_value, &mut cpu, &mut ppu, &mut apu);
+        io.write(wrio_addr, writen_value, &mut ppu, &mut apu);
 
         assert_eq!(io.wrio, writen_value);
     }
 
     #[test]
     fn test_wrmpya_wrmpyb_register_write() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let wrmpya_addr = snes_addr!(0:0x4202);
         let wrmpyb_addr = snes_addr!(0:0x4203);
@@ -781,20 +772,20 @@ mod tests {
         let rdmpyh_addr = snes_addr!(0:0x4217);
         let value_wrmpya = 0x10;
         let value_wrmpyb = 0x25;
-        io.write(wrmpya_addr, value_wrmpya, &mut cpu, &mut ppu, &mut apu);
-        io.write(wrmpyb_addr, value_wrmpyb, &mut cpu, &mut ppu, &mut apu);
+        io.write(wrmpya_addr, value_wrmpya, &mut ppu, &mut apu);
+        io.write(wrmpyb_addr, value_wrmpyb, &mut ppu, &mut apu);
 
         assert_eq!(io.wrmpya, value_wrmpya);
         assert_eq!(io.wrmpyb, value_wrmpyb);
         assert_eq!(io.rdmpy, (io.wrmpya as u16) * (io.wrmpyb as u16));
 
-        assert_eq!(io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu), *io.rdmpy.lo());
-        assert_eq!(io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu), *io.rdmpy.hi());
+        assert_eq!(io.read(rdmpyl_addr, &mut ppu, &mut apu), *io.rdmpy.lo());
+        assert_eq!(io.read(rdmpyh_addr, &mut ppu, &mut apu), *io.rdmpy.hi());
     }
 
     #[test]
     fn test_wrdiv_wrdivb_register_write() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let wrdivl_addr = snes_addr!(0:0x4204);
         let wrdivh_addr = snes_addr!(0:0x4205);
@@ -807,9 +798,9 @@ mod tests {
         let value_wrdivh = 0x25;
         let value_wrdiv: u16 = 0x2510;
         let value_wrdivb = 0x30;
-        io.write(wrdivl_addr, value_wrdivl, &mut cpu, &mut ppu, &mut apu);
-        io.write(wrdivh_addr, value_wrdivh, &mut cpu, &mut ppu, &mut apu);
-        io.write(wrdivb_addr, value_wrdivb, &mut cpu, &mut ppu, &mut apu);
+        io.write(wrdivl_addr, value_wrdivl, &mut ppu, &mut apu);
+        io.write(wrdivh_addr, value_wrdivh, &mut ppu, &mut apu);
+        io.write(wrdivb_addr, value_wrdivb, &mut ppu, &mut apu);
 
         assert_eq!(*io.wrdiv.lo(), value_wrdivl);
         assert_eq!(*io.wrdiv.hi(), value_wrdivh);
@@ -817,16 +808,16 @@ mod tests {
         assert_eq!(io.rddiv, value_wrdiv / value_wrdivb as u16);
         assert_eq!(io.rdmpy, value_wrdiv % value_wrdivb as u16);
 
-        assert_eq!(io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu), *io.rdmpy.lo());
-        assert_eq!(io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu), *io.rdmpy.hi());
+        assert_eq!(io.read(rdmpyl_addr, &mut ppu, &mut apu), *io.rdmpy.lo());
+        assert_eq!(io.read(rdmpyh_addr, &mut ppu, &mut apu), *io.rdmpy.hi());
 
-        assert_eq!(io.read(rddivl_addr, &mut cpu, &mut ppu, &mut apu), *io.rddiv.lo());
-        assert_eq!(io.read(rddivh_addr, &mut cpu, &mut ppu, &mut apu), *io.rddiv.hi());
+        assert_eq!(io.read(rddivl_addr, &mut ppu, &mut apu), *io.rddiv.lo());
+        assert_eq!(io.read(rddivh_addr, &mut ppu, &mut apu), *io.rddiv.hi());
     }
 
     #[test]
     fn test_htimel_vtimel_register_write() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let htimel_addr = snes_addr!(0:0x4207);
         let htimeh_addr = snes_addr!(0:0x4208);
@@ -836,10 +827,10 @@ mod tests {
         let value_htimeh = 0x25;
         let value_vtimel = 0x30;
         let value_vtimeh = 0x45;
-        io.write(htimel_addr, value_htimel, &mut cpu, &mut ppu, &mut apu);
-        io.write(htimeh_addr, value_htimeh, &mut cpu, &mut ppu, &mut apu);
-        io.write(vtimel_addr, value_vtimel, &mut cpu, &mut ppu, &mut apu);
-        io.write(vtimeh_addr, value_vtimeh, &mut cpu, &mut ppu, &mut apu);
+        io.write(htimel_addr, value_htimel, &mut ppu, &mut apu);
+        io.write(htimeh_addr, value_htimeh, &mut ppu, &mut apu);
+        io.write(vtimel_addr, value_vtimel, &mut ppu, &mut apu);
+        io.write(vtimeh_addr, value_vtimeh, &mut ppu, &mut apu);
 
         assert_eq!(*io.htime.lo(), value_htimel);
         assert_eq!(*io.htime.hi(), value_htimeh);
@@ -849,80 +840,80 @@ mod tests {
 
     #[test]
     fn test_mdmaen_register_write() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let mdmaen_addr = snes_addr!(0:0x420B);
         let value_mdmaen = 0x10;
-        io.write(mdmaen_addr, value_mdmaen, &mut cpu, &mut ppu, &mut apu);
+        io.write(mdmaen_addr, value_mdmaen, &mut ppu, &mut apu);
 
         assert_eq!(io.mdmaen, value_mdmaen);
     }
 
     #[test]
     fn test_hdmaen_register_write() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let hdmaen_addr = snes_addr!(0:0x420C);
         let value_hdmaen = 0x10;
-        io.write(hdmaen_addr, value_hdmaen, &mut cpu, &mut ppu, &mut apu);
+        io.write(hdmaen_addr, value_hdmaen, &mut ppu, &mut apu);
 
         assert_eq!(io.hdmaen, value_hdmaen);
     }
 
     #[test]
     fn test_memsel_register_write() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let memsel_addr = snes_addr!(0:0x420D);
         let value_memsel = 0x10;
-        io.write(memsel_addr, value_memsel, &mut cpu, &mut ppu, &mut apu);
+        io.write(memsel_addr, value_memsel, &mut ppu, &mut apu);
 
         assert_eq!(io.memsel, value_memsel);
     }
 
     #[test]
     fn test_rdnmi_register_read() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let rdnmi_addr = snes_addr!(0:0x4210);
         let value_rdnmi = 0xFF;
         io.rdnmi = value_rdnmi;
 
-        let read_value = io.read(rdnmi_addr, &mut cpu, &mut ppu, &mut apu);
+        let read_value = io.read(rdnmi_addr, &mut ppu, &mut apu);
         assert_eq!(read_value, value_rdnmi);
-        let second_read_value = io.read(rdnmi_addr, &mut cpu, &mut ppu, &mut apu);
+        let second_read_value = io.read(rdnmi_addr, &mut ppu, &mut apu);
         assert_eq!(second_read_value, 0b0111_1111);
     }
 
     #[test]
     fn test_timeup_register_read() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let timeup_addr = snes_addr!(0:0x4211);
         let value_timeup = 0xFF;
         io.timeup = value_timeup;
 
-        let read_value = io.read(timeup_addr, &mut cpu, &mut ppu, &mut apu);
+        let read_value = io.read(timeup_addr, &mut ppu, &mut apu);
         assert_eq!(read_value, value_timeup);
-        let second_read_value = io.read(timeup_addr, &mut cpu, &mut ppu, &mut apu);
+        let second_read_value = io.read(timeup_addr, &mut ppu, &mut apu);
         assert_eq!(second_read_value, 0b0111_1111);
     }
 
     #[test]
     fn test_hvbjoy_register_read() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let hvbjoy_addr = snes_addr!(0:0x4212);
         let value_hvbjoy = 0xFF;
         io.hvbjoy = value_hvbjoy;
 
-        let read_value = io.read(hvbjoy_addr, &mut cpu, &mut ppu, &mut apu);
+        let read_value = io.read(hvbjoy_addr, &mut ppu, &mut apu);
         assert_eq!(read_value, value_hvbjoy);
     }
 
     #[test]
     fn test_joy_autoread_result_register_read() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let joy1l_addr = snes_addr!(0:0x4218);
         let joy1h_addr = snes_addr!(0:0x4219);
@@ -941,22 +932,22 @@ mod tests {
         io.joy3 = value_joy3;
         io.joy4 = value_joy4;
 
-        assert_eq!(io.read(joy1l_addr, &mut cpu, &mut ppu, &mut apu), *value_joy1.lo());
-        assert_eq!(io.read(joy1h_addr, &mut cpu, &mut ppu, &mut apu), *value_joy1.hi());
+        assert_eq!(io.read(joy1l_addr, &mut ppu, &mut apu), *value_joy1.lo());
+        assert_eq!(io.read(joy1h_addr, &mut ppu, &mut apu), *value_joy1.hi());
 
-        assert_eq!(io.read(joy2l_addr, &mut cpu, &mut ppu, &mut apu), *value_joy2.lo());
-        assert_eq!(io.read(joy2h_addr, &mut cpu, &mut ppu, &mut apu), *value_joy2.hi());
+        assert_eq!(io.read(joy2l_addr, &mut ppu, &mut apu), *value_joy2.lo());
+        assert_eq!(io.read(joy2h_addr, &mut ppu, &mut apu), *value_joy2.hi());
 
-        assert_eq!(io.read(joy3l_addr, &mut cpu, &mut ppu, &mut apu), *value_joy3.lo());
-        assert_eq!(io.read(joy3h_addr, &mut cpu, &mut ppu, &mut apu), *value_joy3.hi());
+        assert_eq!(io.read(joy3l_addr, &mut ppu, &mut apu), *value_joy3.lo());
+        assert_eq!(io.read(joy3h_addr, &mut ppu, &mut apu), *value_joy3.hi());
 
-        assert_eq!(io.read(joy4l_addr, &mut cpu, &mut ppu, &mut apu), *value_joy4.lo());
-        assert_eq!(io.read(joy4h_addr, &mut cpu, &mut ppu, &mut apu), *value_joy4.hi());
+        assert_eq!(io.read(joy4l_addr, &mut ppu, &mut apu), *value_joy4.lo());
+        assert_eq!(io.read(joy4h_addr, &mut ppu, &mut apu), *value_joy4.hi());
     }
 
     #[test]
     fn test_register_division_by_zero() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
 
         let wrdivl_addr = snes_addr!(0:0x4204);
         let wrdivh_addr = snes_addr!(0:0x4205);
@@ -969,9 +960,9 @@ mod tests {
         let value_wrdivh = 0x25;
         let value_wrdiv: u16 = 0x2510;
         let value_wrdivb = 0x00;
-        io.write(wrdivl_addr, value_wrdivl, &mut cpu, &mut ppu, &mut apu);
-        io.write(wrdivh_addr, value_wrdivh, &mut cpu, &mut ppu, &mut apu);
-        io.write(wrdivb_addr, value_wrdivb, &mut cpu, &mut ppu, &mut apu);
+        io.write(wrdivl_addr, value_wrdivl, &mut ppu, &mut apu);
+        io.write(wrdivh_addr, value_wrdivh, &mut ppu, &mut apu);
+        io.write(wrdivb_addr, value_wrdivb, &mut ppu, &mut apu);
 
         assert_eq!(*io.wrdiv.lo(), value_wrdivl);
         assert_eq!(*io.wrdiv.hi(), value_wrdivh);
@@ -979,19 +970,19 @@ mod tests {
         assert_eq!(io.rddiv, 0xFFFF);
         assert_eq!(io.rdmpy, value_wrdiv);
 
-        let rdmpyl_value = io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu);
-        let rdmpyh_value = io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu);
+        let rdmpyl_value = io.read(rdmpyl_addr, &mut ppu, &mut apu);
+        let rdmpyh_value = io.read(rdmpyh_addr, &mut ppu, &mut apu);
         assert_eq!(rdmpyl_value, value_wrdivl);
         assert_eq!(rdmpyh_value, value_wrdivh);
-        let rddivl_value = io.read(rddivl_addr, &mut cpu, &mut ppu, &mut apu);
-        let rddivh_value = io.read(rddivh_addr, &mut cpu, &mut ppu, &mut apu);
+        let rddivl_value = io.read(rddivl_addr, &mut ppu, &mut apu);
+        let rddivh_value = io.read(rddivh_addr, &mut ppu, &mut apu);
         assert_eq!(rddivl_value, 0xFF);
         assert_eq!(rddivh_value, 0xFF);
     }
 
     #[test]
     fn test_dma_registers() {
-        let (mut io, mut cpu, mut ppu, mut apu) = init_all();
+        let (mut io, mut ppu, mut apu) = init_all();
         let cpu_open_bus_value = 0xE4;
         io.open_bus = cpu_open_bus_value;
 
@@ -1002,8 +993,8 @@ mod tests {
             for dma_reg in (0x0..=0xF) {
                 let reg_addr = snes_addr!(0:channel_addr.addr + dma_reg);
 
-                io.write(reg_addr, value_inc, &mut cpu, &mut ppu, &mut apu);
-                let read_value = io.read(reg_addr, &mut cpu, &mut ppu, &mut apu);
+                io.write(reg_addr, value_inc, &mut ppu, &mut apu);
+                let read_value = io.read(reg_addr, &mut ppu, &mut apu);
                 match dma_reg {
                     0x0 => {
                         assert_eq!(io.dma_channels[channel_nb as usize].dmap, value_inc);

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -45,7 +45,6 @@ pub struct Io {
     pub dma_channels: [DMAChannel; 8],
 }
 
-#[derive(Copy, Clone)]
 pub struct DMAChannel {
     pub dmap: u8,
 
@@ -63,8 +62,8 @@ pub struct DMAChannel {
     pub unused: u8,
 }
 
-impl DMAChannel {
-    pub fn new() -> Self {
+impl Default for DMAChannel {
+    fn default() -> Self {
         Self {
             dmap: 0xFF,
 
@@ -83,8 +82,8 @@ impl DMAChannel {
     }
 }
 
-impl Io {
-    pub fn new() -> Self {
+impl Default for Io {
+    fn default() -> Self {
         Self {
             nmitimen: 0,
             wrio: 0xFF,
@@ -114,10 +113,12 @@ impl Io {
             joy3: 0,
             joy4: 0,
 
-            dma_channels: [DMAChannel::new(); 8],
+            dma_channels: Default::default(),
         }
     }
+}
 
+impl Io {
     fn panic_invalid_addr(addr: SnesAddress) -> ! {
         panic!(
             "Incorrect access to the IO at address: {:06X}",
@@ -508,7 +509,7 @@ mod tests {
     use common::snes_address::snes_addr;
 
     fn init_all() -> (Io, CPU, PPU, Apu) {
-        let io = Io::new();
+        let io = Io::default();
         let cpu = CPU::poweron();
         let ppu = PPU::new();
         let apu = Apu::new();

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -775,10 +775,8 @@ mod tests {
         assert_eq!(io.wrmpyb, value_wrmpyb);
         assert_eq!(io.rdmpy, (io.wrmpya as u16) * (io.wrmpyb as u16));
 
-        let rdmpyl_value = io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu);
-        let rdmpyh_value = io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(rdmpyl_value, (io.rdmpy as u8));
-        assert_eq!(rdmpyh_value, (io.rdmpy >> 8) as u8);
+        assert_eq!(io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu), *io.rdmpy.lo());
+        assert_eq!(io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu), *io.rdmpy.hi());
     }
 
     #[test]
@@ -806,14 +804,11 @@ mod tests {
         assert_eq!(io.rddiv, value_wrdiv / value_wrdivb as u16);
         assert_eq!(io.rdmpy, value_wrdiv % value_wrdivb as u16);
 
-        let rdmpyl_value = io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu);
-        let rdmpyh_value = io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(rdmpyl_value, (io.rdmpy as u8));
-        assert_eq!(rdmpyh_value, (io.rdmpy >> 8) as u8);
-        let rddivl_value = io.read(rddivl_addr, &mut cpu, &mut ppu, &mut apu);
-        let rddivh_value = io.read(rddivh_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(rddivl_value, (io.rddiv as u8));
-        assert_eq!(rddivh_value, (io.rddiv >> 8) as u8);
+        assert_eq!(io.read(rdmpyl_addr, &mut cpu, &mut ppu, &mut apu), *io.rdmpy.lo());
+        assert_eq!(io.read(rdmpyh_addr, &mut cpu, &mut ppu, &mut apu), *io.rdmpy.hi());
+
+        assert_eq!(io.read(rddivl_addr, &mut cpu, &mut ppu, &mut apu), *io.rddiv.lo());
+        assert_eq!(io.read(rddivh_addr, &mut cpu, &mut ppu, &mut apu), *io.rddiv.hi());
     }
 
     #[test]
@@ -933,22 +928,17 @@ mod tests {
         io.joy3 = value_joy3;
         io.joy4 = value_joy4;
 
-        let joy1l_value = io.read(joy1l_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(joy1l_value, value_joy1 as u8);
-        let joy1h_value = io.read(joy1h_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(joy1h_value, (value_joy1 >> 8) as u8);
-        let joy2l_value = io.read(joy2l_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(joy2l_value, value_joy2 as u8);
-        let joy2h_value = io.read(joy2h_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(joy2h_value, (value_joy2 >> 8) as u8);
-        let joy3l_value = io.read(joy3l_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(joy3l_value, value_joy3 as u8);
-        let joy3h_value = io.read(joy3h_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(joy3h_value, (value_joy3 >> 8) as u8);
-        let joy4l_value = io.read(joy4l_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(joy4l_value, value_joy4 as u8);
-        let joy4h_value = io.read(joy4h_addr, &mut cpu, &mut ppu, &mut apu);
-        assert_eq!(joy4h_value, (value_joy4 >> 8) as u8);
+        assert_eq!(io.read(joy1l_addr, &mut cpu, &mut ppu, &mut apu), *value_joy1.lo());
+        assert_eq!(io.read(joy1h_addr, &mut cpu, &mut ppu, &mut apu), *value_joy1.hi());
+
+        assert_eq!(io.read(joy2l_addr, &mut cpu, &mut ppu, &mut apu), *value_joy2.lo());
+        assert_eq!(io.read(joy2h_addr, &mut cpu, &mut ppu, &mut apu), *value_joy2.hi());
+
+        assert_eq!(io.read(joy3l_addr, &mut cpu, &mut ppu, &mut apu), *value_joy3.lo());
+        assert_eq!(io.read(joy3h_addr, &mut cpu, &mut ppu, &mut apu), *value_joy3.hi());
+
+        assert_eq!(io.read(joy4l_addr, &mut cpu, &mut ppu, &mut apu), *value_joy4.lo());
+        assert_eq!(io.read(joy4h_addr, &mut cpu, &mut ppu, &mut apu), *value_joy4.hi());
     }
 
     #[test]

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -160,6 +160,15 @@ pub struct Io {
     /// DMA/HDMA register banks for all 8 channels (`0x4300–0x437F`).
     /// Channel `n` occupies `0x43n0–0x43nF`.
     pub dma_channels: [DMAChannel; 8],
+
+    /// Internal open bus value, updated on every read and write to the I/O zone.
+    ///
+    /// > On real hardware, reads and writes maintain separate internal buses,
+    /// > and undriven bits decay independently. This is a simplified approximation.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki — Open bus](https://snes.nesdev.org/wiki/Open_bus)
+    pub open_bus: u8,
 }
 
 /// Register state for a single SNES DMA/HDMA channel.
@@ -290,6 +299,8 @@ impl Default for Io {
             joy4: 0,
 
             dma_channels: Default::default(),
+
+            open_bus: 0,
         }
     }
 }
@@ -390,12 +401,12 @@ impl Io {
                     0xA => channel.nltr,
                     0xB | 0xF => channel.unused,
 
-                    _ => cpu.data_bus, // Open bus I believe, but not sure if this is the correct behavior
+                    _ => self.open_bus, // Open bus I believe, but not sure if this is the correct behavior
                 }
             }
 
             // Open Bus
-            _ => cpu.data_bus,
+            _ => self.open_bus,
         }
     }
 
@@ -626,23 +637,24 @@ impl Io {
     /// # Panics
     /// Panics if the address does not map to a valid I/O memory location.
     pub fn read(&mut self, addr: SnesAddress, cpu: &mut CPU, ppu: &mut PPU, apu: &mut Apu) -> u8 {
-        match addr.bank {
+        self.open_bus = match addr.bank {
             0x00..=0x3F | 0x80..=0xBF
                 if addr.addr >= IO_START_ADDRESS && addr.addr < IO_END_ADDRESS =>
             {
                 match addr.addr {
-                    0x2000..0x2100 => cpu.data_bus,
+                    0x2000..0x2100 => self.open_bus,
                     #[cfg(not(tarpaulin_include))]
                     0x2100..0x2140 => self.read_ppu(addr, ppu),
                     0x2140..0x4380 => self.read_cpu(addr, cpu, apu),
-                    0x4380..0x6000 => cpu.data_bus,
+                    0x4380..0x6000 => self.open_bus,
 
                     #[cfg(not(tarpaulin_include))]
                     _ => unreachable!(),
                 }
             }
             _ => Self::panic_invalid_addr(addr),
-        }
+        };
+        self.open_bus
     }
 
     /// Writes a byte to the I/O memory zone at the given `SnesAddress`.
@@ -659,6 +671,7 @@ impl Io {
         ppu: &mut PPU,
         apu: &mut Apu,
     ) {
+        self.open_bus = value;
         match addr.bank {
             0x00..=0x3F | 0x80..=0xBF
                 if addr.addr >= IO_START_ADDRESS && addr.addr < IO_END_ADDRESS =>
@@ -725,12 +738,12 @@ mod tests {
     fn test_read_from_open_bus() {
         let (mut io, mut cpu, mut ppu, mut apu) = init_all();
 
-        cpu.data_bus = 0x20;
+        io.open_bus = 0x20;
         let open_bus_addr = snes_addr!(0:0x5000);
         let read_value = io.read(open_bus_addr, &mut cpu, &mut ppu, &mut apu);
         assert_eq!(read_value, 0x20);
 
-        cpu.data_bus = 0x40;
+        io.open_bus = 0x40;
         let open_bus_addr = snes_addr!(0:0x4250);
         let read_value = io.read(open_bus_addr, &mut cpu, &mut ppu, &mut apu);
         assert_eq!(read_value, 0x40);
@@ -980,7 +993,7 @@ mod tests {
     fn test_dma_registers() {
         let (mut io, mut cpu, mut ppu, mut apu) = init_all();
         let cpu_open_bus_value = 0xE4;
-        cpu.data_bus = cpu_open_bus_value;
+        io.open_bus = cpu_open_bus_value;
 
         let mut value_inc = 0;
         for channel_nb in (0..8) {
@@ -1046,7 +1059,7 @@ mod tests {
                         assert_eq!(io.dma_channels[channel_nb as usize].unused, value_inc);
                         assert_eq!(read_value, value_inc);
                     }
-                    _ => assert_eq!(read_value, cpu_open_bus_value),
+                    _ => assert_eq!(read_value, value_inc),
                 }
 
                 value_inc += 1;

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -177,22 +177,22 @@ impl Io {
             0x4213 => todo!("0x4213 : Implement RDIO register read"),
 
             // Divison result register
-            0x4214 => self.rddiv as u8,
-            0x4215 => (self.rddiv >> 8) as u8,
+            0x4214 => *self.rddiv.lo(),
+            0x4215 => *self.rddiv.hi(),
 
             // Multiplication result / Division remainder register
-            0x4216 => self.rdmpy as u8,
-            0x4217 => (self.rdmpy >> 8) as u8,
+            0x4216 => *self.rdmpy.lo(),
+            0x4217 => *self.rdmpy.hi(),
 
             // Joypad data registers
-            0x4218 => self.joy1 as u8,
-            0x4219 => (self.joy1 >> 8) as u8,
-            0x421A => self.joy2 as u8,
-            0x421B => (self.joy2 >> 8) as u8,
-            0x421C => self.joy3 as u8,
-            0x421D => (self.joy3 >> 8) as u8,
-            0x421E => self.joy4 as u8,
-            0x421F => (self.joy4 >> 8) as u8,
+            0x4218 => *self.joy1.lo(),
+            0x4219 => *self.joy1.hi(),
+            0x421A => *self.joy2.lo(),
+            0x421B => *self.joy2.hi(),
+            0x421C => *self.joy3.lo(),
+            0x421D => *self.joy3.hi(),
+            0x421E => *self.joy4.lo(),
+            0x421F => *self.joy4.hi(),
 
             // DMA and HDMA channel registers
             0x4300..0x4380 => {

--- a/bus/src/io.rs
+++ b/bus/src/io.rs
@@ -4,61 +4,237 @@ use common::{snes_addr, snes_address::SnesAddress, u16_split::U16Split};
 use cpu::cpu::CPU;
 use ppu::ppu::PPU;
 
-/// I/O Registers – 0x4000 bytes (mirrored)
+/// I/O register file of the SNES, mapped to `0x2000–0x5FFF` in banks
+/// `0x00–0x3F` and `0x80–0xBF` (fully mirrored).
 ///
-/// - Memory area for various hardware components (CPU, APU, PPU, etc.).  
-/// - Accessible in banks 0x00–0x3F and 0x80–0xBF, within the address
-///   range 0x2000–0x5FFF.  
-/// - Fully mirrored across all these banks.  
+/// Write-only registers store the last written value; read-only registers are
+/// updated internally by the emulator. Fields spanning two bytes are stored as
+/// `u16` and split on access via [`U16Split`].
 ///
-/// For example, the addresses `0x004000` and `0x9E4000` both refer to the
-/// same memory location.
+/// # Reference
+/// [SNESdev Wiki - MMIO registers](https://snes.nesdev.org/wiki/MMIO_registers)
 pub struct Io {
+    /// **NMITIMEN** (`0x4200`, W) - Enables NMI on V-Blank, H/V IRQ, and
+    /// joypad auto-read. Bit 7 = NMI, bits 5–4 = IRQ mode, bit 0 = auto-read.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - NMITIMEN](https://snes.nesdev.org/wiki/MMIO_registers#NMITIMEN)
     pub nmitimen: u8,
+
+    /// **WRIO** (`0x4201`, W) - Programmable I/O port output. Bit 7 latches
+    /// H/V counters on a 1->0 transition.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - WRIO](https://snes.nesdev.org/wiki/MMIO_registers#WRIO)
     pub wrio: u8,
 
+    /// **WRMPYA** (`0x4202`, W) - Multiplicand for the 8×8 unsigned
+    /// multiplier. Result appears in [`rdmpy`](Self::rdmpy) after writing
+    /// [`wrmpyb`](Self::wrmpyb).
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - WRMPYA](https://snes.nesdev.org/wiki/MMIO_registers#WRMPYA)
     pub wrmpya: u8,
+
+    /// **WRMPYB** (`0x4203`, W) - Multiplier for the 8×8 unsigned multiplier.
+    /// Writing triggers `wrmpya * wrmpyb -> rdmpy`.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - WRMPYB](https://snes.nesdev.org/wiki/MMIO_registers#WRMPYB)
     pub wrmpyb: u8,
 
+    /// **WRDIVL/H** (`0x4204–0x4205`, W) - 16-bit dividend for the 16/8
+    /// unsigned divider (lo/hi). Division is triggered by [`wrdivb`](Self::wrdivb).
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - WRDIV](https://snes.nesdev.org/wiki/MMIO_registers#WRDIV)
     pub wrdiv: u16,
+
+    /// **WRDIVB** (`0x4206`, W) - 8-bit divisor. Writing triggers
+    /// `wrdiv / wrdivb -> rddiv`, remainder `-> rdmpy`.
+    /// Division by zero yields `rddiv = 0xFFFF`, `rdmpy = wrdiv`.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - WRDIVB](https://snes.nesdev.org/wiki/MMIO_registers#WRDIVB)
     pub wrdivb: u8,
 
+    /// **HTIMEL/H** (`0x4207–0x4208`, W) - Horizontal dot position (0–339)
+    /// at which the H/V IRQ fires (low 9 bits).
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - HTIME](https://snes.nesdev.org/wiki/MMIO_registers#HTIME)
     pub htime: u16,
+
+    /// **VTIMEL/H** (`0x4209–0x420A`, W) - Vertical scanline (0–261) at
+    /// which the H/V IRQ fires (low 9 bits).
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - VTIME](https://snes.nesdev.org/wiki/MMIO_registers#VTIME)
     pub vtime: u16,
 
+    /// **MDMAEN** (`0x420B`, W) - General-purpose DMA enable bitmask.
+    /// Each bit enables the corresponding channel (0–7) for an immediate
+    /// transfer, executed lowest-to-highest.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - MDMAEN](https://snes.nesdev.org/wiki/DMA_registers#MDMAEN)
     pub mdmaen: u8,
+
+    /// **HDMAEN** (`0x420C`, W) - HDMA enable bitmask. Each bit enables the
+    /// corresponding channel for per-scanline H-Blank DMA.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - HDMAEN](https://snes.nesdev.org/wiki/DMA_registers#HDMAEN)
     pub hdmaen: u8,
+
+    /// **MEMSEL** (`0x420D`, W) - ROM access speed. Bit 0: `1` = FastROM
+    /// (3.58 MHz), `0` = SlowROM (2.68 MHz) for banks `0x80–0xFF`.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - MEMSEL](https://snes.nesdev.org/wiki/MMIO_registers#MEMSEL)
     pub memsel: u8,
 
+    /// **RDDIVL/H** (`0x4214–0x4215`, R) - Quotient of the last 16/8
+    /// division. Updated when [`wrdivb`](Self::wrdivb) is written.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - RDDIV](https://snes.nesdev.org/wiki/MMIO_registers#RDDIV)
     pub rddiv: u16,
+
+    /// **RDMPYL/H** (`0x4216–0x4217`, R) - After multiplication: 16-bit
+    /// product. After division: 16-bit remainder.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - RDMPY](https://snes.nesdev.org/wiki/MMIO_registers#RDMPY)
     pub rdmpy: u16,
 
+    /// **RDNMI** (`0x4210`, R) - V-Blank NMI flag (bit 7) and CPU version
+    /// (bits 3–0). Bit 7 is set at V-Blank start and cleared on read and/or V-Blank end.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - RDNMI](https://snes.nesdev.org/wiki/MMIO_registers#RDNMI)
     pub rdnmi: u8,
+
+    /// **TIMEUP** (`0x4211`, R) - H/V timer IRQ flag (bit 7). Set when the
+    /// IRQ condition is met, cleared on read.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - TIMEUP](https://snes.nesdev.org/wiki/MMIO_registers#TIMEUP)
     pub timeup: u8,
+
+    /// **HVBJOY** (`0x4212`, R) - Screen/joypad status. Bit 7 = V-Blank,
+    /// bit 6 = H-Blank, bit 0 = joypad auto-read in progress.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - HVBJOY](https://snes.nesdev.org/wiki/MMIO_registers#HVBJOY)
     pub hvbjoy: u8,
 
+    /// **JOY1L/H** (`0x4218–0x4219`, R) - Auto-read result for controller
+    /// port 1. Updated once per frame when auto-read is enabled.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - JOY1](https://snes.nesdev.org/wiki/MMIO_registers#JOY1)
     pub joy1: u16,
+
+    /// **JOY2L/H** (`0x421A–0x421B`, R) - Auto-read result for controller
+    /// port 2. See [`joy1`](Self::joy1).
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - JOY2](https://snes.nesdev.org/wiki/MMIO_registers#JOY2)
     pub joy2: u16,
+
+    /// **JOY3L/H** (`0x421C–0x421D`, R) - Auto-read result for controller
+    /// port 3 (multitap). See [`joy1`](Self::joy1).
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - JOY3](https://snes.nesdev.org/wiki/MMIO_registers#JOY3)
     pub joy3: u16,
+
+    /// **JOY4L/H** (`0x421E–0x421F`, R) - Auto-read result for controller
+    /// port 4 (multitap). See [`joy1`](Self::joy1).
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - JOY4](https://snes.nesdev.org/wiki/MMIO_registers#JOY4)
     pub joy4: u16,
 
+    /// DMA/HDMA register banks for all 8 channels (`0x4300–0x437F`).
+    /// Channel `n` occupies `0x43n0–0x43nF`.
     pub dma_channels: [DMAChannel; 8],
 }
 
+/// Register state for a single SNES DMA/HDMA channel.
+///
+/// Each of the 8 channels occupies a 16-byte window at `0x43n0–0x43nF`.
+/// Channels support two modes: **DMA** (immediate bulk transfer, enabled via
+/// [`Io::mdmaen`]) and **HDMA** (one transfer per scanline, enabled via
+/// [`Io::hdmaen`]). Some registers have different roles depending on the
+/// active mode. All registers default to `0xFF` at power-on.
+///
+/// # Reference
+/// [SNESdev Wiki - DMA registers](https://snes.nesdev.org/wiki/DMA_registers)
 pub struct DMAChannel {
+    /// **DMAPn** (`0x43n0`) - Channel parameters.
+    /// Bit 7 = direction (0: CPU->PPU, 1: PPU->CPU), bit 6 = HDMA indirect
+    /// mode, bits 4–3 = A-bus step (inc/dec/fixed), bits 2–0 = transfer unit
+    /// pattern (1/2/4 bytes).
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - DMAPn](https://snes.nesdev.org/wiki/DMA_registers#DMAPn)
     pub dmap: u8,
 
+    /// **BBADn** (`0x43n1`) - B-bus (PPU) target register offset.
+    /// Effective address: `0x2100 + bbad`.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - BBADn](https://snes.nesdev.org/wiki/DMA_registers#BBADn)
     pub bbad: u8,
 
+    /// **A1TLn/A1THn/A1Bn** (`0x43n2–0x43n4`) - Full 24-bit A-bus source
+    /// address (DMA) or HDMA table start address. Advanced per-byte according
+    /// to the step mode in [`dmap`](Self::dmap).
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - A1Tn](https://snes.nesdev.org/wiki/DMA_registers#A1Tn)
     pub a1t: SnesAddress,
 
+    /// **DASLn/DASHn** (`0x43n5–0x43n6`) - DMA: byte count to transfer
+    /// (`0x0000` = 65 536 bytes). HDMA: low 16 bits of the indirect table
+    /// address when [`dmap`](Self::dmap) bit 6 is set.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - DASn](https://snes.nesdev.org/wiki/DMA_registers#DASn)
     pub das: u16,
+
+    /// **DASBn** (`0x43n7`) - HDMA indirect table bank byte. Forms the upper
+    /// byte of the 24-bit indirect address with [`das`](Self::das).
+    /// Unused in DMA mode.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - DASBn](https://snes.nesdev.org/wiki/DMA_registers#DASBn)
     pub dasb: u8,
 
+    /// **A2ALn/A2AHn** (`0x43n8–0x43n9`) - HDMA current table pointer
+    /// (16-bit offset; bank from [`a1t`](Self::a1t)). Initialized to
+    /// `a1t` each frame and advanced as the table is consumed.
+    /// Unused in DMA mode.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - A2An](https://snes.nesdev.org/wiki/DMA_registers#A2An)
     pub a2a: u16,
 
+    /// **NLTRn** (`0x43nA`) - HDMA line counter. Bits 6–0: remaining
+    /// scanlines for the current entry; bit 7: write-once (`1`) vs.
+    /// every-line (`0`). Unused in DMA mode.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - NLTRn](https://snes.nesdev.org/wiki/DMA_registers#NLTRn)
     pub nltr: u8,
 
+    /// **Unused** (`0x43nB` / `0x43nF`) - No hardware function. Both offsets
+    /// alias this byte; reads return the last written value.
+    ///
+    /// # Reference
+    /// [SNESdev Wiki - UNUSEDn](https://snes.nesdev.org/wiki/DMA_registers#UNUSEDn)
     pub unused: u8,
 }
 

--- a/bus/src/lib.rs
+++ b/bus/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod bus;
 pub mod constants;
 pub mod io;
-pub mod memory_region;
 pub mod rom;
 pub mod wram;
 

--- a/bus/src/memory_region.rs
+++ b/bus/src/memory_region.rs
@@ -1,7 +1,0 @@
-use common::snes_address::SnesAddress;
-
-pub trait MemoryRegion {
-    fn read(&self, addr: SnesAddress) -> u8;
-
-    fn write(&mut self, addr: SnesAddress, value: u8);
-}

--- a/bus/src/rom/mod.rs
+++ b/bus/src/rom/mod.rs
@@ -2,7 +2,6 @@ pub mod error;
 pub mod header;
 pub mod rom;
 
-#[cfg(test)]
-pub(crate) mod test_rom;
+pub mod test_rom;
 
 pub use rom::Rom;

--- a/bus/src/rom/rom.rs
+++ b/bus/src/rom/rom.rs
@@ -1,5 +1,4 @@
 use crate::constants::{BANK_SIZE, COPIER_HEADER_SIZE, LOROM_BANK_SIZE};
-use crate::memory_region::MemoryRegion;
 use crate::rom::error::RomError;
 use crate::rom::header::RomHeader;
 use crate::rom::header::mapping_mode::MappingMode;
@@ -136,14 +135,14 @@ impl Rom {
     }
 }
 
-impl MemoryRegion for Rom {
+impl Rom {
     /// Reads a byte from the ROM at the given `SnesAddress`.
     ///
     /// The address is translated to an internal ROM offset using `to_offset`.
     ///
     /// # Panics
     /// Panics if the mapping mode is `MappingMode::Unknown` or index out of bounds.
-    fn read(&self, addr: SnesAddress) -> u8 {
+    pub fn read(&self, addr: SnesAddress) -> u8 {
         let offset = self.to_offset(addr);
 
         return *self.data.get(offset).expect(&format!(
@@ -155,7 +154,7 @@ impl MemoryRegion for Rom {
     /// Ignores writes to the ROM.
     ///
     /// ROM is read-only; this function performs no action.
-    fn write(&mut self, _addr: SnesAddress, _value: u8) {
+    pub fn write(&mut self, _addr: SnesAddress, _value: u8) {
         // ROM is read-only, ignore writes
         // TODO : Add a warning ?
     }

--- a/bus/src/rom/rom.rs
+++ b/bus/src/rom/rom.rs
@@ -125,8 +125,7 @@ impl Rom {
     /// to compute the correct byte position in the loaded ROM data.
     ///
     /// # Panics
-    /// Panics if the address is invalid for the detected mapping mode,
-    /// or if the mapping mode is [`MappingMode::Unknown`].
+    /// Panics if the address is invalid for the detected mapping mode
     fn to_offset(&self, addr: SnesAddress) -> usize {
         match self.map {
             MappingMode::HiRom => Self::get_hirom_offset(addr),
@@ -141,7 +140,7 @@ impl Rom {
     /// The address is translated to an internal ROM offset using `to_offset`.
     ///
     /// # Panics
-    /// Panics if the mapping mode is `MappingMode::Unknown` or index out of bounds.
+    /// Panics if the index is out of bounds.
     pub fn read(&self, addr: SnesAddress) -> u8 {
         let offset = self.to_offset(addr);
 

--- a/bus/src/rom/test_rom.rs
+++ b/bus/src/rom/test_rom.rs
@@ -9,6 +9,7 @@ use common::u16_split::*;
 use std::io::Write;
 use tempfile::tempdir;
 
+#[cfg(not(tarpaulin_include))]
 pub fn create_valid_header(map: MappingMode) -> Vec<u8> {
     let mut header = vec![0u8; HEADER_SIZE];
 
@@ -43,6 +44,7 @@ pub fn create_valid_header(map: MappingMode) -> Vec<u8> {
     header
 }
 
+#[cfg(not(tarpaulin_include))]
 pub fn create_valid_lorom(size: usize) -> Vec<u8> {
     assert!(size >= LOROM_BANK_SIZE, "ROM must be at least 32KiB");
     let mut rom = vec![0; size];
@@ -53,6 +55,7 @@ pub fn create_valid_lorom(size: usize) -> Vec<u8> {
     rom
 }
 
+#[cfg(not(tarpaulin_include))]
 pub fn create_valid_hirom(size: usize) -> Vec<u8> {
     assert!(size >= HIROM_BANK_SIZE, "ROM must be at least 64KiB");
     let mut rom = vec![0; size];
@@ -63,6 +66,7 @@ pub fn create_valid_hirom(size: usize) -> Vec<u8> {
     rom
 }
 
+#[cfg(not(tarpaulin_include))]
 pub fn create_temp_rom(data: &[u8]) -> (std::path::PathBuf, tempfile::TempDir) {
     let dir = tempdir().unwrap();
     let rom_path = dir.path().join("test_rom.sfc");

--- a/bus/src/rom/test_rom.rs
+++ b/bus/src/rom/test_rom.rs
@@ -9,7 +9,7 @@ use common::u16_split::*;
 use std::io::Write;
 use tempfile::tempdir;
 
-pub(crate) fn create_valid_header(map: MappingMode) -> Vec<u8> {
+pub fn create_valid_header(map: MappingMode) -> Vec<u8> {
     let mut header = vec![0u8; HEADER_SIZE];
 
     let title: &[u8; 21] = b"TEST LOROM           "; // 21 bytes
@@ -43,7 +43,7 @@ pub(crate) fn create_valid_header(map: MappingMode) -> Vec<u8> {
     header
 }
 
-pub(crate) fn create_valid_lorom(size: usize) -> Vec<u8> {
+pub fn create_valid_lorom(size: usize) -> Vec<u8> {
     assert!(size >= LOROM_BANK_SIZE, "ROM must be at least 32KiB");
     let mut rom = vec![0; size];
 
@@ -53,7 +53,7 @@ pub(crate) fn create_valid_lorom(size: usize) -> Vec<u8> {
     rom
 }
 
-pub(crate) fn create_valid_hirom(size: usize) -> Vec<u8> {
+pub fn create_valid_hirom(size: usize) -> Vec<u8> {
     assert!(size >= HIROM_BANK_SIZE, "ROM must be at least 64KiB");
     let mut rom = vec![0; size];
 
@@ -63,7 +63,7 @@ pub(crate) fn create_valid_hirom(size: usize) -> Vec<u8> {
     rom
 }
 
-pub(crate) fn create_temp_rom(data: &[u8]) -> (std::path::PathBuf, tempfile::TempDir) {
+pub fn create_temp_rom(data: &[u8]) -> (std::path::PathBuf, tempfile::TempDir) {
     let dir = tempdir().unwrap();
     let rom_path = dir.path().join("test_rom.sfc");
     let mut f = std::fs::File::create(&rom_path).unwrap();

--- a/bus/src/wram.rs
+++ b/bus/src/wram.rs
@@ -1,5 +1,5 @@
 use crate::constants::WRAM_SIZE;
-use crate::memory_region::MemoryRegion;
+
 use common::snes_address::SnesAddress;
 
 /// WRAM (Work RAM) - 128 KiB (2 full banks)
@@ -47,14 +47,14 @@ impl Wram {
     }
 }
 
-impl MemoryRegion for Wram {
+impl Wram {
     /// Reads a byte from WRAM at the given `SnesAddress`.
     ///
     /// The address is first translated to an internal WRAM offset using `to_offset`.
     ///
     /// # Panics
     /// Panics if the address is invalid or out of bounds.
-    fn read(&self, addr: SnesAddress) -> u8 {
+    pub fn read(&self, addr: SnesAddress) -> u8 {
         let offset = Self::to_offset(addr);
 
         return *self.data.get(offset).expect(&format!(
@@ -69,7 +69,7 @@ impl MemoryRegion for Wram {
     ///
     /// # Panics
     /// Panics if the address is invalid or out of bounds.
-    fn write(&mut self, addr: SnesAddress, value: u8) {
+    pub fn write(&mut self, addr: SnesAddress, value: u8) {
         let offset = Self::to_offset(addr);
         if offset < self.data.len() {
             self.data[offset] = value;

--- a/bus/src/wram.rs
+++ b/bus/src/wram.rs
@@ -13,7 +13,7 @@ use common::snes_address::SnesAddress;
 ///
 /// Warning: bank 0x7F is not mirrored, so `0x7F1000` is independent.
 pub struct Wram {
-    data: Box<[u8; WRAM_SIZE]>,
+    pub data: Box<[u8; WRAM_SIZE]>,
 }
 
 impl Wram {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -15,6 +15,7 @@ pub enum RSnesEvent {
     Quit,
 }
 
+#[cfg(not(tarpaulin_include))]
 impl Gui {
     pub const SNES_WIDTH: usize = 256; // TODO : Remove when GUI linked with PPU
     pub const SNES_HEIGHT: usize = 224; // TODO : Remove when GUI linked with PPU

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -177,3 +177,185 @@ impl RSnes {
         self.master_cycles += 1;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bus::rom::test_rom::*;
+
+    fn make_rsnes() -> RSnes {
+        let rom_data = create_valid_lorom(0x20000);
+        let (rom_path, _dir) = create_temp_rom(&rom_data);
+        RSnes::load_rom(&rom_path).unwrap()
+    }
+
+    fn set_dma_channel(
+        rsnes: &mut RSnes,
+        channel: usize,
+        dmap: u8,
+        src_bank: u8,
+        src_addr: u16,
+        size: u16,
+    ) {
+        let ch = &mut rsnes.bus.io.dma_channels[channel];
+        ch.dmap = dmap;
+        ch.bbad = 0xFF; // 0x21FF: safe no-op destination because useful memory zones not implemented yet
+        ch.a1b = src_bank;
+        ch.a1tl = src_addr as u8;
+        ch.a1th = (src_addr >> 8) as u8;
+        ch.dasl = size as u8;
+        ch.dash = (size >> 8) as u8;
+    }
+
+    #[test]
+    fn test_mdmaen_cleared_after_transfer() {
+        let mut rsnes = make_rsnes();
+        rsnes.bus.io.mdmaen = 0b0000_0001;
+        set_dma_channel(&mut rsnes, 0, 0x00, 0x7E, 0x0000, 1);
+
+        rsnes.dma_transfer();
+
+        assert_eq!(
+            rsnes.bus.io.mdmaen, 0,
+            "mdmaen should be cleared after transfer"
+        );
+    }
+
+    #[test]
+    fn test_only_enabled_channels_run() {
+        let mut rsnes = make_rsnes();
+        rsnes.bus.io.mdmaen = 0b0000_0010;
+
+        set_dma_channel(&mut rsnes, 0, 0x00, 0x7E, 0x0000, 1);
+        set_dma_channel(&mut rsnes, 1, 0x00, 0x7E, 0x0000, 1);
+
+        rsnes.dma_transfer();
+
+        // Channel 0 was not enabled, its source address should not have changed
+        let ch0 = &rsnes.bus.io.dma_channels[0];
+        let ch0_addr = ((ch0.a1th as u16) << 8) | ch0.a1tl as u16;
+        assert_eq!(ch0_addr, 0x0000, "Channel 0 should not have run");
+        assert_eq!(rsnes.bus.io.mdmaen, 0);
+    }
+
+    #[test]
+    fn test_multiple_channels_run() {
+        let mut rsnes = make_rsnes();
+        rsnes.bus.io.mdmaen = 0b0000_0011;
+
+        set_dma_channel(&mut rsnes, 0, 0x00, 0x7E, 0x0000, 2);
+        set_dma_channel(&mut rsnes, 1, 0x00, 0x7E, 0x0100, 3);
+
+        rsnes.dma_transfer();
+
+        let ch0 = &rsnes.bus.io.dma_channels[0];
+        let ch0_addr = ((ch0.a1th as u16) << 8) | ch0.a1tl as u16;
+        assert_eq!(ch0_addr, 0x0002, "Channel 0 should have advanced by 2");
+
+        let ch1 = &rsnes.bus.io.dma_channels[1];
+        let ch1_addr = ((ch1.a1th as u16) << 8) | ch1.a1tl as u16;
+        assert_eq!(ch1_addr, 0x0103, "Channel 1 should have advanced by 3");
+    }
+
+    #[test]
+    fn test_a1t_increments_after_transfer() {
+        let mut rsnes = make_rsnes();
+        rsnes.bus.io.mdmaen = 0b0000_0001;
+        set_dma_channel(&mut rsnes, 0, 0x00, 0x7E, 0x0010, 4);
+
+        rsnes.dma_transfer();
+
+        let ch = &rsnes.bus.io.dma_channels[0];
+        let final_addr = ((ch.a1th as u16) << 8) | ch.a1tl as u16;
+        assert_eq!(
+            final_addr, 0x0014,
+            "Source address should have advanced by 4"
+        );
+    }
+
+    #[test]
+    fn test_a1t_decrements_after_transfer() {
+        let mut rsnes = make_rsnes();
+        rsnes.bus.io.mdmaen = 0b0000_0001;
+        set_dma_channel(&mut rsnes, 0, 0b0010_0000, 0x7E, 0x0010, 4);
+
+        rsnes.dma_transfer();
+
+        let ch = &rsnes.bus.io.dma_channels[0];
+        let final_addr = ((ch.a1th as u16) << 8) | ch.a1tl as u16;
+        assert_eq!(
+            final_addr, 0x000C,
+            "Source address should have decreased by 4"
+        );
+    }
+
+    #[test]
+    fn test_a1t_unchanged_in_fixed_mode() {
+        let mut rsnes = make_rsnes();
+        rsnes.bus.io.mdmaen = 0b0000_0001;
+        // dmap: bit4=1 (fixed address)
+        set_dma_channel(&mut rsnes, 0, 0b0001_0000, 0x7E, 0x0010, 4);
+
+        rsnes.dma_transfer();
+
+        let ch = &rsnes.bus.io.dma_channels[0];
+        let final_addr = ((ch.a1th as u16) << 8) | ch.a1tl as u16;
+        assert_eq!(
+            final_addr, 0x0010,
+            "Source address should not change in fixed mode"
+        );
+    }
+
+    #[test]
+    fn test_das_zeroed_after_transfer() {
+        let mut rsnes = make_rsnes();
+        rsnes.bus.io.mdmaen = 0b0000_0001;
+        set_dma_channel(&mut rsnes, 0, 0x00, 0x7E, 0x0000, 8);
+
+        rsnes.dma_transfer();
+
+        let ch = &rsnes.bus.io.dma_channels[0];
+        assert_eq!(ch.dasl, 0, "dasl should be 0 after transfer");
+        assert_eq!(ch.dash, 0, "dash should be 0 after transfer");
+    }
+
+    /// This test isn't really relevant for now because the destination
+    /// does not really registers the written value from a to b
+    #[test]
+    fn test_wram_source_bytes_are_read() {
+        let mut rsnes = make_rsnes();
+
+        rsnes.bus.wram.data[0x0100] = 0xAB;
+        rsnes.bus.wram.data[0x0101] = 0xCD;
+        rsnes.bus.wram.data[0x0102] = 0xEF;
+
+        rsnes.bus.io.mdmaen = 0b0000_0001;
+        set_dma_channel(&mut rsnes, 0, 0x00, 0x7E, 0x0100, 3);
+
+        rsnes.dma_transfer();
+
+        let ch = &rsnes.bus.io.dma_channels[0];
+        let final_addr = ((ch.a1th as u16) << 8) | ch.a1tl as u16;
+        assert_eq!(final_addr, 0x0103);
+    }
+
+    #[test]
+    fn test_direction_b_to_a_writes_into_wram() {
+        let mut rsnes = make_rsnes();
+
+        // Pre-fill so we can confirm it changed
+        rsnes.bus.wram.data[0x0200] = 0xFF;
+        rsnes.bus.wram.data[0x0201] = 0xFF;
+        rsnes.bus.wram.data[0x0202] = 0xFF;
+        rsnes.bus.io.mdmaen = 0b0000_0001;
+        set_dma_channel(&mut rsnes, 0, 0b1000_0000, 0x7E, 0x0200, 3);
+
+        rsnes.dma_transfer();
+
+        assert_eq!(
+            &rsnes.bus.wram.data[0x0200..=0x0202],
+            &[0x00, 0x00, 0x00],
+            "WRAM should have been overwritten with open bus value 0x00"
+        );
+    }
+}

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -277,7 +277,7 @@ mod tests {
     fn test_a1t_decrements_after_transfer() {
         let mut rsnes = make_rsnes();
         rsnes.bus.io.mdmaen = 0b0000_0001;
-        set_dma_channel(&mut rsnes, 0, 0b0010_0000, 0x7E, 0x0010, 4);
+        set_dma_channel(&mut rsnes, 0, 0b0001_0000, 0x7E, 0x0010, 4);
 
         rsnes.dma_transfer();
 
@@ -293,8 +293,7 @@ mod tests {
     fn test_a1t_unchanged_in_fixed_mode() {
         let mut rsnes = make_rsnes();
         rsnes.bus.io.mdmaen = 0b0000_0001;
-        // dmap: bit4=1 (fixed address)
-        set_dma_channel(&mut rsnes, 0, 0b0001_0000, 0x7E, 0x0010, 4);
+        set_dma_channel(&mut rsnes, 0, 0b0000_1000, 0x7E, 0x0010, 4);
 
         rsnes.dma_transfer();
 

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -182,6 +182,7 @@ impl RSnes {
 mod tests {
     use super::*;
     use bus::rom::test_rom::*;
+    use common::snes_addr;
 
     fn make_rsnes() -> RSnes {
         let rom_data = create_valid_lorom(0x20000);
@@ -356,5 +357,56 @@ mod tests {
             &[0x00, 0x00, 0x00],
             "WRAM should have been overwritten with open bus value 0x00"
         );
+    }
+
+    #[test]
+    fn test_cpu_update_function() {
+        let mut rsnes = make_rsnes();
+
+        let reset_addr = bus::rom::Rom::get_lorom_offset(snes_addr!(0:0xFFFC));
+        rsnes.bus.rom.data[reset_addr] = 0x00;
+        rsnes.bus.rom.data[reset_addr + 1] = 0x80;
+
+        rsnes.bus.rom.data[0] = 0xEA;
+        rsnes.bus.rom.data[1] = 0xA9;
+        rsnes.bus.rom.data[2] = 0x42;
+        rsnes.bus.rom.data[3] = 0x8D;
+        rsnes.bus.rom.data[4] = 0x34;
+        rsnes.bus.rom.data[5] = 0x12;
+
+        rsnes.update();
+        assert_eq!(rsnes.cpu_master_cycles_to_wait, 6);
+        rsnes.cpu_master_cycles_to_wait = 0;
+        rsnes.update();
+        assert_eq!(rsnes.cpu.regs().PC, 0);
+        rsnes.cpu_master_cycles_to_wait = 0;
+
+        // NO-OP
+        rsnes.update();
+        rsnes.cpu_master_cycles_to_wait = 0;
+        assert_eq!(rsnes.cpu.regs().PC, 0x8000);
+        rsnes.update();
+        rsnes.cpu_master_cycles_to_wait = 0;
+
+        // LDA
+        assert_ne!(rsnes.cpu.regs().A, 0x42);
+        rsnes.update();
+        rsnes.cpu_master_cycles_to_wait = 0;
+        rsnes.update();
+        rsnes.cpu_master_cycles_to_wait = 0;
+
+        // STA
+        assert_ne!(rsnes.cpu.data_bus, 0x8D);
+        rsnes.update();
+        rsnes.cpu_master_cycles_to_wait = 0;
+        assert_eq!(rsnes.cpu.data_bus, 0x8D);
+        rsnes.update();
+        rsnes.cpu_master_cycles_to_wait = 0;
+        rsnes.update();
+        rsnes.cpu_master_cycles_to_wait = 0;
+        rsnes.update();
+        rsnes.cpu_master_cycles_to_wait = 0;
+
+        assert_eq!(rsnes.bus.wram.read(snes_addr!(0:0x1234)), 0x42);
     }
 }

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -1,9 +1,9 @@
 use apu::Apu;
 use bus::Bus;
+use common::snes_address::SnesAddress;
 use cpu::cpu::CPU;
 use cpu::cpu::CycleResult;
 use ppu::ppu::PPU;
-
 use std::error::Error;
 use std::path::Path;
 use std::path::PathBuf;
@@ -39,12 +39,107 @@ impl RSnes {
         })
     }
 
+    fn dma_transfer(&mut self) {
+        let mdmaen = self.bus.io.mdmaen;
+
+        for channel_nb in 0..8 {
+            if mdmaen & (1 << channel_nb) == 0 {
+                continue;
+            }
+            self.execute_dma_channel(channel_nb);
+        }
+
+        self.bus.io.mdmaen = 0;
+    }
+
+    fn execute_dma_channel(&mut self, channel_nb: u8) {
+        let ch = self.bus.io.dma_channels[channel_nb as usize];
+
+        // Get transfer parameters from channel DMAP register
+        let direction = (ch.dmap >> 7) & 1;
+        let fixed = (ch.dmap >> 4) & 1;
+        let decrement = (ch.dmap >> 5) & 1;
+        let mode = ch.dmap & 0x07;
+
+        let mut a_addr = SnesAddress {
+            bank: ch.a1b,
+            addr: ((ch.a1th as u16) << 8) | ch.a1tl as u16,
+        };
+
+        // 0x0000 means 65536 bytes, u32 needed to not overflow
+        let mut remaining: u32 = {
+            let raw = ((ch.dash as u16) << 8) | ch.dasl as u16;
+            if raw == 0 { 0x10000 } else { raw as u32 }
+        };
+
+        let b_offsets: &[u8] = match mode {
+            0 => &[0],
+            1 => &[0, 1],
+            2 | 6 => &[0, 0],
+            3 | 7 => &[0, 0, 1, 1],
+            4 => &[0, 1, 2, 3],
+            5 => &[0, 1, 0, 1],
+            _ => unreachable!(),
+        };
+        let mut pattern_idx = 0;
+
+        while remaining > 0 {
+            let b_offset = b_offsets[pattern_idx % b_offsets.len()];
+            let b_addr = SnesAddress {
+                bank: 0x00,
+                addr: 0x2100 | ch.bbad as u16 + b_offset as u16,
+            };
+
+            if direction == 0 {
+                // A-Bus to B-Bus
+                let byte = self
+                    .bus
+                    .read(a_addr, &mut self.cpu, &mut self.ppu, &mut self.apu);
+                self.bus
+                    .write(b_addr, byte, &mut self.cpu, &mut self.ppu, &mut self.apu);
+            } else {
+                // B-Bus to A-Bus
+                let byte = self
+                    .bus
+                    .read(b_addr, &mut self.cpu, &mut self.ppu, &mut self.apu);
+                self.bus
+                    .write(a_addr, byte, &mut self.cpu, &mut self.ppu, &mut self.apu);
+            }
+
+            if fixed == 0 {
+                if decrement == 0 {
+                    a_addr.increment();
+                } else {
+                    a_addr.decrement();
+                }
+            }
+
+            pattern_idx += 1;
+            remaining -= 1;
+
+            // Each byte transferred takes 8 master cycles - ROUGH WAY TO HANDLE IT, TO CHANGE LATER
+            self.cpu_master_cycles_to_wait += 8;
+        }
+
+        // Reset DMA channel registers
+        let ch = &mut self.bus.io.dma_channels[channel_nb as usize];
+        ch.dasl = 0;
+        ch.dash = 0;
+        ch.a1tl = a_addr.addr as u8;
+        ch.a1th = (a_addr.addr >> 8) as u8;
+    }
+
     /// This function will be called every master cycle, it will either decrease the
     /// number of master cycles to wait or execute a cpu cycle
     fn update_cpu_cycles(&mut self) {
         if self.cpu_master_cycles_to_wait > 0 {
             self.cpu_master_cycles_to_wait -= 1;
             return;
+        }
+
+        // Check for DMA start
+        if self.bus.io.mdmaen != 0 {
+            self.dma_transfer();
         }
 
         match self.cpu.cycle() {

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -53,7 +53,9 @@ impl RSnes {
             }
             CycleResult::Read => {
                 let addr = *self.cpu.addr_bus();
-                let byte = self.bus.read(addr);
+                let byte = self
+                    .bus
+                    .read(addr, &mut self.cpu, &mut self.ppu, &mut self.apu);
 
                 self.cpu.data_bus = byte;
 
@@ -64,7 +66,8 @@ impl RSnes {
                 let addr = *self.cpu.addr_bus();
                 let byte = self.cpu.data_bus;
 
-                self.bus.write(addr, byte);
+                self.bus
+                    .write(addr, byte, &mut self.cpu, &mut self.ppu, &mut self.apu);
 
                 // Default to 6 cycles for now
                 self.cpu_master_cycles_to_wait = 6; // TODO : have the bus return the number of cycle to wait

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -57,8 +57,8 @@ impl RSnes {
 
         // Get transfer parameters from channel DMAP register
         let direction = (ch.dmap >> 7) & 1;
-        let fixed = (ch.dmap >> 4) & 1;
-        let decrement = (ch.dmap >> 5) & 1;
+        let fixed = (ch.dmap >> 3) & 1;
+        let decrement = (ch.dmap >> 4) & 1;
         let mode = ch.dmap & 0x07;
 
         let mut a_addr = SnesAddress {

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -62,13 +62,13 @@ impl RSnes {
         let mode = ch.dmap & 0x07;
 
         let mut a_addr = SnesAddress {
-            bank: ch.a1b,
-            addr: ((ch.a1th as u16) << 8) | ch.a1tl as u16,
+            bank: ch.a1t.bank,
+            addr: ch.a1t.addr,
         };
 
         // 0x0000 means 65536 bytes, u32 needed to not overflow
         let mut remaining: u32 = {
-            let raw = ((ch.dash as u16) << 8) | ch.dasl as u16;
+            let raw = ch.das;
             if raw == 0 { 0x10000 } else { raw as u32 }
         };
 
@@ -123,10 +123,8 @@ impl RSnes {
 
         // Reset DMA channel registers
         let ch = &mut self.bus.io.dma_channels[channel_nb as usize];
-        ch.dasl = 0;
-        ch.dash = 0;
-        ch.a1tl = a_addr.addr as u8;
-        ch.a1th = (a_addr.addr >> 8) as u8;
+        ch.das = 0;
+        ch.a1t.addr = a_addr.addr;
     }
 
     /// This function will be called every master cycle, it will either decrease the
@@ -201,11 +199,9 @@ mod tests {
         let ch = &mut rsnes.bus.io.dma_channels[channel];
         ch.dmap = dmap;
         ch.bbad = 0xFF; // 0x21FF: safe no-op destination because useful memory zones not implemented yet
-        ch.a1b = src_bank;
-        ch.a1tl = src_addr as u8;
-        ch.a1th = (src_addr >> 8) as u8;
-        ch.dasl = size as u8;
-        ch.dash = (size >> 8) as u8;
+        ch.a1t.bank = src_bank;
+        ch.a1t.addr = src_addr;
+        ch.das = size;
     }
 
     #[test]
@@ -234,7 +230,7 @@ mod tests {
 
         // Channel 0 was not enabled, its source address should not have changed
         let ch0 = &rsnes.bus.io.dma_channels[0];
-        let ch0_addr = ((ch0.a1th as u16) << 8) | ch0.a1tl as u16;
+        let ch0_addr = ch0.a1t.addr;
         assert_eq!(ch0_addr, 0x0000, "Channel 0 should not have run");
         assert_eq!(rsnes.bus.io.mdmaen, 0);
     }
@@ -250,11 +246,11 @@ mod tests {
         rsnes.dma_transfer();
 
         let ch0 = &rsnes.bus.io.dma_channels[0];
-        let ch0_addr = ((ch0.a1th as u16) << 8) | ch0.a1tl as u16;
+        let ch0_addr = ch0.a1t.addr;
         assert_eq!(ch0_addr, 0x0002, "Channel 0 should have advanced by 2");
 
         let ch1 = &rsnes.bus.io.dma_channels[1];
-        let ch1_addr = ((ch1.a1th as u16) << 8) | ch1.a1tl as u16;
+        let ch1_addr = ch1.a1t.addr;
         assert_eq!(ch1_addr, 0x0103, "Channel 1 should have advanced by 3");
     }
 
@@ -267,7 +263,7 @@ mod tests {
         rsnes.dma_transfer();
 
         let ch = &rsnes.bus.io.dma_channels[0];
-        let final_addr = ((ch.a1th as u16) << 8) | ch.a1tl as u16;
+        let final_addr = ch.a1t.addr;
         assert_eq!(
             final_addr, 0x0014,
             "Source address should have advanced by 4"
@@ -283,7 +279,7 @@ mod tests {
         rsnes.dma_transfer();
 
         let ch = &rsnes.bus.io.dma_channels[0];
-        let final_addr = ((ch.a1th as u16) << 8) | ch.a1tl as u16;
+        let final_addr = ch.a1t.addr;
         assert_eq!(
             final_addr, 0x000C,
             "Source address should have decreased by 4"
@@ -299,7 +295,7 @@ mod tests {
         rsnes.dma_transfer();
 
         let ch = &rsnes.bus.io.dma_channels[0];
-        let final_addr = ((ch.a1th as u16) << 8) | ch.a1tl as u16;
+        let final_addr = ch.a1t.addr;
         assert_eq!(
             final_addr, 0x0010,
             "Source address should not change in fixed mode"
@@ -315,8 +311,7 @@ mod tests {
         rsnes.dma_transfer();
 
         let ch = &rsnes.bus.io.dma_channels[0];
-        assert_eq!(ch.dasl, 0, "dasl should be 0 after transfer");
-        assert_eq!(ch.dash, 0, "dash should be 0 after transfer");
+        assert_eq!(ch.das, 0, "das should be 0 after transfer");
     }
 
     /// This test isn't really relevant for now because the destination
@@ -335,7 +330,7 @@ mod tests {
         rsnes.dma_transfer();
 
         let ch = &rsnes.bus.io.dma_channels[0];
-        let final_addr = ((ch.a1th as u16) << 8) | ch.a1tl as u16;
+        let final_addr = ch.a1t.addr;
         assert_eq!(final_addr, 0x0103);
     }
 

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -53,13 +53,14 @@ impl RSnes {
     }
 
     fn execute_dma_channel(&mut self, channel_nb: u8) {
-        let ch = self.bus.io.dma_channels[channel_nb as usize];
+        let ch = &self.bus.io.dma_channels[channel_nb as usize];
 
         // Get transfer parameters from channel DMAP register
         let direction = (ch.dmap >> 7) & 1;
         let fixed = (ch.dmap >> 3) & 1;
         let decrement = (ch.dmap >> 4) & 1;
         let mode = ch.dmap & 0x07;
+        let ch_b_addr = ch.bbad;
 
         let mut a_addr = SnesAddress {
             bank: ch.a1t.bank,
@@ -87,7 +88,7 @@ impl RSnes {
             let b_offset = b_offsets[pattern_idx % b_offsets.len()];
             let b_addr = SnesAddress {
                 bank: 0x00,
-                addr: 0x2100 | ch.bbad as u16 + b_offset as u16,
+                addr: 0x2100 | ch_b_addr as u16 + b_offset as u16,
             };
 
             if direction == 0 {

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -90,21 +90,16 @@ impl RSnes {
                 addr: 0x2100 | ch_b_addr as u16 + b_offset as u16,
             };
 
-            if direction == 0 {
-                // A-Bus to B-Bus
-                let byte = self
-                    .bus
-                    .read(a_addr, &mut self.cpu, &mut self.ppu, &mut self.apu);
-                self.bus
-                    .write(b_addr, byte, &mut self.cpu, &mut self.ppu, &mut self.apu);
+            let (src, dest) = if direction == 0 {
+                (a_addr, b_addr)
             } else {
-                // B-Bus to A-Bus
-                let byte = self
-                    .bus
-                    .read(b_addr, &mut self.cpu, &mut self.ppu, &mut self.apu);
-                self.bus
-                    .write(a_addr, byte, &mut self.cpu, &mut self.ppu, &mut self.apu);
-            }
+                (b_addr, a_addr)
+            };
+            let byte = self
+                .bus
+                .read(src, &mut self.cpu, &mut self.ppu, &mut self.apu);
+            self.bus
+                .write(dest, byte, &mut self.cpu, &mut self.ppu, &mut self.apu);
 
             if fixed == 0 {
                 if decrement == 0 {

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -62,10 +62,7 @@ impl RSnes {
         let mode = ch.dmap & 0x07;
         let ch_b_addr = ch.bbad;
 
-        let mut a_addr = SnesAddress {
-            bank: ch.a1t.bank,
-            addr: ch.a1t.addr,
-        };
+        let mut a_addr = ch.a1t;
 
         // 0x0000 means 65536 bytes, u32 needed to not overflow
         let mut remaining: u32 = {

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -92,11 +92,8 @@ impl RSnes {
             } else {
                 (b_addr, a_addr)
             };
-            let byte = self
-                .bus
-                .read(src, &mut self.cpu, &mut self.ppu, &mut self.apu);
-            self.bus
-                .write(dest, byte, &mut self.cpu, &mut self.ppu, &mut self.apu);
+            let byte = self.bus.read(src, &mut self.ppu, &mut self.apu);
+            self.bus.write(dest, byte, &mut self.ppu, &mut self.apu);
 
             if fixed == 0 {
                 if decrement == 0 {
@@ -135,9 +132,7 @@ impl RSnes {
             }
             CycleResult::Read => {
                 let addr = *self.cpu.addr_bus();
-                let byte = self
-                    .bus
-                    .read(addr, &mut self.cpu, &mut self.ppu, &mut self.apu);
+                let byte = self.bus.read(addr, &mut self.ppu, &mut self.apu);
 
                 self.cpu.data_bus = byte;
 
@@ -148,8 +143,7 @@ impl RSnes {
                 let addr = *self.cpu.addr_bus();
                 let byte = self.cpu.data_bus;
 
-                self.bus
-                    .write(addr, byte, &mut self.cpu, &mut self.ppu, &mut self.apu);
+                self.bus.write(addr, byte, &mut self.ppu, &mut self.apu);
 
                 // Default to 6 cycles for now
                 self.cpu_master_cycles_to_wait = 6; // TODO : have the bus return the number of cycle to wait

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -82,10 +82,9 @@ impl RSnes {
             5 => &[0, 1, 0, 1],
             _ => unreachable!(),
         };
-        let mut pattern_idx = 0;
 
-        while remaining > 0 {
-            let b_offset = b_offsets[pattern_idx % b_offsets.len()];
+        for pattern_idx in 0..remaining {
+            let b_offset = b_offsets[pattern_idx as usize % b_offsets.len()];
             let b_addr = SnesAddress {
                 bank: 0x00,
                 addr: 0x2100 | ch_b_addr as u16 + b_offset as u16,
@@ -114,9 +113,6 @@ impl RSnes {
                     a_addr.decrement();
                 }
             }
-
-            pattern_idx += 1;
-            remaining -= 1;
 
             // Each byte transferred takes 8 master cycles - ROUGH WAY TO HANDLE IT, TO CHANGE LATER
             self.cpu_master_cycles_to_wait += 8;


### PR DESCRIPTION
## 📝 Description

This pull request adds the handling of the many different registers in the IO memory zone (`0x2000` - `0x6000`). There are still some registers that doesn't do anything and that aren't linked, for example all the ppu registers, the interruption registers (RDNMI, NMITIMEN, ...), the APU registers, and some others. However, each of those are written and have `todo!` labels so we know that they aren't implemented.

The main feature added in this pull request is the DMA that has also been implemented. At the moment it doesn't follow how it works in the console itself. The way I implemented it is that it does all the data transfers, then wait the expected time for the DMA to complete in one go with a manual increase of `Rsnes::cpu_master_cycles_to_wait`.

The ideal way would be for it to work kind of like how the cpu works, when a DMA is enabled, it will handle one byte of data, then wait, then another byte and so on and so on. I did not do it like that for now because I was already struggling with implementing the DMA transfer itself. Now that it works, I will later work on making it work like it does in the console originally.

## 🔍 Related Issues

Closes EpitechPromo2027/G-EIP-600-NAN-6-1-eip-florent.charpentier#38
