### PR TITLE
cpu interrupts

### DIFF
--- a/cpu/src/instrs/instr_tab.rs
+++ b/cpu/src/instrs/instr_tab.rs
@@ -5,6 +5,7 @@ use crate::instrs::{
     arithmetic::*,
     branches::*,
     flags::*,
+    interrupts::*,
     jumps::*,
     loads::*,
     stack::*,
@@ -42,9 +43,9 @@ macro_rules! todo_opcode {
 }
 
 const INSTR_CYC1: [InstrCycle; 256] = [
-    /* 00 */ InstrCycle(todo_opcode!(0x00)),
+    /* 00 */ InstrCycle(brk_cyc1),
     /* 01 */ InstrCycle(ora::dxind_cyc1),
-    /* 02 */ InstrCycle(todo_opcode!(0x02)),
+    /* 02 */ InstrCycle(cop_cyc1),
     /* 03 */ InstrCycle(ora::sr_cyc1),
     /* 04 */ InstrCycle(tsb_d_cyc1),
     /* 05 */ InstrCycle(ora::d_cyc1),
@@ -106,7 +107,7 @@ const INSTR_CYC1: [InstrCycle; 256] = [
     /* 3d */ InstrCycle(and::absx_cyc1),
     /* 3e */ InstrCycle(rol_absx_cyc1),
     /* 3f */ InstrCycle(and::abslx_cyc1),
-    /* 40 */ InstrCycle(todo_opcode!(0x40)),
+    /* 40 */ InstrCycle(rti_cyc1),
     /* 41 */ InstrCycle(eor::dxind_cyc1),
     /* 42 */ InstrCycle(wdm_cyc1),
     /* 43 */ InstrCycle(eor::sr_cyc1),
@@ -261,7 +262,7 @@ const INSTR_CYC1: [InstrCycle; 256] = [
     /* d8 */ InstrCycle(cld_cyc1),
     /* d9 */ InstrCycle(cmp::absy_cyc1),
     /* da */ InstrCycle(phx_cyc1),
-    /* db */ InstrCycle(todo_opcode!(0xdb)),
+    /* db */ InstrCycle(stp_cyc1),
     /* dc */ InstrCycle(jml_cyc1),
     /* dd */ InstrCycle(cmp::absx_cyc1),
     /* de */ InstrCycle(dec_absx_cyc1),

--- a/cpu/src/instrs/interrupts.rs
+++ b/cpu/src/instrs/interrupts.rs
@@ -1,0 +1,67 @@
+use instr_metalang_procmacro::cpu_instr_no_inc_pc;
+use duplicate::duplicate;
+
+cpu_instr_no_inc_pc!(brk {
+    meta FETCH8_IMM; // ignored imm read
+
+    if cpu.registers.E {
+        // skip the PB push if in emu mode
+        return brk_cyc3(cpu);
+    }
+    meta PUSH8 cpu.registers.PB;
+    meta PUSH16 cpu.registers.PC.wrapping_add(2);
+    meta PUSH8 cpu.registers.P.into();
+
+    cpu.registers.P.I = true;
+    cpu.registers.P.D = false;
+
+    let addr = if cpu.registers.E {
+        0xFFFE
+    } else {
+        0xFFE6
+    };
+    cpu.addr_bus = snes_addr!(0:addr);
+    meta FETCH16_INTO cpu.registers.PC;
+    cpu.registers.PB = 0;
+});
+
+cpu_instr_no_inc_pc!(cop {
+    meta FETCH8_IMM; // ignored imm read
+
+    if cpu.registers.E {
+        // skip the PB push if in emu mode
+        return cop_cyc3(cpu);
+    }
+    meta PUSH8 cpu.registers.PB;
+    meta PUSH16 cpu.registers.PC.wrapping_add(2);
+    meta PUSH8 cpu.registers.P.into();
+
+    cpu.registers.P.I = true;
+    cpu.registers.P.D = false;
+
+    let addr = if cpu.registers.E {
+        0xFFF4
+    } else {
+        0xFFE4
+    };
+    cpu.addr_bus = snes_addr!(0:addr);
+    meta FETCH16_INTO cpu.registers.PC;
+    cpu.registers.PB = 0;
+});
+
+cpu_instr_no_inc_pc!(rti {
+    meta END_CYCLE Internal;
+    meta END_CYCLE Internal;
+
+    meta PULL8;
+    cpu.registers.P = cpu.data_bus.into();
+
+    meta PULL16_INTO cpu.registers.PC;
+
+    // emu mode doesn't pull PB, goes straight to opcode fetch
+    if cpu.registers.E {
+        return opcode_fetch(cpu);
+    }
+
+    meta PULL8_INTO cpu.registers.PB;
+});

--- a/cpu/src/instrs/interrupts.rs
+++ b/cpu/src/instrs/interrupts.rs
@@ -1,53 +1,36 @@
 use instr_metalang_procmacro::cpu_instr_no_inc_pc;
 use duplicate::duplicate;
 
-cpu_instr_no_inc_pc!(brk {
-    meta FETCH8_IMM; // ignored imm read
+duplicate! {
+    [
+        DUP_name    DUP_cyc3    DUP_emu_vec     DUP_nat_vec;
+        [brk]       [brk_cyc3]  [0xFFFE]        [0xFFE6];
+        [cop]       [cop_cyc3]  [0xFFF4]        [0xFFE4];
+    ]
+    cpu_instr_no_inc_pc!(DUP_name {
+        meta FETCH8_IMM; // ignored imm read
 
-    if cpu.registers.E {
-        // skip the PB push if in emu mode
-        return brk_cyc3(cpu);
-    }
-    meta PUSH8 cpu.registers.PB;
-    meta PUSH16 cpu.registers.PC.wrapping_add(2);
-    meta PUSH8 cpu.registers.P.into();
+        if cpu.registers.E {
+            // skip the PB push if in emu mode
+            return DUP_cyc3(cpu);
+        }
+        meta PUSH8 cpu.registers.PB;
+        meta PUSH16 cpu.registers.PC.wrapping_add(2);
+        meta PUSH8 cpu.registers.P.into();
 
-    cpu.registers.P.I = true;
-    cpu.registers.P.D = false;
+        cpu.registers.P.I = true;
+        cpu.registers.P.D = false;
 
-    let addr = if cpu.registers.E {
-        0xFFFE
-    } else {
-        0xFFE6
-    };
-    cpu.addr_bus = snes_addr!(0:addr);
-    meta FETCH16_INTO cpu.registers.PC;
-    cpu.registers.PB = 0;
-});
-
-cpu_instr_no_inc_pc!(cop {
-    meta FETCH8_IMM; // ignored imm read
-
-    if cpu.registers.E {
-        // skip the PB push if in emu mode
-        return cop_cyc3(cpu);
-    }
-    meta PUSH8 cpu.registers.PB;
-    meta PUSH16 cpu.registers.PC.wrapping_add(2);
-    meta PUSH8 cpu.registers.P.into();
-
-    cpu.registers.P.I = true;
-    cpu.registers.P.D = false;
-
-    let addr = if cpu.registers.E {
-        0xFFF4
-    } else {
-        0xFFE4
-    };
-    cpu.addr_bus = snes_addr!(0:addr);
-    meta FETCH16_INTO cpu.registers.PC;
-    cpu.registers.PB = 0;
-});
+        let addr = if cpu.registers.E {
+            DUP_emu_vec
+        } else {
+            DUP_nat_vec
+        };
+        cpu.addr_bus = snes_addr!(0:addr);
+        meta FETCH16_INTO cpu.registers.PC;
+        cpu.registers.PB = 0;
+    });
+}
 
 cpu_instr_no_inc_pc!(rti {
     meta END_CYCLE Internal;

--- a/cpu/src/instrs/interrupts.rs
+++ b/cpu/src/instrs/interrupts.rs
@@ -199,4 +199,95 @@ mod test {
         expected_regs.P.I = true;
         assert_eq!(*cpu.regs(), expected_regs);
     }
+
+    #[test]
+    fn rti_emu() {
+        let mut regs = Registers::default();
+        regs.PB = 0; // interrupt code will usually be in bank 0
+        regs.PC = 0x3456;
+        regs.S = 0x0180;
+        regs.E = true;
+
+        let mut expected_regs = regs.clone();
+
+        let mut cpu = CPU::new(regs);
+
+        expect_opcode_fetch(&mut cpu, 0x40);
+        expect_internal_cycle(&mut cpu, "idle 1");
+        expect_internal_cycle(&mut cpu, "idle 2");
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0x0181),
+            0b11001100,
+            "pull P",
+        );
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0x0182),
+            0x77,
+            "pull PCL",
+        );
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0x0183),
+            0x88,
+            "pull PCH",
+        );
+
+        expect_opcode_fetch_cycle(&mut cpu);
+
+        expected_regs.S = 0x0183;
+        expected_regs.PC = 0x8877;
+        expected_regs.P = 0b11001100.into();
+        assert_eq!(*cpu.regs(), expected_regs);
+    }
+
+    #[test]
+    fn rti_nat() {
+        let mut regs = Registers::default();
+        regs.PB = 0; // interrupt code will usually be in bank 0
+        regs.PC = 0x3456;
+        regs.S = 0x0180;
+        regs.E = false;
+
+        let mut expected_regs = regs.clone();
+
+        let mut cpu = CPU::new(regs);
+
+        expect_opcode_fetch(&mut cpu, 0x40);
+        expect_internal_cycle(&mut cpu, "idle 1");
+        expect_internal_cycle(&mut cpu, "idle 2");
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0x0181),
+            0b11001100,
+            "pull P",
+        );
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0x0182),
+            0x77,
+            "pull PCL",
+        );
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0x0183),
+            0x88,
+            "pull PCH",
+        );
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0x0184),
+            0x99,
+            "pull PB",
+        );
+
+        expect_opcode_fetch_cycle(&mut cpu);
+
+        expected_regs.S = 0x0184;
+        expected_regs.PB = 0x99;
+        expected_regs.PC = 0x8877;
+        expected_regs.P = 0b11001100.into();
+        assert_eq!(*cpu.regs(), expected_regs);
+    }
 }

--- a/cpu/src/instrs/interrupts.rs
+++ b/cpu/src/instrs/interrupts.rs
@@ -65,3 +65,138 @@ cpu_instr_no_inc_pc!(rti {
 
     meta PULL8_INTO cpu.registers.PB;
 });
+
+#[cfg(test)]
+mod test {
+    use super::super::test_prelude::*;
+
+    #[test]
+    fn brk_emu() {
+        let mut regs = Registers::default();
+        regs.PB = 0x12;
+        regs.PC = 0x3456;
+        regs.S = 0x0180;
+        regs.P = 0b10101010.into();
+        regs.E = true;
+
+        let mut expected_regs = regs.clone();
+
+        let mut cpu = CPU::new(regs);
+
+        expect_opcode_fetch(&mut cpu, 0x00);
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0x12:0x3457),
+            0x33,
+            "signature byte (ignored)",
+        );
+        expect_write_cycle(
+            &mut cpu,
+            snes_addr!(0:0x0180),
+            0x34,
+            "PCH",
+        );
+        expect_write_cycle(
+            &mut cpu,
+            snes_addr!(0:0x017f),
+            0x56 + 2, // pushes PC + 2
+            "PCL",
+        );
+        expect_write_cycle(
+            &mut cpu,
+            snes_addr!(0:0x017e),
+            0b10101010,
+            "P",
+        );
+
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0xFFFE),
+            0x66,
+            "interrupt routine addr low",
+        );
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0xFFFF),
+            0x33,
+            "interrupt routine addr hi",
+        );
+
+        expect_opcode_fetch_cycle(&mut cpu);
+
+        expected_regs.PC = 0x3366;
+        expected_regs.PB = 0;
+        expected_regs.S = 0x017d;
+        expected_regs.P.D = false;
+        expected_regs.P.I = true;
+        assert_eq!(*cpu.regs(), expected_regs);
+    }
+
+    #[test]
+    fn brk_nat() {
+        let mut regs = Registers::default();
+        regs.PB = 0x12;
+        regs.PC = 0x3456;
+        regs.S = 0x0180;
+        regs.P = 0b10101010.into();
+        regs.E = false;
+
+        let mut expected_regs = regs.clone();
+
+        let mut cpu = CPU::new(regs);
+
+        expect_opcode_fetch(&mut cpu, 0x00);
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0x12:0x3457),
+            0x33,
+            "signature byte (ignored)",
+        );
+        expect_write_cycle(
+            &mut cpu,
+            snes_addr!(0:0x0180),
+            0x12,
+            "PB",
+        );
+        expect_write_cycle(
+            &mut cpu,
+            snes_addr!(0:0x017f),
+            0x34,
+            "PCH",
+        );
+        expect_write_cycle(
+            &mut cpu,
+            snes_addr!(0:0x017e),
+            0x56 + 2, // pushes PC + 2
+            "PCL",
+        );
+        expect_write_cycle(
+            &mut cpu,
+            snes_addr!(0:0x017d),
+            0b10101010,
+            "P",
+        );
+
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0xFFE6),
+            0x66,
+            "interrupt routine addr low",
+        );
+        expect_read_cycle(
+            &mut cpu,
+            snes_addr!(0:0xFFE7),
+            0x33,
+            "interrupt routine addr hi",
+        );
+
+        expect_opcode_fetch_cycle(&mut cpu);
+
+        expected_regs.PC = 0x3366;
+        expected_regs.PB = 0;
+        expected_regs.S = 0x017c;
+        expected_regs.P.D = false;
+        expected_regs.P.I = true;
+        assert_eq!(*cpu.regs(), expected_regs);
+    }
+}

--- a/cpu/src/instrs/mod.rs
+++ b/cpu/src/instrs/mod.rs
@@ -9,6 +9,7 @@ mod algorithms;
 
 mod branches;
 mod flags;
+mod interrupts;
 mod jumps;
 mod loads;
 mod stores;

--- a/cpu/src/instrs/uncategorised.rs
+++ b/cpu/src/instrs/uncategorised.rs
@@ -141,6 +141,10 @@ duplicate! {
     });
 }
 
+cpu_instr_no_inc_pc!(stp {
+    meta END_CYCLE Internal;
+});
+
 #[cfg(test)]
 mod tests {
     use crate::instrs::test_prelude::*;

--- a/cpu/src/instrs/uncategorised.rs
+++ b/cpu/src/instrs/uncategorised.rs
@@ -141,9 +141,15 @@ duplicate! {
     });
 }
 
-cpu_instr_no_inc_pc!(stp {
-    meta END_CYCLE Internal;
-});
+pub(crate) use stp::*;
+mod stp {
+    use crate::instrs::prelude::*;
+
+    pub(crate) fn stp_cyc1(_: &mut CPU) -> (CycleResult, InstrCycle) {
+        // just return internal cycles indefinitely
+        (Internal, InstrCycle(stp_cyc1))
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -450,5 +456,20 @@ mod tests {
         expected_regs.Y = 1;
 
         assert_eq!(*cpu.regs(), expected_regs);
+    }
+
+    #[test]
+    fn stp_spin_loops() {
+        let mut regs = Registers::default();
+        regs.PB = 0x12;
+        regs.PC = 0x3456;
+
+        let mut cpu = CPU::new(regs);
+
+        expect_opcode_fetch(&mut cpu, 0xdb);
+
+        for _ in 0..100 {
+            expect_internal_cycle(&mut cpu, "spin loop");
+        }
     }
 }


### PR DESCRIPTION
## 📝 Description

Implements all software interrupts required to reach the end of the test ROM

Implementation is a bit rough, it relies on the intermediate format produced by the metalang (which is something I try to avoid, to make it easier in case I want to change this intermediate representation, but for now it works, we'll see if/when ever I want to change it)

