### PR TITLE
Group related PPU registers

### DIFF
--- a/ppu/src/cgram.rs
+++ b/ppu/src/cgram.rs
@@ -22,17 +22,17 @@ impl CGRAM {
     // $2121 - CGADD
     // ============================================================
 
-    pub fn write_addr(&mut self, PPURegisters { cgdata_latch, .. }: &mut PPURegisters, value: u8) {
+    pub fn write_addr(&mut self, PPURegisters { cgram_latch, .. }: &mut PPURegisters, value: u8) {
         self.word_addr = value;
-        cgdata_latch.reset();
+        cgram_latch.reset();
     }
 
     // ============================================================
     // $2122 - CGDATA (Write-twice)
     // ============================================================
 
-    pub fn write_data(&mut self, PPURegisters { cgdata_latch, .. }: &mut PPURegisters, value: u8) {
-        if let Some((lo, hi)) = cgdata_latch.write(value) {
+    pub fn write_data(&mut self, PPURegisters { cgram_latch, .. }: &mut PPURegisters, value: u8) {
+        if let Some((lo, hi)) = cgram_latch.write(value) {
             let word = &mut self.memory[self.word_addr as usize];
             *word.lo_mut() = lo;
             *word.hi_mut() = hi & 0x7F;
@@ -45,17 +45,17 @@ impl CGRAM {
     // $213B - CGDATAREAD
     // ============================================================
 
-    pub fn read_data(&mut self, PPURegisters { cgdata_latch, .. }: &mut PPURegisters) -> u8 {
+    pub fn read_data(&mut self, PPURegisters { cgram_latch, .. }: &mut PPURegisters) -> u8 {
         let word = self.memory[self.word_addr as usize];
-        let value = match cgdata_latch.phase {
+        let value = match cgram_latch.phase {
             BytePhase::Low  => *word.lo(),
             BytePhase::High => *word.hi() | (self.ppu_open_bus & 0x80),
         };
 
-        if cgdata_latch.phase.is_high() {
+        if cgram_latch.phase.is_high() {
             self.word_addr = self.word_addr.wrapping_add(1);
         }
-        cgdata_latch.phase.flip();
+        cgram_latch.phase.flip();
         self.ppu_open_bus = value;
         value
     }
@@ -85,9 +85,8 @@ mod tests {
     // ============================================================
     // CGRAM::new
     // ============================================================
-    
-    /// A freshly created CGRAM must have all memory zeroed, word_addr at 0,
-    /// byte_phase at Low, and open bus at 0.
+
+    /// A freshly created CGRAM must have all memory zeroed and open bus at 0.
     #[test]
     fn test_new_zeroed() {
         let cgram = CGRAM::new();
@@ -99,94 +98,60 @@ mod tests {
     // write_addr ($2121)
     // ============================================================
 
-    /// write_addr must set the word address and reset byte_phase to Low.
+    /// write_addr sets the word address and resets the byte phase to Low,
+    /// so the next write pair targets the new address.
     #[test]
-    fn test_write_addr_sets_word_address() {
+    fn test_write_addr() {
         let mut cgram = CGRAM::new();
         let mut regs = make_regs();
-        // Put cgram in High phase first
-        cgram.write_data(&mut regs, 0x10);
-        cgram.write_addr(&mut regs, 0x42);
-        // Only observable side-effect: next write goes to word 0x42 (&mut regs, low byte)
-        cgram.write_data(&mut regs, 0xAB);
-        cgram.write_data(&mut regs, 0x3F);
-        assert_eq!(cgram.memory[0x42], 0x3FAB);
-    }
 
-    /// write_addr must reset byte_phase to Low even if previously in High phase.
-    #[test]
-    fn test_write_addr_resets_phase_to_low() {
-        let mut cgram = CGRAM::new();
-        let mut regs = make_regs();
+        // Advance phase to High, then reset via write_addr
         cgram.write_data(&mut regs, 0xFF); // phase -> High
-        cgram.write_addr(&mut regs, 0x00); // must reset to Low
-        // Writing one byte should only latch (Low phase), not commit
+        cgram.write_addr(&mut regs, 0x42); // must reset to Low
+
+        // One write in Low phase should not commit
         cgram.write_data(&mut regs, 0xBB);
-        assert_eq!(cgram.memory[0x00], 0x0000); // nothing committed yet
+        assert_eq!(cgram.memory[0x42], 0x0000);
+
+        // Second write commits the pair to word 0x42
+        cgram.write_data(&mut regs, 0x3F);
+        assert_eq!(cgram.memory[0x42], 0x3FBB);
     }
 
     // ============================================================
     // write_data ($2122)
     // ============================================================
 
-    /// First write (Low phase) must latch the byte without touching memory.
+    /// write_data latches on the first write (Low phase) without touching memory,
+    /// then commits lo+hi on the second write (High phase), masking bit 7 of hi.
+    /// After commit, word_addr increments. ppu_open_bus is updated on every write.
     #[test]
-    fn test_write_data_low_phase_only_latches() {
+    fn test_write_data() {
         let mut cgram = CGRAM::new();
         let mut regs = make_regs();
+
+        // Low phase: no commit
         cgram.write_data(&mut regs, 0xAB);
         assert_eq!(cgram.memory[0x00], 0x0000);
-    }
+        assert_eq!(cgram.ppu_open_bus, 0xAB);
 
-    /// Second write (High phase) must commit lo+hi to the current word, masking bit 7 of hi.
-    #[test]
-    fn test_write_data_low_then_high_commits_word() {
-        let mut cgram = CGRAM::new();
-        let mut regs = make_regs();
-        cgram.write_data(&mut regs, 0xCD); // lo latch
-        cgram.write_data(&mut regs, 0xFF); // hi write - bit 7 masked -> 0x7F
-        assert_eq!(cgram.memory[0x00], 0x7FCD);
-    }
+        // High phase: commit with bit 7 of hi masked
+        cgram.write_data(&mut regs, 0xFF);
+        assert_eq!(cgram.memory[0x00], 0x7FAB);
+        assert_eq!(cgram.ppu_open_bus, 0xFF);
 
-    /// After a complete low+high write, word_addr must increment by 1.
-    #[test]
-    fn test_write_data_increments_word_addr_after_high() {
-        let mut cgram = CGRAM::new();
-        let mut regs = make_regs();
-        cgram.write_data(&mut regs, 0x11);
-        cgram.write_data(&mut regs, 0x22);
-        // Next pair goes to word 0x01
+        // addr incremented: next pair goes to word 0x01
         cgram.write_data(&mut regs, 0x33);
         cgram.write_data(&mut regs, 0x44);
         assert_eq!(cgram.memory[0x01], 0x4433);
     }
 
-    /// High byte bit 7 must always be masked to 0 on write (CGRAM stores 15-bit colours).
-    #[test]
-    fn test_write_high_byte_masks_bit7() {
-        let mut cgram = CGRAM::new();
-        let mut regs = make_regs();
-        cgram.write_data(&mut regs, 0x00);
-        cgram.write_data(&mut regs, 0xFF); // bit 7 must be stripped -> 0x7F
-        assert_eq!((cgram.memory[0x00] >> 8) as u8, 0x7F);
-    }
-
-    /// write_data must update ppu_open_bus with the written value on every write.
-    #[test]
-    fn test_write_data_updates_open_bus() {
-        let mut cgram = CGRAM::new();
-        let mut regs = make_regs();
-        cgram.write_data(&mut regs, 0xAB);
-        assert_eq!(cgram.ppu_open_bus, 0xAB);
-        cgram.write_data(&mut regs, 0x3C);
-        assert_eq!(cgram.ppu_open_bus, 0x3C);
-    }
-
-    /// word_addr must wrap from 0xFF back to 0x00 after a complete write at address 0xFF.
+    /// word_addr must wrap from 0xFF to 0x00 after a complete write at address 0xFF.
     #[test]
     fn test_write_data_word_addr_wraps() {
         let mut cgram = CGRAM::new();
         let mut regs = make_regs();
+
         cgram.write_addr(&mut regs, 0xFF);
         cgram.write_data(&mut regs, 0x12);
         cgram.write_data(&mut regs, 0x34);
@@ -198,11 +163,12 @@ mod tests {
 
     /// Sequential writes across multiple words must not corrupt adjacent entries.
     #[test]
-    fn test_sequential_write_multiple_words() {
+    fn test_write_data_sequential_words() {
         let mut cgram = CGRAM::new();
         let mut regs = make_regs();
+
         for i in 0u8..4 {
-            cgram.write_data(&mut regs, i);        // lo
+            cgram.write_data(&mut regs, i); // lo
             cgram.write_data(&mut regs, i + 0x10); // hi (bit 7 clear, no masking effect)
         }
         assert_eq!(cgram.memory[0x00], 0x1000);
@@ -215,76 +181,43 @@ mod tests {
     // read_data ($213B)
     // ============================================================
 
-    /// Reading in Low phase must return the low byte of the current word.
+    /// Low phase returns the lo byte; High phase returns hi OR'd with open-bus bit 7.
+    /// word_addr increments only after the High phase read.
+    /// ppu_open_bus is updated with the returned value on every read.
     #[test]
-    fn test_read_data_low_phase_returns_lo_byte() {
+    fn test_read_data() {
         let mut cgram = CGRAM::new();
         let mut regs = make_regs();
         cgram.memory[0x00] = 0x1234;
-        let val = cgram.read_data(&mut regs, );
-        assert_eq!(val, 0x34);
-    }
+        cgram.memory[0x01] = 0x2222;
 
-    /// Reading in High phase must return hi byte OR'd with open-bus bit 7.
-    #[test]
-    fn test_read_data_high_phase_returns_hi_with_open_bus_bit7() {
-        let mut cgram = CGRAM::new();
-        let mut regs = make_regs();
-        cgram.memory[0x00] = 0x1234;
-        let _lo = cgram.read_data(&mut regs, ); // Low phase - ppu_open_bus becomes 0x34
-        // Simulate open bus bit 7 being set by a previous PPU operation
+        // Low phase: returns lo byte, open bus updated, addr stays
+        let lo = cgram.read_data(&mut regs);
+        assert_eq!(lo, 0x34);
+        assert_eq!(cgram.ppu_open_bus, 0x34);
+
+        // Force open bus bit 7 before high read
         cgram.ppu_open_bus = 0x80;
-        let hi = cgram.read_data(&mut regs, ); // High phase
+        let hi = cgram.read_data(&mut regs);
         // hi byte of 0x1234 = 0x12; open bus bit7 = 0x80 -> 0x12 | 0x80 = 0x92
         assert_eq!(hi, 0x92);
+
+        // addr incremented to 0x01 after High phase
+        let lo1 = cgram.read_data(&mut regs);
+        assert_eq!(lo1, 0x22);
     }
 
     /// Bit 7 of the high-byte read must come from open bus, not from CGRAM data.
     #[test]
-    fn test_open_bus_bit7_on_high_read() {
+    fn test_read_data_open_bus_bit7() {
         let mut cgram = CGRAM::new();
         let mut regs = make_regs();
         cgram.memory[0x00] = 0x7F00; // hi = 0x7F (bit 7 clear in CGRAM)
-        let _lo = cgram.read_data(&mut regs, ); // Low phase - ppu_open_bus becomes 0x00
-        // Force open bus bit 7 before the high read
-        cgram.ppu_open_bus = 0x80;
-        let hi = cgram.read_data(&mut regs, );
-        assert_eq!(hi & 0x80, 0x80); // bit 7 must come from open bus
-    }
 
-    /// After a complete low+high read, word_addr must increment by 1.
-    #[test]
-    fn test_read_data_increments_word_addr_after_high_phase() {
-        let mut cgram = CGRAM::new();
-        let mut regs = make_regs();
-        cgram.memory[0x00] = 0x1111;
-        cgram.memory[0x01] = 0x2222;
-        let _lo0 = cgram.read_data(&mut regs, ); // Low  @ 0x00
-        let _hi0 = cgram.read_data(&mut regs, ); // High @ 0x00 -> addr increments to 0x01
-        let lo1 = cgram.read_data(&mut regs, );  // Low  @ 0x01
-        assert_eq!(lo1, 0x22);
-    }
-
-    /// read_data must NOT increment word_addr after the Low phase read.
-    #[test]
-    fn test_read_data_no_increment_after_low_phase() {
-        let mut cgram = CGRAM::new();
-        let mut regs = make_regs();
-        cgram.memory[0x00] = 0xABCD;
-        let _lo = cgram.read_data(&mut regs, ); // Low phase - addr must stay at 0x00
-        // High phase read should still be from word 0x00
-        let hi = cgram.read_data(&mut regs, );
-        assert_eq!(hi & 0x7F, 0xAB & 0x7F);
-    }
-
-    /// read_data must update ppu_open_bus with the returned value.
-    #[test]
-    fn test_read_data_updates_open_bus() {
-        let mut cgram = CGRAM::new();
-        let mut regs = make_regs();
-        cgram.memory[0x00] = 0x1234;
-        let lo = cgram.read_data(&mut regs, );
-        assert_eq!(cgram.ppu_open_bus, lo);
+        let _lo = cgram.read_data(&mut regs); // Low phase - ppu_open_bus = 0x00
+        cgram.ppu_open_bus = 0x80; // force open bus bit 7
+        let hi = cgram.read_data(&mut regs);
+        assert_eq!(hi & 0x80, 0x80);
     }
 
     /// word_addr must wrap from 0xFF to 0x00 after a complete read at address 0xFF.
@@ -295,9 +228,10 @@ mod tests {
         cgram.write_addr(&mut regs, 0xFF);
         cgram.memory[0xFF] = 0x1234;
         cgram.memory[0x00] = 0x5678;
-        let _lo = cgram.read_data(&mut regs, );
-        let _hi = cgram.read_data(&mut regs, ); // addr wraps to 0x00
-        let lo_next = cgram.read_data(&mut regs, );
+
+        let _lo = cgram.read_data(&mut regs);
+        let _hi = cgram.read_data(&mut regs); // addr wraps to 0x00
+        let lo_next = cgram.read_data(&mut regs);
         assert_eq!(lo_next, 0x78);
     }
 
@@ -305,23 +239,18 @@ mod tests {
     // read helper
     // ============================================================
 
-    /// read() must return the raw 16-bit word at the given index without side effects.
+    /// read() returns the raw 16-bit word at the given index with no side effects
+    /// on word_addr, byte_phase, or open_bus.
     #[test]
-    fn test_read_helper_returns_raw_word() {
-        let mut cgram = CGRAM::new();
-        cgram.memory[0x10] = 0xBEEF;
-        assert_eq!(cgram.read(0x10), 0xBEEF);
-    }
-
-    /// read() must not modify word_addr, byte_phase, or open_bus.
-    #[test]
-    fn test_read_helper_has_no_side_effects() {
+    fn test_read_helper() {
         let mut cgram = CGRAM::new();
         let mut regs = make_regs();
-        cgram.memory[0x05] = 0x1234;
+        cgram.memory[0x10] = 0xBEEF;
+        assert_eq!(cgram.read(0x10), 0xBEEF);
+
+        // No side effects: subsequent write pair still targets the address set by write_addr
         cgram.write_addr(&mut regs, 0x05);
         let _ = cgram.read(0x05);
-        // If read() had side effects, the subsequent write_data sequence would go wrong
         cgram.write_data(&mut regs, 0xAB);
         cgram.write_data(&mut regs, 0x3F);
         assert_eq!(cgram.memory[0x05], 0x3FAB);
@@ -336,14 +265,14 @@ mod tests {
     fn test_round_trip_write_then_read() {
         let mut cgram = CGRAM::new();
         let mut regs = make_regs();
-        cgram.write_addr(&mut regs, 0x20);
-        cgram.write_data(&mut regs, 0x56); // lo
-        cgram.write_data(&mut regs, 0x3A); // hi (bit 7 clear)
 
         cgram.write_addr(&mut regs, 0x20);
-        let lo = cgram.read_data(&mut regs, );
-        let hi = cgram.read_data(&mut regs, );
+        cgram.write_data(&mut regs, 0x56);
+        cgram.write_data(&mut regs, 0x3A); // bit 7 clear
 
+        cgram.write_addr(&mut regs, 0x20);
+        let lo = cgram.read_data(&mut regs);
+        let hi = cgram.read_data(&mut regs);
         assert_eq!(lo, 0x56);
         assert_eq!(hi & 0x7F, 0x3A);
     }

--- a/ppu/src/ppu.rs
+++ b/ppu/src/ppu.rs
@@ -37,8 +37,8 @@ impl PPU {
             // OAM
             // ==========================
             0x2101 => self.regs.objsel = value, // TODO
-            0x2102 => self.regs.oamaddl = value, // TODO
-            0x2103 => self.regs.oamaddh = value, // TODO
+            0x2102 => *self.regs.oamadd.lo_mut() = value, // TODO
+            0x2103 => *self.regs.oamadd.hi_mut() = value & 0x01, // TODO
             0x2104 => self.regs.oamdata = value, // TODO
 
             // ==========================
@@ -46,35 +46,102 @@ impl PPU {
             // ==========================
             0x2105 => self.regs.bgmode = value,
             0x2106 => self.regs.mosaic = value, // TODO
-            0x2107 => self.regs.bg1sc = value,
-            0x2108 => self.regs.bg2sc = value, // TODO
-            0x2109 => self.regs.bg3sc = value, // TODO
-            0x210A => self.regs.bg4sc = value, // TODO
+            0x2107 => self.regs.bgsc[0] = value,
+            0x2108 => self.regs.bgsc[1] = value, // TODO
+            0x2109 => self.regs.bgsc[2] = value, // TODO
+            0x210A => self.regs.bgsc[3] = value, // TODO
             0x210B => self.regs.bg12nba = value, // TODO
             0x210C => self.regs.bg34nba = value, // TODO
 
-            // BG1 HOFS
+            // BG1HOFS / M7HOFS - same address ($210D)
             0x210D => {
-                if let Some((lo, hi)) = self.regs.bg1hofs_latch.write(value) {
-                    *self.regs.bg1hofs.lo_mut() = lo;
-                    *self.regs.bg1hofs.hi_mut() = hi & 0x07;
-                }
+                // BG1HOFS (W8x2): result = (value << 8) | (bgofs_latch & ~7) | (bghofs_latch & 7)
+                let lo = (self.regs.bgofs_latch & !0x07) | (self.regs.bghofs_latch & 0x07);
+                let hi = value & 0x03;
+                *self.regs.bg1hofs.lo_mut() = lo;
+                *self.regs.bg1hofs.hi_mut() = hi;
+                // M7HOFS (W8x2): result = (value << 8) | mode7_latch
+                let m7lo = self.regs.mode7_latch;
+                *self.regs.m7hofs.lo_mut() = m7lo;
+                *self.regs.m7hofs.hi_mut() = value;
+                // Update latches
+                self.regs.bgofs_latch = value;
+                self.regs.bghofs_latch = value;
+                self.regs.mode7_latch = value;
             }
 
-            // BG1 VOFS
+            // BG1VOFS / M7VOFS - same address ($210E)
             0x210E => {
-                if let Some((lo, hi)) = self.regs.bg1vofs_latch.write(value) {
-                    *self.regs.bg1vofs.lo_mut() = lo;
-                    *self.regs.bg1vofs.hi_mut() = hi & 0x07;
-                }
+                // BG1VOFS (W8x2): result = (value << 8) | bgofs_latch
+                let lo = self.regs.bgofs_latch;
+                let hi = value & 0x03;
+                *self.regs.bg1vofs.lo_mut() = lo;
+                *self.regs.bg1vofs.hi_mut() = hi;
+                // M7VOFS (W8x2): result = (value << 8) | mode7_latch
+                let m7lo = self.regs.mode7_latch;
+                *self.regs.m7vofs.lo_mut() = m7lo;
+                *self.regs.m7vofs.hi_mut() = value;
+                // Update latches
+                self.regs.bgofs_latch = value;
+                self.regs.mode7_latch = value;
             }
 
-            0x210F => self.regs.bg1vofs = value as u16, // TODO
-            0x2110 => self.regs.m7vofs = value as u16, // TODO
-            0x2111 => self.regs.bg2hofs = value as u16, // TODO
-            0x2112 => self.regs.bg2vofs = value as u16, // TODO
-            0x2113 => self.regs.bg3hofs = value as u16, // TODO
-            0x2114 => self.regs.bg3vofs = value as u16, // TODO
+            // BG2HOFS ($210F)
+            0x210F => {
+                let lo = (self.regs.bgofs_latch & !0x07) | (self.regs.bghofs_latch & 0x07);
+                let hi = value & 0x03;
+                *self.regs.bghofs[0].lo_mut() = lo;
+                *self.regs.bghofs[0].hi_mut() = hi;
+                self.regs.bgofs_latch = value;
+                self.regs.bghofs_latch = value;
+            }
+
+            // BG2VOFS ($2110)
+            0x2110 => {
+                let lo = self.regs.bgofs_latch;
+                let hi = value & 0x03;
+                *self.regs.bgvofs[0].lo_mut() = lo;
+                *self.regs.bgvofs[0].hi_mut() = hi;
+                self.regs.bgofs_latch = value;
+            }
+
+            // BG3HOFS ($2111)
+            0x2111 => {
+                let lo = (self.regs.bgofs_latch & !0x07) | (self.regs.bghofs_latch & 0x07);
+                let hi = value & 0x03;
+                *self.regs.bghofs[1].lo_mut() = lo;
+                *self.regs.bghofs[1].hi_mut() = hi;
+                self.regs.bgofs_latch = value;
+                self.regs.bghofs_latch = value;
+            }
+
+            // BG3VOFS ($2112)
+            0x2112 => {
+                let lo = self.regs.bgofs_latch;
+                let hi = value & 0x03;
+                *self.regs.bgvofs[1].lo_mut() = lo;
+                *self.regs.bgvofs[1].hi_mut() = hi;
+                self.regs.bgofs_latch = value;
+            }
+
+            // BG4HOFS ($2113)
+            0x2113 => {
+                let lo = (self.regs.bgofs_latch & !0x07) | (self.regs.bghofs_latch & 0x07);
+                let hi = value & 0x03;
+                *self.regs.bghofs[2].lo_mut() = lo;
+                *self.regs.bghofs[2].hi_mut() = hi;
+                self.regs.bgofs_latch = value;
+                self.regs.bghofs_latch = value;
+            }
+
+            // BG4VOFS ($2114)
+            0x2114 => {
+                let lo = self.regs.bgofs_latch;
+                let hi = value & 0x03;
+                *self.regs.bgvofs[2].lo_mut() = lo;
+                *self.regs.bgvofs[2].hi_mut() = hi;
+                self.regs.bgofs_latch = value;
+            }
 
             // ==========================
             // VRAM
@@ -89,12 +156,42 @@ impl PPU {
             // Mode 7
             // ==========================
             0x211A => self.regs.m7sel = value, // TODO
-            0x211B => self.regs.m7a = value as u16, // TODO
-            0x211C => self.regs.m7b = value as u16, // TODO
-            0x211D => self.regs.m7c = value as u16, // TODO
-            0x211E => self.regs.m7d = value as u16, // TODO
-            0x211F => self.regs.m7x = value as u16, // TODO
-            0x2120 => self.regs.m7y = value as u16, // TODO
+            0x211B => { // M7A (W8x2)
+                let lo = self.regs.mode7_latch;
+                *self.regs.m7a.lo_mut() = lo;
+                *self.regs.m7a.hi_mut() = value;
+                self.regs.mode7_latch = value;
+            }
+            0x211C => { // M7B (W8x2)
+                let lo = self.regs.mode7_latch;
+                *self.regs.m7b.lo_mut() = lo;
+                *self.regs.m7b.hi_mut() = value;
+                self.regs.mode7_latch = value;
+            }
+            0x211D => { // M7C (W8x2)
+                let lo = self.regs.mode7_latch;
+                *self.regs.m7c.lo_mut() = lo;
+                *self.regs.m7c.hi_mut() = value;
+                self.regs.mode7_latch = value;
+            }
+            0x211E => { // M7D (W8x2)
+                let lo = self.regs.mode7_latch;
+                *self.regs.m7d.lo_mut() = lo;
+                *self.regs.m7d.hi_mut() = value;
+                self.regs.mode7_latch = value;
+            }
+            0x211F => { // M7X (W8x2)
+                let lo = self.regs.mode7_latch;
+                *self.regs.m7x.lo_mut() = lo;
+                *self.regs.m7x.hi_mut() = value;
+                self.regs.mode7_latch = value;
+            }
+            0x2120 => { // M7Y (W8x2)
+                let lo = self.regs.mode7_latch;
+                *self.regs.m7y.lo_mut() = lo;
+                *self.regs.m7y.hi_mut() = value;
+                self.regs.mode7_latch = value;
+            }
 
             // ==========================
             // CGRAM
@@ -163,7 +260,7 @@ impl PPU {
             0x2137 => Self::unimplemented_read_only(addr), // TODO
             0x213C => Self::unimplemented_read_only(addr), // TODO
             0x213D => Self::unimplemented_read_only(addr), // TODO
-            
+
             // ==========================
             // Status
             // ==========================
@@ -225,36 +322,21 @@ mod tests {
     // $2100 - INIDISP: force_blank / brightness
     // ============================================================
 
-    /// force_blank must return true when bit 7 of INIDISP is set.
-    #[test]
-    fn test_force_blank_true_when_bit7_set() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2100, 0x80);
-        assert!(ppu.force_blank());
-    }
-
-    /// force_blank must return false when bit 7 of INIDISP is clear.
-    #[test]
-    fn test_force_blank_false_when_bit7_clear() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2100, 0x0F);
-        assert!(!ppu.force_blank());
-    }
-
+    /// force_blank must return true when bit 7 of INIDISP is set, false otherwise.
     /// brightness must return only the lower 4 bits of INIDISP.
     #[test]
-    fn test_brightness_returns_lower_nibble() {
+    fn test_inidisp() {
         let mut ppu = PPU::new();
+
+        ppu.write(0x2100, 0x80);
+        assert!(ppu.force_blank());
+        assert_eq!(ppu.brightness(), 0);
+
+        ppu.write(0x2100, 0x0F);
+        assert!(!ppu.force_blank());
+
         ppu.write(0x2100, 0xFF);
         assert_eq!(ppu.brightness(), 0x0F);
-    }
-
-    /// brightness must return 0 when INIDISP lower nibble is 0.
-    #[test]
-    fn test_brightness_zero() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2100, 0x80);
-        assert_eq!(ppu.brightness(), 0);
     }
 
     // ============================================================
@@ -262,33 +344,22 @@ mod tests {
     // ============================================================
 
     /// Writing $2101 must update objsel.
-    #[test]
-    fn test_write_objsel() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2101, 0xA5);
-        assert_eq!(ppu.regs.objsel, 0xA5);
-    }
-
-    /// Writing $2102 must update oamaddl.
-    #[test]
-    fn test_write_oamaddl() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2102, 0x7F);
-        assert_eq!(ppu.regs.oamaddl, 0x7F);
-    }
-
-    /// Writing $2103 must update oamaddh.
-    #[test]
-    fn test_write_oamaddh() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2103, 0x01);
-        assert_eq!(ppu.regs.oamaddh, 0x01);
-    }
-
+    /// Writing $2102 must update the low byte of oamadd.
+    /// Writing $2103 must update the high byte of oamadd (only bit 0 is valid).
     /// Writing $2104 must update oamdata.
     #[test]
-    fn test_write_oamdata() {
+    fn test_write_oam_registers() {
         let mut ppu = PPU::new();
+
+        ppu.write(0x2101, 0xA5);
+        assert_eq!(ppu.regs.objsel, 0xA5);
+
+        ppu.write(0x2102, 0x7F);
+        assert_eq!(*ppu.regs.oamadd.lo(), 0x7F);
+
+        ppu.write(0x2103, 0x01);
+        assert_eq!(*ppu.regs.oamadd.hi(), 0x01);
+
         ppu.write(0x2104, 0xBE);
         assert_eq!(ppu.regs.oamdata, 0xBE);
     }
@@ -298,25 +369,14 @@ mod tests {
     // ============================================================
 
     /// Writing $2105 must update bgmode.
-    #[test]
-    fn test_write_bgmode() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2105, 0x07);
-        assert_eq!(ppu.regs.bgmode, 0x07);
-    }
-
     /// bg_mode must return only bits[2:0] of BGMODE.
     #[test]
-    fn test_bg_mode_returns_lower_3_bits() {
+    fn test_bgmode() {
         let mut ppu = PPU::new();
+
         ppu.write(0x2105, 0b11110111);
         assert_eq!(ppu.regs.bg_mode(), 7);
-    }
 
-    /// bg_mode must mask out bits above bit 2.
-    #[test]
-    fn test_bg_mode_masks_upper_bits() {
-        let mut ppu = PPU::new();
         ppu.write(0x2105, 0b11111000);
         assert_eq!(ppu.regs.bg_mode(), 0);
     }
@@ -337,247 +397,182 @@ mod tests {
     // $2107–$210A - BGxSC
     // ============================================================
 
-    /// Writing $2107 must update bg1sc.
+    /// Writing $2107–$210A must update bgsc[0]–bgsc[3].
     #[test]
-    fn test_write_bg1sc() {
+    fn test_write_bgsc() {
         let mut ppu = PPU::new();
+
         ppu.write(0x2107, 0xFC);
-        assert_eq!(ppu.regs.bg1sc, 0xFC);
-    }
+        assert_eq!(ppu.regs.bgsc[0], 0xFC);
 
-    /// Writing $2108 must update bg2sc.
-    #[test]
-    fn test_write_bg2sc() {
-        let mut ppu = PPU::new();
         ppu.write(0x2108, 0x10);
-        assert_eq!(ppu.regs.bg2sc, 0x10);
-    }
+        assert_eq!(ppu.regs.bgsc[1], 0x10);
 
-    /// Writing $2109 must update bg3sc.
-    #[test]
-    fn test_write_bg3sc() {
-        let mut ppu = PPU::new();
         ppu.write(0x2109, 0x20);
-        assert_eq!(ppu.regs.bg3sc, 0x20);
-    }
+        assert_eq!(ppu.regs.bgsc[2], 0x20);
 
-    /// Writing $210A must update bg4sc.
-    #[test]
-    fn test_write_bg4sc() {
-        let mut ppu = PPU::new();
         ppu.write(0x210A, 0x30);
-        assert_eq!(ppu.regs.bg4sc, 0x30);
+        assert_eq!(ppu.regs.bgsc[3], 0x30);
     }
 
     // ============================================================
-    // $210B–$210C - BG12NBA / BG34NBA / bg1_tiledata_addr()
+    // $210B–$210C - BG12NBA / BG34NBA / tiledata helpers
     // ============================================================
 
-    /// Writing $210B must update bg12nba.
+    /// Writing $210B/$210C must update bg12nba/bg34nba.
+    /// Tiledata address helpers must derive correctly from the nibbles.
     #[test]
-    fn test_write_bg12nba() {
+    fn test_bgnba_and_tiledata_addrs() {
         let mut ppu = PPU::new();
+
         ppu.write(0x210B, 0x01);
         assert_eq!(ppu.regs.bg12nba, 0x01);
-    }
+        assert_eq!(ppu.regs.bg1_tiledata_addr(), 0x1000);
 
-    /// Writing $210C must update bg34nba.
-    #[test]
-    fn test_write_bg34nba() {
-        let mut ppu = PPU::new();
+        ppu.write(0x210B, 0x00);
+        assert_eq!(ppu.regs.bg1_tiledata_addr(), 0x0000);
+
+        ppu.write(0x210B, 0x0F);
+        assert_eq!(ppu.regs.bg1_tiledata_addr(), 0xF000);
+
         ppu.write(0x210C, 0x23);
         assert_eq!(ppu.regs.bg34nba, 0x23);
     }
 
-    /// bg1_tiledata_addr must derive the CHR base address from bits[3:0] of BG12NBA.
-    #[test]
-    fn test_bg1_tiledata_addr_derivation() {
-        let mut ppu = PPU::new();
-        ppu.write(0x210B, 0x01); // nibble = 1 -> 0x1000
-        assert_eq!(ppu.regs.bg1_tiledata_addr(), 0x1000);
-    }
-
-    /// bg1_tiledata_addr must return 0 when BG12NBA is 0.
-    #[test]
-    fn test_bg1_tiledata_addr_zero() {
-        let mut ppu = PPU::new();
-        ppu.write(0x210B, 0x00);
-        assert_eq!(ppu.regs.bg1_tiledata_addr(), 0x0000);
-    }
-
-    /// bg1_tiledata_addr must handle the maximum low nibble (0xF -> 0xF000).
-    #[test]
-    fn test_bg1_tiledata_addr_maximum() {
-        let mut ppu = PPU::new();
-        ppu.write(0x210B, 0x0F);
-        assert_eq!(ppu.regs.bg1_tiledata_addr(), 0xF000);
-    }
-
     // ============================================================
-    // $210D - BG1HOFS (two-write latch)
+    // $210D - BG1HOFS / M7HOFS (W8x2, shared address)
     // ============================================================
 
-    /// First write to $210D must not commit bg1hofs.
+    /// BG1HOFS uses a write-twice mechanism via bgofs_latch/bghofs_latch.
+    /// The result is: lo = (bgofs_latch & ~7) | (bghofs_latch & 7), hi = value & 0x03.
+    /// M7HOFS uses mode7_latch: lo = mode7_latch, hi = value.
     #[test]
-    fn test_bg1hofs_first_write_latches() {
+    fn test_write_bg1hofs_and_m7hofs() {
         let mut ppu = PPU::new();
+
+        // First write: only updates latches, no commit yet
         ppu.write(0x210D, 0xAB);
-        assert_eq!(ppu.regs.bg1hofs, 0x0000);
-    }
+        assert_eq!(ppu.regs.bgofs_latch, 0xAB);
+        assert_eq!(ppu.regs.bghofs_latch, 0xAB);
+        assert_eq!(ppu.regs.mode7_latch, 0xAB);
 
-    /// Second write to $210D must commit the full 10-bit scroll value.
-    #[test]
-    fn test_bg1hofs_second_write_commits() {
-        let mut ppu = PPU::new();
-        ppu.write(0x210D, 0xCD);
+        // Second write commits both BG1HOFS and M7HOFS
         ppu.write(0x210D, 0x03);
-        assert_eq!(ppu.regs.bg1hofs, 0x03CD);
-    }
+        // BG1HOFS: lo = (0xAB & ~7) | (0xAB & 7) = 0xAB, hi = 0x03 & 0x03 = 0x03
+        assert_eq!(ppu.regs.bg1hofs, 0x03AB);
+        // M7HOFS: lo = 0xAB (first write's mode7_latch), hi = 0x03
+        assert_eq!(ppu.regs.m7hofs, 0x03AB);
 
-    /// The high byte of BG1HOFS must be masked to bits[2:0] only (10-bit scroll).
-    #[test]
-    fn test_bg1hofs_high_byte_masked_to_3_bits() {
+        // High byte of BG1HOFS masked to bits[1:0] (10-bit scroll)
         let mut ppu = PPU::new();
         ppu.write(0x210D, 0xFF);
         ppu.write(0x210D, 0xFF);
-        assert_eq!(*ppu.regs.bg1hofs.hi(), 0x07);
-    }
-
-    /// A third write to $210D must start a new latch cycle without committing.
-    #[test]
-    fn test_bg1hofs_third_write_starts_new_cycle() {
-        let mut ppu = PPU::new();
-        ppu.write(0x210D, 0x11);
-        ppu.write(0x210D, 0x02); // commits 0x0211
-        ppu.write(0x210D, 0x33); // new lo, not committed yet
-        assert_eq!(ppu.regs.bg1hofs, 0x0211);
+        assert_eq!(*ppu.regs.bg1hofs.hi(), 0x03);
     }
 
     // ============================================================
-    // $210E - BG1VOFS (two-write latch)
+    // $210E - BG1VOFS / M7VOFS (W8x2, shared address)
     // ============================================================
 
-    /// First write to $210E must not commit bg1vofs.
+    /// BG1VOFS: lo = bgofs_latch, hi = value & 0x03.
+    /// M7VOFS: lo = mode7_latch, hi = value.
     #[test]
-    fn test_bg1vofs_first_write_latches() {
+    fn test_write_bg1vofs_and_m7vofs() {
         let mut ppu = PPU::new();
-        ppu.write(0x210E, 0x55);
-        assert_eq!(ppu.regs.bg1vofs, 0x0000);
-    }
 
-    /// Second write to $210E must commit the full 10-bit scroll value.
-    #[test]
-    fn test_bg1vofs_second_write_commits() {
-        let mut ppu = PPU::new();
         ppu.write(0x210E, 0x78);
         ppu.write(0x210E, 0x02);
+        // BG1VOFS: lo = 0x78 (bgofs_latch from first write), hi = 0x02 & 0x03
         assert_eq!(ppu.regs.bg1vofs, 0x0278);
-    }
+        // M7VOFS: lo = 0x78 (mode7_latch from first write), hi = 0x02
+        assert_eq!(ppu.regs.m7vofs, 0x0278);
 
-    /// The high byte of BG1VOFS must be masked to bits[2:0] only.
-    #[test]
-    fn test_bg1vofs_high_byte_masked_to_3_bits() {
+        // High byte of BG1VOFS masked to bits[1:0]
         let mut ppu = PPU::new();
         ppu.write(0x210E, 0x00);
         ppu.write(0x210E, 0xFF);
-        assert_eq!(*ppu.regs.bg1vofs.hi(), 0x07);
+        assert_eq!(*ppu.regs.bg1vofs.hi(), 0x03);
     }
 
     // ============================================================
-    // $210F–$2114 - remaining BG scroll (placeholder writes)
+    // $210F–$2114 - BG2–BG4 scroll (W8x2 via bgofs_latch/bghofs_latch)
     // ============================================================
 
-    /// Writing $210F must update bg1vofs as a raw u8->u16.
+    /// BG2HOFS–BG4VOFS use the shared bgofs_latch/bghofs_latch.
+    /// Each write pair commits the correct entry in bghofs[]/bgvofs[].
     #[test]
-    fn test_write_bg1vofs_placeholder() {
+    fn test_write_bg2_to_bg4_scroll() {
         let mut ppu = PPU::new();
-        ppu.write(0x210F, 0x42);
-        assert_eq!(ppu.regs.bg1vofs, 0x42);
-    }
 
-    /// Writing $2110 must update m7vofs.
-    #[test]
-    fn test_write_m7vofs() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2110, 0x11);
-        assert_eq!(ppu.regs.m7vofs, 0x11);
-    }
+        // BG2HOFS ($210F): write lo latch, then commit
+        ppu.write(0x210F, 0x10);
+        ppu.write(0x210F, 0x01);
+        assert_eq!(ppu.regs.bghofs[0], 0x0110);
 
-    /// Writing $2111 must update bg2hofs.
-    #[test]
-    fn test_write_bg2hofs() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2111, 0x22);
-        assert_eq!(ppu.regs.bg2hofs, 0x22);
-    }
+        // BG2VOFS ($2110)
+        ppu.write(0x2110, 0x20);
+        ppu.write(0x2110, 0x02);
+        assert_eq!(ppu.regs.bgvofs[0], 0x0220);
 
-    /// Writing $2112 must update bg2vofs.
-    #[test]
-    fn test_write_bg2vofs() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2112, 0x33);
-        assert_eq!(ppu.regs.bg2vofs, 0x33);
-    }
+        // BG3HOFS ($2111)
+        ppu.write(0x2111, 0x30);
+        ppu.write(0x2111, 0x03);
+        assert_eq!(ppu.regs.bghofs[1], 0x0330);
 
-    /// Writing $2113 must update bg3hofs.
-    #[test]
-    fn test_write_bg3hofs() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2113, 0x44);
-        assert_eq!(ppu.regs.bg3hofs, 0x44);
-    }
+        // BG3VOFS ($2112)
+        ppu.write(0x2112, 0x40);
+        ppu.write(0x2112, 0x04);
+        // Note: hi is masked to bits[1:0] -> 0x04 & 0x03 = 0x00... wait, 0x04 & 0x03 = 0x00
+        // Actually it's 0x00 since 0x04 & 0x03 == 0x00
+        // Let's use a value that survives the mask
+        let mut ppu2 = PPU::new();
+        ppu2.write(0x2112, 0x40);
+        ppu2.write(0x2112, 0x01);
+        assert_eq!(ppu2.regs.bgvofs[1], 0x0140);
 
-    /// Writing $2114 must update bg3vofs.
-    #[test]
-    fn test_write_bg3vofs() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2114, 0x55);
-        assert_eq!(ppu.regs.bg3vofs, 0x55);
+        // BG4HOFS ($2113)
+        let mut ppu3 = PPU::new();
+        ppu3.write(0x2113, 0x50);
+        ppu3.write(0x2113, 0x01);
+        assert_eq!(ppu3.regs.bghofs[2], 0x0150);
+
+        // BG4VOFS ($2114)
+        let mut ppu4 = PPU::new();
+        ppu4.write(0x2114, 0x60);
+        ppu4.write(0x2114, 0x02);
+        assert_eq!(ppu4.regs.bgvofs[2], 0x0260);
     }
 
     // ============================================================
-    // $2115–$2119 - VRAM / $2139–$213A - VRAM read
+    // $2115–$2119 / $2139–$213A - VRAM
     // ============================================================
 
     /// Writing $2115 must update vmain.
+    /// Setting VRAM address and writing a word must store the correct data.
+    /// Reading back $2139/$213A must return the written bytes.
+    /// Address must increment after each complete word write.
     #[test]
-    fn test_write_vmain() {
+    fn test_vram_via_ppu() {
         let mut ppu = PPU::new();
+
         ppu.write(0x2115, 0x80);
         assert_eq!(ppu.regs.vmain, 0x80);
-    }
 
-    /// Setting VRAM address and writing a word must store the correct data.
-    #[test]
-    fn test_vram_write_via_ppu() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2115, 0x80); // increment after high byte
+        // Write word 0xABCD at address 0x0010
         ppu.write(0x2116, 0x10);
-        ppu.write(0x2117, 0x00); // address = 0x0010
+        ppu.write(0x2117, 0x00);
         ppu.write(0x2118, 0xCD);
-        ppu.write(0x2119, 0xAB); // word = 0xABCD
+        ppu.write(0x2119, 0xAB);
         assert_eq!(ppu.vram.memory[0x0010], 0xABCD);
-    }
 
-    /// Reading $2139/$213A must return the previously written VRAM data.
-    #[test]
-    fn test_vram_read_via_ppu() {
-        let mut ppu = PPU::new();
+        // Read back
         ppu.vram.memory[0x0005] = 0x1234;
-        ppu.write(0x2115, 0x80);
         ppu.write(0x2116, 0x05);
         ppu.write(0x2117, 0x00);
-        let lo = ppu.read(0x2139);
-        let hi = ppu.read(0x213A);
-        assert_eq!(lo, 0x34);
-        assert_eq!(hi, 0x12);
-    }
+        assert_eq!(ppu.read(0x2139), 0x34);
+        assert_eq!(ppu.read(0x213A), 0x12);
 
-    /// VRAM address must increment after a complete word write (vmain = 0x80).
-    #[test]
-    fn test_vram_address_increments_after_write() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2115, 0x80);
+        // Sequential writes increment address
         ppu.write(0x2116, 0x00);
         ppu.write(0x2117, 0x00);
         ppu.write(0x2118, 0x11);
@@ -589,63 +584,43 @@ mod tests {
     }
 
     // ============================================================
-    // $211A–$2120 - Mode 7
+    // $211A–$2120 - Mode 7 (W8x2 via mode7_latch)
     // ============================================================
 
     /// Writing $211A must update m7sel.
+    /// Mode 7 matrix registers ($211B–$2120) are W8x2 via mode7_latch:
+    /// first write stores latch, second write commits (hi=second, lo=first).
     #[test]
-    fn test_write_m7sel() {
+    fn test_mode7_registers() {
         let mut ppu = PPU::new();
+
         ppu.write(0x211A, 0x03);
         assert_eq!(ppu.regs.m7sel, 0x03);
-    }
 
-    /// Writing $211B must update m7a.
-    #[test]
-    fn test_write_m7a() {
-        let mut ppu = PPU::new();
-        ppu.write(0x211B, 0x7F);
-        assert_eq!(ppu.regs.m7a, 0x7F);
-    }
+        // M7A: two writes -> full 16-bit value
+        ppu.write(0x211B, 0x34);
+        ppu.write(0x211B, 0x12);
+        assert_eq!(ppu.regs.m7a, 0x1234);
 
-    /// Writing $211C must update m7b.
-    #[test]
-    fn test_write_m7b() {
-        let mut ppu = PPU::new();
-        ppu.write(0x211C, 0x01);
-        assert_eq!(ppu.regs.m7b, 0x01);
-    }
+        ppu.write(0x211C, 0x56);
+        ppu.write(0x211C, 0x78);
+        assert_eq!(ppu.regs.m7b, 0x7856);
 
-    /// Writing $211D must update m7c.
-    #[test]
-    fn test_write_m7c() {
-        let mut ppu = PPU::new();
-        ppu.write(0x211D, 0x02);
-        assert_eq!(ppu.regs.m7c, 0x02);
-    }
+        ppu.write(0x211D, 0xAB);
+        ppu.write(0x211D, 0xCD);
+        assert_eq!(ppu.regs.m7c, 0xCDAB);
 
-    /// Writing $211E must update m7d.
-    #[test]
-    fn test_write_m7d() {
-        let mut ppu = PPU::new();
-        ppu.write(0x211E, 0x03);
-        assert_eq!(ppu.regs.m7d, 0x03);
-    }
+        ppu.write(0x211E, 0x11);
+        ppu.write(0x211E, 0x22);
+        assert_eq!(ppu.regs.m7d, 0x2211);
 
-    /// Writing $211F must update m7x.
-    #[test]
-    fn test_write_m7x() {
-        let mut ppu = PPU::new();
         ppu.write(0x211F, 0x80);
-        assert_eq!(ppu.regs.m7x, 0x80);
-    }
+        ppu.write(0x211F, 0x00);
+        assert_eq!(ppu.regs.m7x, 0x0080);
 
-    /// Writing $2120 must update m7y.
-    #[test]
-    fn test_write_m7y() {
-        let mut ppu = PPU::new();
         ppu.write(0x2120, 0x40);
-        assert_eq!(ppu.regs.m7y, 0x40);
+        ppu.write(0x2120, 0x01);
+        assert_eq!(ppu.regs.m7y, 0x0140);
     }
 
     // ============================================================
@@ -692,20 +667,18 @@ mod tests {
     }
 
     // ============================================================
-    // $212C–$2132 - Color math / layer enable
+    // $212C–$2133 - Color math / layer enable / SETINI
     // ============================================================
 
-    /// Writing $212C must update tm.
+    /// Writing $212C must update tm; bg1_enabled reflects bit 0.
+    /// Writing $212D–$2133 must store verbatim.
     #[test]
-    fn test_write_tm() {
+    fn test_write_color_math_and_layer_registers() {
         let mut ppu = PPU::new();
+
         ppu.write(0x212C, 0x1F);
         assert_eq!(ppu.regs.tm, 0x1F);
-    }
 
-    /// Writing color math registers must store the value verbatim.
-    #[test]
-    fn test_write_color_math_registers() {
         let cases: &[(u16, fn(&PPURegisters) -> u8)] = &[
             (0x212D, |r| r.ts),
             (0x212E, |r| r.tmw),
@@ -713,6 +686,7 @@ mod tests {
             (0x2130, |r| r.cgwsel),
             (0x2131, |r| r.cgadsub),
             (0x2132, |r| r.coldata),
+            (0x2133, |r| r.setini),
         ];
         for &(addr, getter) in cases {
             let mut ppu = PPU::new();
@@ -721,62 +695,40 @@ mod tests {
         }
     }
 
-    /// Writing $2133 must update setini.
-    #[test]
-    fn test_write_setini() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2133, 0x04);
-        assert_eq!(ppu.regs.setini, 0x04);
-    }
-
     // ============================================================
-    // $212C - TM / bg1_enabled() / bg1_tilemap_addr()
+    // $212C - TM / bg1_enabled()
     // ============================================================
 
-    /// bg1_enabled must return true when bit 0 of TM is set.
+    /// bg1_enabled must reflect bit 0 of TM only.
     #[test]
-    fn test_bg1_enabled_true_when_tm_bit0_set() {
+    fn test_bg1_enabled() {
         let mut ppu = PPU::new();
+
         ppu.write(0x212C, 0x01);
         assert!(ppu.regs.bg1_enabled());
-    }
 
-    /// bg1_enabled must return false when bit 0 of TM is clear.
-    #[test]
-    fn test_bg1_enabled_false_when_tm_bit0_clear() {
-        let mut ppu = PPU::new();
         ppu.write(0x212C, 0xFE);
         assert!(!ppu.regs.bg1_enabled());
-    }
 
-    /// bg1_enabled must ignore all bits of TM except bit 0.
-    #[test]
-    fn test_bg1_enabled_ignores_upper_bits_of_tm() {
-        let mut ppu = PPU::new();
         ppu.write(0x212C, 0x1E);
         assert!(!ppu.regs.bg1_enabled());
     }
 
-    /// bg1_tilemap_addr must derive the VRAM address from bits[7:2] of BG1SC.
-    #[test]
-    fn test_bg1_tilemap_addr_derivation() {
-        let mut ppu = PPU::new();
-        ppu.write(0x2107, 0b00000100); // bits[7:2] = 1 -> 0x0400
-        assert_eq!(ppu.regs.bg1_tilemap_addr(), 0x0400);
-    }
+    // ============================================================
+    // $2107 - BG1SC / bg1_tilemap_addr()
+    // ============================================================
 
-    /// bg1_tilemap_addr must return 0 when BG1SC is 0.
+    /// bg1_tilemap_addr must derive the VRAM address from bits[7:2] of bgsc[0].
     #[test]
-    fn test_bg1_tilemap_addr_zero() {
+    fn test_bg1_tilemap_addr() {
         let mut ppu = PPU::new();
+
+        ppu.write(0x2107, 0b00000100);
+        assert_eq!(ppu.regs.bg1_tilemap_addr(), 0x0400);
+
         ppu.write(0x2107, 0x00);
         assert_eq!(ppu.regs.bg1_tilemap_addr(), 0x0000);
-    }
 
-    /// bg1_tilemap_addr must handle the maximum value (bits[7:2] = 0x3F -> 0x3F * 0x400).
-    #[test]
-    fn test_bg1_tilemap_addr_maximum() {
-        let mut ppu = PPU::new();
         ppu.write(0x2107, 0xFF);
         assert_eq!(ppu.regs.bg1_tilemap_addr(), 0x3F * 0x400);
     }
@@ -785,41 +737,30 @@ mod tests {
     // step_scanline
     // ============================================================
 
-    /// step_scanline must increment the scanline counter by 1.
+    /// step_scanline increments the counter, wraps at SCANLINES_PER_FRAME,
+    /// and sets frame_ready only on the wrap.
     #[test]
-    fn test_step_scanline_increments() {
+    fn test_step_scanline() {
         let mut ppu = PPU::new();
+
         ppu.step_scanline();
         assert_eq!(ppu.scanline, 1);
-    }
+        assert!(!ppu.frame_ready);
 
-    /// After SCANLINES_PER_FRAME steps, scanline must wrap to 0 and frame_ready be set.
-    #[test]
-    fn test_step_scanline_wraps_at_262() {
-        let mut ppu = PPU::new();
-        for _ in 0..SCANLINES_PER_FRAME {
-            ppu.step_scanline();
-        }
-        assert_eq!(ppu.scanline, 0);
-        assert!(ppu.frame_ready);
-    }
-
-    /// frame_ready must remain false until the last scanline is reached.
-    #[test]
-    fn test_frame_ready_false_before_wrap() {
-        let mut ppu = PPU::new();
-        for _ in 0..SCANLINES_PER_FRAME - 1 {
+        // One step before wrap
+        for _ in 1..SCANLINES_PER_FRAME - 1 {
             ppu.step_scanline();
         }
         assert!(!ppu.frame_ready);
         assert_eq!(ppu.scanline, SCANLINES_PER_FRAME - 1);
-    }
 
-    /// frame_ready must remain true across subsequent frames.
-    #[test]
-    fn test_frame_ready_stays_true_on_subsequent_frames() {
-        let mut ppu = PPU::new();
-        for _ in 0..SCANLINES_PER_FRAME * 2 {
+        // Wrap
+        ppu.step_scanline();
+        assert_eq!(ppu.scanline, 0);
+        assert!(ppu.frame_ready);
+
+        // Second frame wrap also sets frame_ready
+        for _ in 0..SCANLINES_PER_FRAME {
             ppu.step_scanline();
         }
         assert!(ppu.frame_ready);

--- a/ppu/src/registers.rs
+++ b/ppu/src/registers.rs
@@ -3,232 +3,232 @@ use crate::write_twice::WriteTwice;
 /// PPU Registers placeholder definitions
 /// Each field is a placeholder; actual behavior, latches, buffering, and timing to implement later.
 pub struct PPURegisters {
-    // $2100 - INIDISP (W8)
+    /// $2100 - INIDISP (W8)
     pub inidisp: u8, // Bits: F...BBBB | Forced blanking (F), screen brightness (B).
 
-    // $2101 - OBJSEL (W8)
+    /// $2101 - OBJSEL (W8)
     pub objsel: u8, // Bits: SSSNNbBB | OBJ sprite size (S), name secondary select (N), name base address (B).
 
-    // $2102/$2103 - OAMADDL/OAMADDH (W16)
-    // OAMADDL ($2102): Bits: AAAAAAAA | OAM word address low
-    // OAMADDH ($2103): Bits: P.......B | Priority rotation (P), address high bit (B)
+    /// $2102/$2103 - OAMADDL/OAMADDH (W16)
+    /// OAMADDL ($2102): Bits: AAAAAAAA | OAM word address low
+    /// OAMADDH ($2103): Bits: P.......B | Priority rotation (P), address high bit (B)
     pub oamadd: u16,
 
-    // $2104 - OAMDATA (W8x2)
+    /// $2104 - OAMDATA (W8x2)
     pub oamdata: u8, // Bits: DDDDDDDD | OAM data write byte, increments OAMADD
 
-    // $2105 - BGMODE (W8)
+    /// $2105 - BGMODE (W8)
     pub bgmode: u8, // Bits: 4321PMMM | Tilemap tile size (#), BG3 priority (P), BG mode (M)
 
-    // $2106 - MOSAIC (W8)
+    /// $2106 - MOSAIC (W8)
     pub mosaic: u8, // Bits: SSSS4321 | Mosaic size (S), mosaic BG enable (#)
 
-    // $2107/$2108/$2109/$210A - BG1SC/BG2SC/BG3SC/BG4SC (W8)
-    // Bits: AAAAAAYX | Tilemap VRAM address (A), vertical tilemap count (Y), horizontal tilemap count (X)
-    // bgsc[0] = BG1SC ($2107), bgsc[1] = BG2SC ($2108), bgsc[2] = BG3SC ($2109), bgsc[3] = BG4SC ($210A)
+    /// $2107/$2108/$2109/$210A - BG1SC/BG2SC/BG3SC/BG4SC (W8)
+    /// Bits: AAAAAAYX | Tilemap VRAM address (A), vertical tilemap count (Y), horizontal tilemap count (X)
+    /// bgsc[0] = BG1SC ($2107), bgsc[1] = BG2SC ($2108), bgsc[2] = BG3SC ($2109), bgsc[3] = BG4SC ($210A)
     pub bgsc: [u8; 4],
 
-    // $210B - BG12NBA (W8)
+    /// $210B - BG12NBA (W8)
     pub bg12nba: u8, // Bits: BBBBAAAA | BG2 CHR base address (B), BG1 CHR base address (A)
 
-    // $210C - BG34NBA (W8)
+    /// $210C - BG34NBA (W8)
     pub bg34nba: u8, // Bits: DDDDCCCC | BG4 CHR base address (D), BG3 CHR base address (C)
 
-    // $210D - BG1HOFS (W8x2, shares address with M7HOFS)
-    // Bits: ......XX XXXXXXXX | BG1 horizontal scroll
-    // On write: BG1HOFS = (value << 8) | (bgofs_latch & ~7) | (bghofs_latch & 7)
-    //           bgofs_latch = value; bghofs_latch = value
+    /// $210D - BG1HOFS (W8x2, shares address with M7HOFS)
+    /// Bits: ......XX XXXXXXXX | BG1 horizontal scroll
+    /// On write: BG1HOFS = (value << 8) | (bgofs_latch & ~7) | (bghofs_latch & 7)
+    ///           bgofs_latch = value; bghofs_latch = value
     pub bg1hofs: u16,
 
-    // $210D - M7HOFS (W8x2, shares address with BG1HOFS)
-    // Bits: ...XXXXX XXXXXXXX | Mode 7 horizontal scroll (signed)
-    // On write: M7HOFS = (value << 8) | mode7_latch; mode7_latch = value
+    /// $210D - M7HOFS (W8x2, shares address with BG1HOFS)
+    /// Bits: ...XXXXX XXXXXXXX | Mode 7 horizontal scroll (signed)
+    /// On write: M7HOFS = (value << 8) | mode7_latch; mode7_latch = value
     pub m7hofs: u16,
 
-    // $210E - BG1VOFS (W8x2, shares address with M7VOFS)
-    // Bits: ......YY YYYYYYYY | BG1 vertical scroll
-    // On write: BG1VOFS = (value << 8) | bgofs_latch; bgofs_latch = value
+    /// $210E - BG1VOFS (W8x2, shares address with M7VOFS)
+    /// Bits: ......YY YYYYYYYY | BG1 vertical scroll
+    /// On write: BG1VOFS = (value << 8) | bgofs_latch; bgofs_latch = value
     pub bg1vofs: u16,
 
-    // $210E - M7VOFS (W8x2, shares address with BG1VOFS)
-    // Bits: ...YYYYY YYYYYYYY | Mode 7 vertical scroll (signed)
-    // On write: M7VOFS = (value << 8) | mode7_latch; mode7_latch = value
+    /// $210E - M7VOFS (W8x2, shares address with BG1VOFS)
+    /// Bits: ...YYYYY YYYYYYYY | Mode 7 vertical scroll (signed)
+    /// On write: M7VOFS = (value << 8) | mode7_latch; mode7_latch = value
     pub m7vofs: u16,
 
-    // $210F/$2110/$2111/$2112/$2113/$2114 - BG2HOFS/BG2VOFS/BG3HOFS/BG3VOFS/BG4HOFS/BG4VOFS (W8x2)
-    // bghofs[0] = BG2HOFS ($210F), bghofs[1] = BG3HOFS ($2111), bghofs[2] = BG4HOFS ($2113)
-    // Bits: ......XX XXXXXXXX | BGn horizontal scroll
-    // On write: BGnHOFS = (value << 8) | (bgofs_latch & ~7) | (bghofs_latch & 7)
-    //           bgofs_latch = value; bghofs_latch = value
+    /// $210F/$2110/$2111/$2112/$2113/$2114 - BG2HOFS/BG2VOFS/BG3HOFS/BG3VOFS/BG4HOFS/BG4VOFS (W8x2)
+    /// bghofs[0] = BG2HOFS ($210F), bghofs[1] = BG3HOFS ($2111), bghofs[2] = BG4HOFS ($2113)
+    /// Bits: ......XX XXXXXXXX | BGn horizontal scroll
+    /// On write: BGnHOFS = (value << 8) | (bgofs_latch & ~7) | (bghofs_latch & 7)
+    ///           bgofs_latch = value; bghofs_latch = value
     pub bghofs: [u16; 3],
 
-    // bgvofs[0] = BG2VOFS ($2110), bgvofs[1] = BG3VOFS ($2112), bgvofs[2] = BG4VOFS ($2114)
-    // Bits: ......YY YYYYYYYY | BGn vertical scroll
-    // On write: BGnVOFS = (value << 8) | bgofs_latch; bgofs_latch = value
+    /// bgvofs[0] = BG2VOFS ($2110), bgvofs[1] = BG3VOFS ($2112), bgvofs[2] = BG4VOFS ($2114)
+    /// Bits: ......YY YYYYYYYY | BGn vertical scroll
+    /// On write: BGnVOFS = (value << 8) | bgofs_latch; bgofs_latch = value
     pub bgvofs: [u16; 3],
 
-    // $2115 - VMAIN (W8)
+    /// $2115 - VMAIN (W8)
     pub vmain: u8, // Bits: M...RRII | VRAM address increment mode (M), remapping (R), increment size (I)
 
-    // $2116/$2117 - VMADDL/VMADDH (W16)
-    // VMADDL ($2116): Bits: LLLLLLLL | VRAM word address low
-    // VMADDH ($2117): Bits: hHHHHHHH | VRAM word address high
+    /// $2116/$2117 - VMADDL/VMADDH (W16)
+    /// VMADDL ($2116): Bits: LLLLLLLL | VRAM word address low
+    /// VMADDH ($2117): Bits: hHHHHHHH | VRAM word address high
     pub vmadd: u16,
 
-    // $2118/$2119 - VMDATAL/VMDATAH (W16)
-    // VMDATAL ($2118): Bits: LLLLLLLL | VRAM data write low
-    // VMDATAH ($2119): Bits: HHHHHHHH | VRAM data write high
-    // Increments VMADD after write according to VMAIN setting
+    /// $2118/$2119 - VMDATAL/VMDATAH (W16)
+    /// VMDATAL ($2118): Bits: LLLLLLLL | VRAM data write low
+    /// VMDATAH ($2119): Bits: HHHHHHHH | VRAM data write high
+    /// Increments VMADD after write according to VMAIN setting
     pub vmdata: u16,
 
-    // $211A - M7SEL (W8)
+    /// $211A - M7SEL (W8)
     pub m7sel: u8, // Bits: RF....YX | Mode 7 tilemap repeat (R), fill (F), flip vertical (Y), flip horizontal (X)
 
-    // $211B - M7A (W8x2)
-    // Bits: DDDDDDDD dddddddd | Mode 7 matrix A (8.8 fixed point) / 16-bit signed multiplication factor
-    // On write: M7A = (value << 8) | mode7_latch; mode7_latch = value
+    /// $211B - M7A (W8x2)
+    /// Bits: DDDDDDDD dddddddd | Mode 7 matrix A (8.8 fixed point) / 16-bit signed multiplication factor
+    /// On write: M7A = (value << 8) | mode7_latch; mode7_latch = value
     pub m7a: u16,
 
-    // $211C - M7B (W8x2)
-    // Bits: DDDDDDDD dddddddd | Mode 7 matrix B (8.8 fixed point) / 8-bit signed multiplication factor
-    // On write: M7B = (value << 8) | mode7_latch; mode7_latch = value
+    /// $211C - M7B (W8x2)
+    /// Bits: DDDDDDDD dddddddd | Mode 7 matrix B (8.8 fixed point) / 8-bit signed multiplication factor
+    /// On write: M7B = (value << 8) | mode7_latch; mode7_latch = value
     pub m7b: u16,
 
-    // $211D - M7C (W8x2)
-    // Bits: DDDDDDDD dddddddd | Mode 7 matrix C (8.8 fixed point)
-    // On write: M7C = (value << 8) | mode7_latch; mode7_latch = value
+    /// $211D - M7C (W8x2)
+    /// Bits: DDDDDDDD dddddddd | Mode 7 matrix C (8.8 fixed point)
+    /// On write: M7C = (value << 8) | mode7_latch; mode7_latch = value
     pub m7c: u16,
 
-    // $211E - M7D (W8x2)
-    // Bits: DDDDDDDD dddddddd | Mode 7 matrix D (8.8 fixed point)
-    // On write: M7D = (value << 8) | mode7_latch; mode7_latch = value
+    /// $211E - M7D (W8x2)
+    /// Bits: DDDDDDDD dddddddd | Mode 7 matrix D (8.8 fixed point)
+    /// On write: M7D = (value << 8) | mode7_latch; mode7_latch = value
     pub m7d: u16,
 
-    // $211F - M7X (W8x2)
-    // Bits: ...XXXXX XXXXXXXX | Mode 7 center X (signed)
-    // On write: M7X = (value << 8) | mode7_latch; mode7_latch = value
+    /// $211F - M7X (W8x2)
+    /// Bits: ...XXXXX XXXXXXXX | Mode 7 center X (signed)
+    /// On write: M7X = (value << 8) | mode7_latch; mode7_latch = value
     pub m7x: u16,
 
-    // $2120 - M7Y (W8x2)
-    // Bits: ...YYYYY YYYYYYYY | Mode 7 center Y (signed)
-    // On write: M7Y = (value << 8) | mode7_latch; mode7_latch = value
+    /// $2120 - M7Y (W8x2)
+    /// Bits: ...YYYYY YYYYYYYY | Mode 7 center Y (signed)
+    /// On write: M7Y = (value << 8) | mode7_latch; mode7_latch = value
     pub m7y: u16,
 
-    // $2121 - CGADD (W8)
+    /// $2121 - CGADD (W8)
     pub cgadd: u8, // Bits: AAAAAAAA | CGRAM word address. On write: cgram_byte = 0
 
-    // $2122 - CGDATA (W8x2)
-    // Bits: .BBBBBGG GGGRRRRR | CGRAM data write, increments CGADD after each word write
-    // On write: if cgram_byte == 0: cgram_latch = value
-    //           if cgram_byte == 1: CGDATA = (value << 8) | cgram_latch
-    //           cgram_byte = ~cgram_byte
+    /// $2122 - CGDATA (W8x2)
+    /// Bits: .BBBBBGG GGGRRRRR | CGRAM data write, increments CGADD after each word write
+    /// On write: if cgram_byte == 0: cgram_latch = value
+    ///           if cgram_byte == 1: CGDATA = (value << 8) | cgram_latch
+    ///           cgram_byte = ~cgram_byte
     pub cgdata: u16,
 
-    // $2123 - W12SEL (W8)
+    /// $2123 - W12SEL (W8)
     pub w12sel: u8, // Bits: DdCcBbAa | Enable (ABCD) and invert (abcd) windows for BG1 (AB) and BG2 (CD)
 
-    // $2124 - W34SEL (W8)
+    /// $2124 - W34SEL (W8)
     pub w34sel: u8, // Bits: HhGgFfEe | Enable (EFGH) and invert (efgh) windows for BG3 (EF) and BG4 (GH)
 
-    // $2125 - WOBJSEL (W8)
+    /// $2125 - WOBJSEL (W8)
     pub wobjsel: u8, // Bits: LlKkJjIi | Enable (IJKL) and invert (ijkl) windows for OBJ (IJ) and color (KL)
 
-    // $2126 - WH0 (W8)
+    /// $2126 - WH0 (W8)
     pub wh0: u8, // Bits: LLLLLLLL | Window 1 left edge position
 
-    // $2127 - WH1 (W8)
+    /// $2127 - WH1 (W8)
     pub wh1: u8, // Bits: RRRRRRRR | Window 1 right edge position
 
-    // $2128 - WH2 (W8)
+    /// $2128 - WH2 (W8)
     pub wh2: u8, // Bits: LLLLLLLL | Window 2 left edge position
 
-    // $2129 - WH3 (W8)
+    /// $2129 - WH3 (W8)
     pub wh3: u8, // Bits: RRRRRRRR | Window 2 right edge position
 
-    // $212A - WBGLOG (W8)
+    /// $212A - WBGLOG (W8)
     pub wbglog: u8, // Bits: 44332211 | Window mask logic for BG layers (00=OR, 01=AND, 10=XOR, 11=XNOR)
 
-    // $212B - WOBJLOG (W8)
+    /// $212B - WOBJLOG (W8)
     pub wobjlog: u8, // Bits: ....CCOO | Window mask logic for OBJ (O) and color (C)
 
-    // $212C - TM (W8)
+    /// $212C - TM (W8)
     pub tm: u8, // Bits: ...O4321 | Main screen layer enable (OBJ, BG4-BG1)
 
-    // $212D - TS (W8)
+    /// $212D - TS (W8)
     pub ts: u8, // Bits: ...O4321 | Sub screen layer enable (OBJ, BG4-BG1)
 
-    // $212E - TMW (W8)
+    /// $212E - TMW (W8)
     pub tmw: u8, // Bits: ...O4321 | Main screen layer window enable (OBJ, BG4-BG1)
 
-    // $212F - TSW (W8)
+    /// $212F - TSW (W8)
     pub tsw: u8, // Bits: ...O4321 | Sub screen layer window enable (OBJ, BG4-BG1)
 
-    // $2130 - CGWSEL (W8)
+    /// $2130 - CGWSEL (W8)
     pub cgwsel: u8, // Bits: MMSS..AD | Main/sub screen color window black/transparent (MS), fixed/subscreen (A), direct color (D)
 
-    // $2131 - CGADSUB (W8)
+    /// $2131 - CGADSUB (W8)
     pub cgadsub: u8, // Bits: MHBO4321 | Color math operator (M), half (H), backdrop (B), layer enable (O4321)
 
-    // $2132 - COLDATA (W8)
+    /// $2132 - COLDATA (W8)
     pub coldata: u8, // Bits: BGRCCCCC | Fixed color channel select (BGR) and value (C)
 
-    // $2133 - SETINI (W8)
+    /// $2133 - SETINI (W8)
     pub setini: u8, // Bits: EX..HOiI | External sync (E), EXTBG (X), Hi-res (H), Overscan (O), OBJ interlace (i), Screen interlace (I)
 
-    // $2134/$2135/$2136 - MPYL/MPYM/MPYH (R24, read-only)
-    // MPYL ($2134): Bits: LLLLLLLL | Multiplication result low byte
-    // MPYM ($2135): Bits: MMMMMMMM | Multiplication result middle byte
-    // MPYH ($2136): Bits: HHHHHHHH | Multiplication result high byte
-    // Signed 24-bit result of M7A (signed 16-bit) * M7B (signed 8-bit)
+    /// $2134/$2135/$2136 - MPYL/MPYM/MPYH (R24, read-only)
+    /// MPYL ($2134): Bits: LLLLLLLL | Multiplication result low byte
+    /// MPYM ($2135): Bits: MMMMMMMM | Multiplication result middle byte
+    /// MPYH ($2136): Bits: HHHHHHHH | Multiplication result high byte
+    /// Signed 24-bit result of M7A (signed 16-bit) * M7B (signed 8-bit)
     pub mpy: u32,
 
-    // $2137 - SLHV (R8, read-only)
+    /// $2137 - SLHV (R8, read-only)
     pub slhv: u8, // Bits: xxxxxxxx | CPU open bus. On read: counter_latch = 1
 
-    // $2138 - OAMDATAREAD (R8, read-only)
+    /// $2138 - OAMDATAREAD (R8, read-only)
     pub oamdataread: u8, // Bits: DDDDDDDD | Read OAM data byte, increments OAMADD
 
-    // $2139/$213A - VMDATALREAD/VMDATAHREAD (R16, read-only)
-    // VMDATALREAD ($2139): Bits: LLLLLLLL | VRAM data read low (from vram_latch)
-    // VMDATAHREAD ($213A): Bits: HHHHHHHH | VRAM data read high (from vram_latch)
-    // Increments VMADD after read according to VMAIN setting
+    /// $2139/$213A - VMDATALREAD/VMDATAHREAD (R16, read-only)
+    /// VMDATALREAD ($2139): Bits: LLLLLLLL | VRAM data read low (from vram_latch)
+    /// VMDATAHREAD ($213A): Bits: HHHHHHHH | VRAM data read high (from vram_latch)
+    /// Increments VMADD after read according to VMAIN setting
     pub vmdataread: u16,
 
-    // $213B - CGDATAREAD (R8x2, read-only)
-    // Bits: xBBBBBGG GGGRRRRR | CGRAM data read, increments CGADD after each word read
-    // On read: if cgram_byte == 0: value = CGDATA.low
-    //          if cgram_byte == 1: value = CGDATA.high
-    //          cgram_byte = ~cgram_byte
+    /// $213B - CGDATAREAD (R8x2, read-only)
+    /// Bits: xBBBBBGG GGGRRRRR | CGRAM data read, increments CGADD after each word read
+    /// On read: if cgram_byte == 0: value = CGDATA.low
+    ///          if cgram_byte == 1: value = CGDATA.high
+    ///          cgram_byte = ~cgram_byte
     pub cgdataread: u16,
 
-    // $213C - OPHCT (R8x2, read-only)
-    // Bits: xxxxxxxH HHHHHHHH | Output horizontal counter (9 bits)
-    // On read: if ophct_byte == 0: value = OPHCT.low
-    //          if ophct_byte == 1: value = OPHCT.high
-    //          ophct_byte = ~ophct_byte
+    /// $213C - OPHCT (R8x2, read-only)
+    /// Bits: xxxxxxxH HHHHHHHH | Output horizontal counter (9 bits)
+    /// On read: if ophct_byte == 0: value = OPHCT.low
+    ///          if ophct_byte == 1: value = OPHCT.high
+    ///          ophct_byte = ~ophct_byte
     pub ophct: u16,
 
-    // $213D - OPVCT (R8x2, read-only)
-    // Bits: xxxxxxxV VVVVVVVV | Output vertical counter (9 bits)
-    // On read: if opvct_byte == 0: value = OPVCT.low
-    //          if opvct_byte == 1: value = OPVCT.high
-    //          opvct_byte = ~opvct_byte
+    /// $213D - OPVCT (R8x2, read-only)
+    /// Bits: xxxxxxxV VVVVVVVV | Output vertical counter (9 bits)
+    /// On read: if opvct_byte == 0: value = OPVCT.low
+    ///          if opvct_byte == 1: value = OPVCT.high
+    ///          opvct_byte = ~opvct_byte
     pub opvct: u16,
 
-    // $213E - STAT77 (R8, read-only)
+    /// $213E - STAT77 (R8, read-only)
     pub stat77: u8, // Bits: TRMxVVVV | Time over/sprite overflow (T), range over/tile overflow (R), master/slave (M), PPU1 open bus (x), PPU1 version (V)
 
-    // $213F - STAT78 (R8, read-only)
-    // On read: counter_latch = 0; ophct_byte = 0; opvct_byte = 0
+    /// $213F - STAT78 (R8, read-only)
+    /// On read: counter_latch = 0; ophct_byte = 0; opvct_byte = 0
     pub stat78: u8, // Bits: FLxMVVVV | Interlace field (F), counter latch (L), PPU2 open bus (x), NTSC/PAL (M), PPU2 version (V)
 
     // ============================================================
     // Latches (internal hardware state, not directly addressable)
     // ============================================================
 
-    // Shared latch for all BGnHOFS/BGnVOFS writes ($210D-$2114)
-    // bgofs_latch is written on every BGnHOFS and BGnVOFS write
-    // bghofs_latch is written on every BGnHOFS write only
+    /// Shared latch for all BGnHOFS/BGnVOFS writes ($210D-$2114)
+    /// bgofs_latch is written on every BGnHOFS and BGnVOFS write
+    /// bghofs_latch is written on every BGnHOFS write only
     pub bgofs_latch: u8,
     pub bghofs_latch: u8,
 

--- a/ppu/src/registers.rs
+++ b/ppu/src/registers.rs
@@ -3,202 +3,246 @@ use crate::write_twice::WriteTwice;
 /// PPU Registers placeholder definitions
 /// Each field is a placeholder; actual behavior, latches, buffering, and timing to implement later.
 pub struct PPURegisters {
-    // $2100 - INIDISP
+    // $2100 - INIDISP (W8)
     pub inidisp: u8, // Bits: F...BBBB | Forced blanking (F), screen brightness (B).
 
-    // $2101 - OBJSEL
+    // $2101 - OBJSEL (W8)
     pub objsel: u8, // Bits: SSSNNbBB | OBJ sprite size (S), name secondary select (N), name base address (B).
 
-    // $2102 - OAMADDL
-    pub oamaddl: u8, // Bits: AAAAAAAA | OAM word address low
+    // $2102/$2103 - OAMADDL/OAMADDH (W16)
+    // OAMADDL ($2102): Bits: AAAAAAAA | OAM word address low
+    // OAMADDH ($2103): Bits: P.......B | Priority rotation (P), address high bit (B)
+    pub oamadd: u16,
 
-    // $2103 - OAMADDH
-    pub oamaddh: u8, // Bits: P...B | Priority rotation (P), address high bit (B)
-
-    // $2104 - OAMDATA
+    // $2104 - OAMDATA (W8x2)
     pub oamdata: u8, // Bits: DDDDDDDD | OAM data write byte, increments OAMADD
 
-    // $2105 - BGMODE
+    // $2105 - BGMODE (W8)
     pub bgmode: u8, // Bits: 4321PMMM | Tilemap tile size (#), BG3 priority (P), BG mode (M)
 
-    // $2106 - MOSAIC
+    // $2106 - MOSAIC (W8)
     pub mosaic: u8, // Bits: SSSS4321 | Mosaic size (S), mosaic BG enable (#)
 
-    // $2107 - BG1SC
-    pub bg1sc: u8, // Bits: AAAAAAYX | Tilemap VRAM address (A), vertical/horizontal tilemap count
+    // $2107/$2108/$2109/$210A - BG1SC/BG2SC/BG3SC/BG4SC (W8)
+    // Bits: AAAAAAYX | Tilemap VRAM address (A), vertical tilemap count (Y), horizontal tilemap count (X)
+    // bgsc[0] = BG1SC ($2107), bgsc[1] = BG2SC ($2108), bgsc[2] = BG3SC ($2109), bgsc[3] = BG4SC ($210A)
+    pub bgsc: [u8; 4],
 
-    // $2108 - BG2SC
-    pub bg2sc: u8, // Bits: AAAAAAYX | Tilemap VRAM address (A), vertical/horizontal tilemap count
-
-    // $2109 - BG3SC
-    pub bg3sc: u8, // Bits: AAAAAAYX | Tilemap VRAM address (A), vertical/horizontal tilemap count
-
-    // $210A - BG4SC
-    pub bg4sc: u8, // Bits: AAAAAAYX | Tilemap VRAM address (A), vertical/horizontal tilemap count
-
-    // $210B - BG12NBA
+    // $210B - BG12NBA (W8)
     pub bg12nba: u8, // Bits: BBBBAAAA | BG2 CHR base address (B), BG1 CHR base address (A)
 
-    // $210C - BG34NBA
+    // $210C - BG34NBA (W8)
     pub bg34nba: u8, // Bits: DDDDCCCC | BG4 CHR base address (D), BG3 CHR base address (C)
 
-    // $210D - BG1HOFS
-    pub bg1hofs: u16, // Bits: .... ..XX XXXX XXXX | BG1 horizontal scroll (X)
+    // $210D - BG1HOFS (W8x2, shares address with M7HOFS)
+    // Bits: ......XX XXXXXXXX | BG1 horizontal scroll
+    // On write: BG1HOFS = (value << 8) | (bgofs_latch & ~7) | (bghofs_latch & 7)
+    //           bgofs_latch = value; bghofs_latch = value
+    pub bg1hofs: u16,
 
-    // $210E - M7HOFS
-    pub m7hofs: u16, // Bits: .... ..XX XXXX XXXX | Mode 7 horizontal scroll (x)
+    // $210D - M7HOFS (W8x2, shares address with BG1HOFS)
+    // Bits: ...XXXXX XXXXXXXX | Mode 7 horizontal scroll (signed)
+    // On write: M7HOFS = (value << 8) | mode7_latch; mode7_latch = value
+    pub m7hofs: u16,
 
-    // $210F - BG1VOFS
-    pub bg1vofs: u16, // Bits: .... ..YY YYYY YYYY | BG1 vertical scroll (Y)
+    // $210E - BG1VOFS (W8x2, shares address with M7VOFS)
+    // Bits: ......YY YYYYYYYY | BG1 vertical scroll
+    // On write: BG1VOFS = (value << 8) | bgofs_latch; bgofs_latch = value
+    pub bg1vofs: u16,
 
-    // $2110 - M7VOFS
-    pub m7vofs: u16, // Bits: .... ..YY YYYY YYYY | Mode 7 vertical scroll (y)
+    // $210E - M7VOFS (W8x2, shares address with BG1VOFS)
+    // Bits: ...YYYYY YYYYYYYY | Mode 7 vertical scroll (signed)
+    // On write: M7VOFS = (value << 8) | mode7_latch; mode7_latch = value
+    pub m7vofs: u16,
 
-    // $2111 - BG2HOFS
-    pub bg2hofs: u16, // Bits: .... ..XX XXXX XXXX | BG2 horizontal scroll (X)
+    // $210F/$2110/$2111/$2112/$2113/$2114 - BG2HOFS/BG2VOFS/BG3HOFS/BG3VOFS/BG4HOFS/BG4VOFS (W8x2)
+    // bghofs[0] = BG2HOFS ($210F), bghofs[1] = BG3HOFS ($2111), bghofs[2] = BG4HOFS ($2113)
+    // Bits: ......XX XXXXXXXX | BGn horizontal scroll
+    // On write: BGnHOFS = (value << 8) | (bgofs_latch & ~7) | (bghofs_latch & 7)
+    //           bgofs_latch = value; bghofs_latch = value
+    pub bghofs: [u16; 3],
 
-    // $2112 - BG2VOFS
-    pub bg2vofs: u16, // Bits: .... ..YY YYYY YYYY | BG2 vertical scroll (Y)
+    // bgvofs[0] = BG2VOFS ($2110), bgvofs[1] = BG3VOFS ($2112), bgvofs[2] = BG4VOFS ($2114)
+    // Bits: ......YY YYYYYYYY | BGn vertical scroll
+    // On write: BGnVOFS = (value << 8) | bgofs_latch; bgofs_latch = value
+    pub bgvofs: [u16; 3],
 
-    // $2113 - BG3HOFS
-    pub bg3hofs: u16, // Bits: .... ..XX XXXX XXXX | BG3 horizontal scroll (X)
-
-    // $2114 - BG3VOFS
-    pub bg3vofs: u16, // Bits: .... ..YY YYYY YYYY | BG3 vertical scroll (Y)
-
-    // $2115 - VMAIN
+    // $2115 - VMAIN (W8)
     pub vmain: u8, // Bits: M...RRII | VRAM address increment mode (M), remapping (R), increment size (I)
 
-    // $2116 - VMADDL
-    pub vmaddl: u8, // Bits: LLLLLLLL | VRAM word address low
+    // $2116/$2117 - VMADDL/VMADDH (W16)
+    // VMADDL ($2116): Bits: LLLLLLLL | VRAM word address low
+    // VMADDH ($2117): Bits: hHHHHHHH | VRAM word address high
+    pub vmadd: u16,
 
-    // $2117 - VMADDH
-    pub vmaddh: u8, // Bits: hHHHHHHH | VRAM word address high
+    // $2118/$2119 - VMDATAL/VMDATAH (W16)
+    // VMDATAL ($2118): Bits: LLLLLLLL | VRAM data write low
+    // VMDATAH ($2119): Bits: HHHHHHHH | VRAM data write high
+    // Increments VMADD after write according to VMAIN setting
+    pub vmdata: u16,
 
-    // $2118 - VMDATAL
-    pub vmdatal: u8, // Bits: LLLLLLLL | VRAM data write low, increments VMADD
+    // $211A - M7SEL (W8)
+    pub m7sel: u8, // Bits: RF....YX | Mode 7 tilemap repeat (R), fill (F), flip vertical (Y), flip horizontal (X)
 
-    // $2119 - VMDATAH
-    pub vmdatah: u8, // Bits: HHHHHHHH | VRAM data write high, increments VMADD
+    // $211B - M7A (W8x2)
+    // Bits: DDDDDDDD dddddddd | Mode 7 matrix A (8.8 fixed point) / 16-bit signed multiplication factor
+    // On write: M7A = (value << 8) | mode7_latch; mode7_latch = value
+    pub m7a: u16,
 
-    // $211A - M7SEL
-    pub m7sel: u8, // Bits: RF..YX | Mode 7 tilemap repeat (R), fill (F), flip vertical (Y), flip horizontal (X)
+    // $211C - M7B (W8x2)
+    // Bits: DDDDDDDD dddddddd | Mode 7 matrix B (8.8 fixed point) / 8-bit signed multiplication factor
+    // On write: M7B = (value << 8) | mode7_latch; mode7_latch = value
+    pub m7b: u16,
 
-    // $211B - M7A
-    pub m7a: u16, // Mode 7 matrix A
+    // $211D - M7C (W8x2)
+    // Bits: DDDDDDDD dddddddd | Mode 7 matrix C (8.8 fixed point)
+    // On write: M7C = (value << 8) | mode7_latch; mode7_latch = value
+    pub m7c: u16,
 
-    // $211C - M7B
-    pub m7b: u16, // Mode 7 matrix B
+    // $211E - M7D (W8x2)
+    // Bits: DDDDDDDD dddddddd | Mode 7 matrix D (8.8 fixed point)
+    // On write: M7D = (value << 8) | mode7_latch; mode7_latch = value
+    pub m7d: u16,
 
-    // $211D - M7C
-    pub m7c: u16, // Mode 7 matrix C
+    // $211F - M7X (W8x2)
+    // Bits: ...XXXXX XXXXXXXX | Mode 7 center X (signed)
+    // On write: M7X = (value << 8) | mode7_latch; mode7_latch = value
+    pub m7x: u16,
 
-    // $211E - M7D
-    pub m7d: u16, // Mode 7 matrix D
+    // $2120 - M7Y (W8x2)
+    // Bits: ...YYYYY YYYYYYYY | Mode 7 center Y (signed)
+    // On write: M7Y = (value << 8) | mode7_latch; mode7_latch = value
+    pub m7y: u16,
 
-    // $211F - M7X
-    pub m7x: u16, // Mode 7 center X
+    // $2121 - CGADD (W8)
+    pub cgadd: u8, // Bits: AAAAAAAA | CGRAM word address. On write: cgram_byte = 0
 
-    // $2120 - M7Y
-    pub m7y: u16, // Mode 7 center Y
+    // $2122 - CGDATA (W8x2)
+    // Bits: .BBBBBGG GGGRRRRR | CGRAM data write, increments CGADD after each word write
+    // On write: if cgram_byte == 0: cgram_latch = value
+    //           if cgram_byte == 1: CGDATA = (value << 8) | cgram_latch
+    //           cgram_byte = ~cgram_byte
+    pub cgdata: u16,
 
-    // $2121 - CGADD
-    pub cgadd: u8, // CGRAM word address
+    // $2123 - W12SEL (W8)
+    pub w12sel: u8, // Bits: DdCcBbAa | Enable (ABCD) and invert (abcd) windows for BG1 (AB) and BG2 (CD)
 
-    // $2122 - CGDATA
-    pub cgdata: u16, // CGRAM data write, increments CGADD
+    // $2124 - W34SEL (W8)
+    pub w34sel: u8, // Bits: HhGgFfEe | Enable (EFGH) and invert (efgh) windows for BG3 (EF) and BG4 (GH)
 
-    // $2123 - W12SEL
-    pub w12sel: u8, // Enable/invert windows for BG1/BG2
+    // $2125 - WOBJSEL (W8)
+    pub wobjsel: u8, // Bits: LlKkJjIi | Enable (IJKL) and invert (ijkl) windows for OBJ (IJ) and color (KL)
 
-    // $2124 - W34SEL
-    pub w34sel: u8, // Enable/invert windows for BG3/BG4
+    // $2126 - WH0 (W8)
+    pub wh0: u8, // Bits: LLLLLLLL | Window 1 left edge position
 
-    // $2125 - WOBJSEL
-    pub wobjsel: u8, // Enable/invert windows for OBJ
+    // $2127 - WH1 (W8)
+    pub wh1: u8, // Bits: RRRRRRRR | Window 1 right edge position
 
-    // $2126 - WH0
-    pub wh0: u8, // Window 1 left position
+    // $2128 - WH2 (W8)
+    pub wh2: u8, // Bits: LLLLLLLL | Window 2 left edge position
 
-    // $2127 - WH1
-    pub wh1: u8, // Window 1 right position
+    // $2129 - WH3 (W8)
+    pub wh3: u8, // Bits: RRRRRRRR | Window 2 right edge position
 
-    // $2128 - WH2
-    pub wh2: u8, // Window 2 left position
+    // $212A - WBGLOG (W8)
+    pub wbglog: u8, // Bits: 44332211 | Window mask logic for BG layers (00=OR, 01=AND, 10=XOR, 11=XNOR)
 
-    // $2129 - WH3
-    pub wh3: u8, // Window 2 right position
+    // $212B - WOBJLOG (W8)
+    pub wobjlog: u8, // Bits: ....CCOO | Window mask logic for OBJ (O) and color (C)
 
-    // $212A - WBGLOG
-    pub wbglog: u8, // Window mask logic for BG layers
+    // $212C - TM (W8)
+    pub tm: u8, // Bits: ...O4321 | Main screen layer enable (OBJ, BG4-BG1)
 
-    // $212B - WOBJLOG
-    pub wobjlog: u8, // Window mask logic for OBJ and color
+    // $212D - TS (W8)
+    pub ts: u8, // Bits: ...O4321 | Sub screen layer enable (OBJ, BG4-BG1)
 
-    // $212C - TM
-    pub tm: u8, // Main screen layer enable
+    // $212E - TMW (W8)
+    pub tmw: u8, // Bits: ...O4321 | Main screen layer window enable (OBJ, BG4-BG1)
 
-    // $212D - TS
-    pub ts: u8, // Sub screen layer enable
+    // $212F - TSW (W8)
+    pub tsw: u8, // Bits: ...O4321 | Sub screen layer window enable (OBJ, BG4-BG1)
 
-    // $212E - TMW
-    pub tmw: u8, // Main screen layer window enable
+    // $2130 - CGWSEL (W8)
+    pub cgwsel: u8, // Bits: MMSS..AD | Main/sub screen color window black/transparent (MS), fixed/subscreen (A), direct color (D)
 
-    // $212F - TSW
-    pub tsw: u8, // Sub screen layer window enable
+    // $2131 - CGADSUB (W8)
+    pub cgadsub: u8, // Bits: MHBO4321 | Color math operator (M), half (H), backdrop (B), layer enable (O4321)
 
-    // $2130 - CGWSEL
-    pub cgwsel: u8, // Main/sub screen color window, fixed/subscreen, direct color
+    // $2132 - COLDATA (W8)
+    pub coldata: u8, // Bits: BGRCCCCC | Fixed color channel select (BGR) and value (C)
 
-    // $2131 - CGADSUB
-    pub cgadsub: u8, // Color math add/subtract, half, backdrop, layer enable
+    // $2133 - SETINI (W8)
+    pub setini: u8, // Bits: EX..HOiI | External sync (E), EXTBG (X), Hi-res (H), Overscan (O), OBJ interlace (i), Screen interlace (I)
 
-    // $2132 - COLDATA
-    pub coldata: u8, // Fixed color channel select (BGR) and value
+    // $2134/$2135/$2136 - MPYL/MPYM/MPYH (R24, read-only)
+    // MPYL ($2134): Bits: LLLLLLLL | Multiplication result low byte
+    // MPYM ($2135): Bits: MMMMMMMM | Multiplication result middle byte
+    // MPYH ($2136): Bits: HHHHHHHH | Multiplication result high byte
+    // Signed 24-bit result of M7A (signed 16-bit) * M7B (signed 8-bit)
+    pub mpy: u32,
 
-    // $2133 - SETINI
-    pub setini: u8, // External sync, EXTBG, Hi-res, Overscan, OBJ interlace, Screen interlace
+    // $2137 - SLHV (R8, read-only)
+    pub slhv: u8, // Bits: xxxxxxxx | CPU open bus. On read: counter_latch = 1
 
-    // $2134 - MPYL
-    pub mpyl: u8, // Multiplication result low byte
+    // $2138 - OAMDATAREAD (R8, read-only)
+    pub oamdataread: u8, // Bits: DDDDDDDD | Read OAM data byte, increments OAMADD
 
-    // $2135 - MPYM
-    pub mpym: u8, // Multiplication result middle byte
+    // $2139/$213A - VMDATALREAD/VMDATAHREAD (R16, read-only)
+    // VMDATALREAD ($2139): Bits: LLLLLLLL | VRAM data read low (from vram_latch)
+    // VMDATAHREAD ($213A): Bits: HHHHHHHH | VRAM data read high (from vram_latch)
+    // Increments VMADD after read according to VMAIN setting
+    pub vmdataread: u16,
 
-    // $2136 - MPYH
-    pub mpyh: u8, // Multiplication result high byte
+    // $213B - CGDATAREAD (R8x2, read-only)
+    // Bits: xBBBBBGG GGGRRRRR | CGRAM data read, increments CGADD after each word read
+    // On read: if cgram_byte == 0: value = CGDATA.low
+    //          if cgram_byte == 1: value = CGDATA.high
+    //          cgram_byte = ~cgram_byte
+    pub cgdataread: u16,
 
-    // $2137 - SLHV
-    pub slhv: u8, // Software latch for H/V counters
+    // $213C - OPHCT (R8x2, read-only)
+    // Bits: xxxxxxxH HHHHHHHH | Output horizontal counter (9 bits)
+    // On read: if ophct_byte == 0: value = OPHCT.low
+    //          if ophct_byte == 1: value = OPHCT.high
+    //          ophct_byte = ~ophct_byte
+    pub ophct: u16,
 
-    // $2138 - OAMDATAREAD
-    pub oamdataread: u8, // Read OAM data byte
+    // $213D - OPVCT (R8x2, read-only)
+    // Bits: xxxxxxxV VVVVVVVV | Output vertical counter (9 bits)
+    // On read: if opvct_byte == 0: value = OPVCT.low
+    //          if opvct_byte == 1: value = OPVCT.high
+    //          opvct_byte = ~opvct_byte
+    pub opvct: u16,
 
-    // $2139 - VMDATALREAD
-    pub vmdatalread: u8, // VRAM data read low
+    // $213E - STAT77 (R8, read-only)
+    pub stat77: u8, // Bits: TRMxVVVV | Time over/sprite overflow (T), range over/tile overflow (R), master/slave (M), PPU1 open bus (x), PPU1 version (V)
 
-    // $213A - VMDATAHREAD
-    pub vmdatahread: u8, // VRAM data read high
+    // $213F - STAT78 (R8, read-only)
+    // On read: counter_latch = 0; ophct_byte = 0; opvct_byte = 0
+    pub stat78: u8, // Bits: FLxMVVVV | Interlace field (F), counter latch (L), PPU2 open bus (x), NTSC/PAL (M), PPU2 version (V)
 
-    // $213B - CGDATAREAD
-    pub cgdataread: u16, // CGRAM data read
+    // ============================================================
+    // Latches (internal hardware state, not directly addressable)
+    // ============================================================
 
-    // $213C - OPHCT
-    pub ophct: u16, // Output horizontal counter
+    // Shared latch for all BGnHOFS/BGnVOFS writes ($210D-$2114)
+    // bgofs_latch is written on every BGnHOFS and BGnVOFS write
+    // bghofs_latch is written on every BGnHOFS write only
+    pub bgofs_latch: u8,
+    pub bghofs_latch: u8,
 
-    // $213D - OPVCT
-    pub opvct: u16, // Output vertical counter
+    // Shared latch for all Mode 7 writes ($210D-$2120, $211B-$211E)
+    pub mode7_latch: u8,
 
-    // $213E - STAT77
-    pub stat77: u8, // Sprite overflow, sprite tile overflow, master/slave, PPU1 version
+    // Internal flip-flop for CGDATA ($2122) and CGDATAREAD ($213B) - shared per hardware
+    pub cgram_latch: WriteTwice,
 
-    // $213F - STAT78
-    pub stat78: u8, // Interlace field, counter latch, NTSC/PAL, PPU2 version
+    // Internal flip-flop for OPHCT ($213C) reads
+    pub ophct_latch: WriteTwice,
 
-    // Latches
-    pub bg1hofs_latch: WriteTwice,
-    pub bg1vofs_latch: WriteTwice,
-    pub cgdata_latch: WriteTwice,
+    // Internal flip-flop for OPVCT ($213D) reads
+    pub opvct_latch: WriteTwice,
 }
 
 impl PPURegisters {
@@ -206,30 +250,22 @@ impl PPURegisters {
         Self {
             inidisp: 0,
             objsel: 0,
-            oamaddl: 0,
-            oamaddh: 0,
+            oamadd: 0,
             oamdata: 0,
             bgmode: 0,
             mosaic: 0,
-            bg1sc: 0,
-            bg2sc: 0,
-            bg3sc: 0,
-            bg4sc: 0,
+            bgsc: [0; 4],
             bg12nba: 0,
             bg34nba: 0,
             bg1hofs: 0,
             m7hofs: 0,
             bg1vofs: 0,
             m7vofs: 0,
-            bg2hofs: 0,
-            bg2vofs: 0,
-            bg3hofs: 0,
-            bg3vofs: 0,
+            bghofs: [0; 3],
+            bgvofs: [0; 3],
             vmain: 0,
-            vmaddl: 0,
-            vmaddh: 0,
-            vmdatal: 0,
-            vmdatah: 0,
+            vmadd: 0,
+            vmdata: 0,
             m7sel: 0,
             m7a: 0,
             m7b: 0,
@@ -256,21 +292,21 @@ impl PPURegisters {
             cgadsub: 0,
             coldata: 0,
             setini: 0,
-            mpyl: 0,
-            mpym: 0,
-            mpyh: 0,
+            mpy: 0,
             slhv: 0,
             oamdataread: 0,
-            vmdatalread: 0,
-            vmdatahread: 0,
+            vmdataread: 0,
             cgdataread: 0,
             ophct: 0,
             opvct: 0,
             stat77: 0,
             stat78: 0,
-            bg1hofs_latch: WriteTwice::new(),
-            bg1vofs_latch: WriteTwice::new(),
-            cgdata_latch: WriteTwice::new(),
+            bgofs_latch: 0,
+            bghofs_latch: 0,
+            mode7_latch: 0,
+            cgram_latch: WriteTwice::new(),
+            ophct_latch: WriteTwice::new(),
+            opvct_latch: WriteTwice::new(),
         }
     }
 
@@ -286,122 +322,37 @@ impl PPURegisters {
         self.bgmode & 0x07
     }
 
+    // Tilemap addresses - bgsc[n] bits[7:2] in 0x400-word steps
     pub fn bg1_tilemap_addr(&self) -> u16 {
-        (self.bg1sc as u16 >> 2) * 0x400
+        (self.bgsc[0] as u16 >> 2) * 0x400
     }
 
+    pub fn bg2_tilemap_addr(&self) -> u16 {
+        (self.bgsc[1] as u16 >> 2) * 0x400
+    }
+
+    pub fn bg3_tilemap_addr(&self) -> u16 {
+        (self.bgsc[2] as u16 >> 2) * 0x400
+    }
+
+    pub fn bg4_tilemap_addr(&self) -> u16 {
+        (self.bgsc[3] as u16 >> 2) * 0x400
+    }
+
+    // CHR base addresses - BG12NBA low/high nibble, BG34NBA low/high nibble, in 0x1000-word steps
     pub fn bg1_tiledata_addr(&self) -> u16 {
-        (self.bg12nba as u16) << 12
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // ============================================================
-    // bg1_enabled
-    // ============================================================
-
-    /// bit 0 of TM set -> BG1 enabled.
-    #[test]
-    fn test_bg1_enabled_true() {
-        let mut regs = PPURegisters::new();
-        regs.tm = 0x01;
-        assert!(regs.bg1_enabled());
+        (self.bg12nba as u16 & 0x0F) << 12
     }
 
-    /// bit 0 of TM clear -> BG1 disabled.
-    #[test]
-    fn test_bg1_enabled_false() {
-        let mut regs = PPURegisters::new();
-        regs.tm = 0xFE;
-        assert!(!regs.bg1_enabled());
+    pub fn bg2_tiledata_addr(&self) -> u16 {
+        (self.bg12nba as u16 >> 4) << 12
     }
 
-    /// Upper bits of TM must not affect the result.
-    #[test]
-    fn test_bg1_enabled_ignores_upper_bits() {
-        let mut regs = PPURegisters::new();
-        regs.tm = 0xFF;
-        assert!(regs.bg1_enabled());
-        regs.tm = 0x1E;
-        assert!(!regs.bg1_enabled());
+    pub fn bg3_tiledata_addr(&self) -> u16 {
+        (self.bg34nba as u16 & 0x0F) << 12
     }
 
-    // ============================================================
-    // bg_mode
-    // ============================================================
-
-    /// Only the lower 3 bits of BGMODE are returned.
-    #[test]
-    fn test_bg_mode_lower_3_bits() {
-        let mut regs = PPURegisters::new();
-        regs.bgmode = 0b11110111;
-        assert_eq!(regs.bg_mode(), 7);
-    }
-
-    /// Upper bits of BGMODE are masked out.
-    #[test]
-    fn test_bg_mode_masks_upper_bits() {
-        let mut regs = PPURegisters::new();
-        regs.bgmode = 0b11111000;
-        assert_eq!(regs.bg_mode(), 0);
-    }
-
-    // ============================================================
-    // bg1_tilemap_addr
-    // ============================================================
-
-    /// BG1SC bits[7:2] select the tilemap word address in 0x400-word steps.
-    #[test]
-    fn test_bg1_tilemap_addr_derivation() {
-        let mut regs = PPURegisters::new();
-        regs.bg1sc = 0b00000100; // bits[7:2] = 1 -> 1 * 0x400
-        assert_eq!(regs.bg1_tilemap_addr(), 0x0400);
-    }
-
-    /// BG1SC = 0 -> tilemap at address 0.
-    #[test]
-    fn test_bg1_tilemap_addr_zero() {
-        let mut regs = PPURegisters::new();
-        regs.bg1sc = 0x00;
-        assert_eq!(regs.bg1_tilemap_addr(), 0x0000);
-    }
-
-    /// BG1SC = 0xFF -> bits[7:2] = 0x3F -> 0x3F * 0x400.
-    #[test]
-    fn test_bg1_tilemap_addr_maximum() {
-        let mut regs = PPURegisters::new();
-        regs.bg1sc = 0xFF;
-        assert_eq!(regs.bg1_tilemap_addr(), 0x3F * 0x400);
-    }
-
-    // ============================================================
-    // bg1_tiledata_addr
-    // ============================================================
-
-    /// BG12NBA low nibble selects the CHR base address in 0x1000-word steps.
-    #[test]
-    fn test_bg1_tiledata_addr_derivation() {
-        let mut regs = PPURegisters::new();
-        regs.bg12nba = 0x01;
-        assert_eq!(regs.bg1_tiledata_addr(), 0x1000);
-    }
-
-    /// BG12NBA = 0 -> CHR base at address 0.
-    #[test]
-    fn test_bg1_tiledata_addr_zero() {
-        let mut regs = PPURegisters::new();
-        regs.bg12nba = 0x00;
-        assert_eq!(regs.bg1_tiledata_addr(), 0x0000);
-    }
-
-    /// BG12NBA = 0x0F -> 0xF << 12 = 0xF000.
-    #[test]
-    fn test_bg1_tiledata_addr_maximum() {
-        let mut regs = PPURegisters::new();
-        regs.bg12nba = 0x0F;
-        assert_eq!(regs.bg1_tiledata_addr(), 0xF000);
+    pub fn bg4_tiledata_addr(&self) -> u16 {
+        (self.bg34nba as u16 >> 4) << 12
     }
 }

--- a/ppu/src/vram.rs
+++ b/ppu/src/vram.rs
@@ -21,8 +21,8 @@ impl VRAM {
     // Address increment logic
     // ============================================================
 
-    pub fn increment_amount(vmain: u8) -> u16 {
-        match vmain & 0b11 {
+    pub fn increment_amount(regs: &PPURegisters) -> u16 {
+        match regs.vmain & 0b11 {
             0 => 1,
             1 => 32,
             2 | 3 => 128,
@@ -30,16 +30,16 @@ impl VRAM {
         }
     }
 
-    pub fn increment_after_low(vmain: u8) -> bool {
-        (vmain & 0x80) == 0
+    pub fn increment_after_low(regs: &PPURegisters) -> bool {
+        (regs.vmain & 0x80) == 0
     }
 
-    pub fn increment_after_high(vmain: u8) -> bool {
-        (vmain & 0x80) != 0
+    pub fn increment_after_high(regs: &PPURegisters) -> bool {
+        (regs.vmain & 0x80) != 0
     }
 
-    fn increment_vmadd(vmain: u8, vmadd: &mut u16) {
-        *vmadd = vmadd.wrapping_add(Self::increment_amount(vmain)) & 0x7FFF;
+    fn increment_vmadd(regs: &mut PPURegisters) {
+        regs.vmadd = regs.vmadd.wrapping_add(Self::increment_amount(regs)) & 0x7FFF;
     }
 
     // ============================================================
@@ -65,37 +65,37 @@ impl VRAM {
     // VRAM DATA WRITE ($2118 / $2119)
     // ============================================================
 
-    pub fn write_vmdata(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters, value: u16) {
-        let addr = (*vmadd & 0x7FFF) as usize;
+    pub fn write_vmdata(&mut self, regs: &mut PPURegisters, value: u16) {
+        let addr = (regs.vmadd & 0x7FFF) as usize;
         *self.memory[addr].lo_mut() = *value.lo();
 
-        if Self::increment_after_low(*vmain) {
-            Self::increment_vmadd(*vmain, vmadd);
+        if Self::increment_after_low(regs) {
+            Self::increment_vmadd(regs);
         }
 
-        let addr = (*vmadd & 0x7FFF) as usize;
+        let addr = (regs.vmadd & 0x7FFF) as usize;
         *self.memory[addr].hi_mut() = *value.hi();
 
-        if Self::increment_after_high(*vmain) {
-            Self::increment_vmadd(*vmain, vmadd);
+        if Self::increment_after_high(regs) {
+            Self::increment_vmadd(regs);
         }
     }
 
-    pub fn write_vmdatal(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters, value: u8) {
-        let addr = (*vmadd & 0x7FFF) as usize;
+    pub fn write_vmdatal(&mut self, regs: &mut PPURegisters, value: u8) {
+        let addr = (regs.vmadd & 0x7FFF) as usize;
         *self.memory[addr].lo_mut() = value;
 
-        if Self::increment_after_low(*vmain) {
-            Self::increment_vmadd(*vmain, vmadd);
+        if Self::increment_after_low(regs) {
+            Self::increment_vmadd(regs);
         }
     }
 
-    pub fn write_vmdatah(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters, value: u8) {
-        let addr = (*vmadd & 0x7FFF) as usize;
+    pub fn write_vmdatah(&mut self, regs: &mut PPURegisters, value: u8) {
+        let addr = (regs.vmadd & 0x7FFF) as usize;
         *self.memory[addr].hi_mut() = value;
 
-        if Self::increment_after_high(*vmain) {
-            Self::increment_vmadd(*vmain, vmadd);
+        if Self::increment_after_high(regs) {
+            Self::increment_vmadd(regs);
         }
     }
 
@@ -103,41 +103,41 @@ impl VRAM {
     // VRAM DATA READ ($2139 / $213A)
     // ============================================================
 
-    pub fn read_vmdata(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters) -> u16 {
+    pub fn read_vmdata(&mut self, regs: &mut PPURegisters) -> u16 {
         let lo = *self.vram_latch.lo();
 
-        if Self::increment_after_low(*vmain) {
-            Self::increment_vmadd(*vmain, vmadd);
-            self.load_latch(*vmadd);
+        if Self::increment_after_low(regs) {
+            Self::increment_vmadd(regs);
+            self.load_latch(regs.vmadd);
         }
 
         let hi = *self.vram_latch.hi();
 
-        if Self::increment_after_high(*vmain) {
-            Self::increment_vmadd(*vmain, vmadd);
-            self.load_latch(*vmadd);
+        if Self::increment_after_high(regs) {
+            Self::increment_vmadd(regs);
+            self.load_latch(regs.vmadd);
         }
 
         (lo as u16) | ((hi as u16) << 8)
     }
 
-    pub fn read_vmdatal(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters) -> u8 {
+    pub fn read_vmdatal(&mut self, regs: &mut PPURegisters) -> u8 {
         let value = *self.vram_latch.lo();
 
-        if Self::increment_after_low(*vmain) {
-            Self::increment_vmadd(*vmain, vmadd);
-            self.load_latch(*vmadd);
+        if Self::increment_after_low(regs) {
+            Self::increment_vmadd(regs);
+            self.load_latch(regs.vmadd);
         }
 
         value
     }
 
-    pub fn read_vmdatah(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters) -> u8 {
+    pub fn read_vmdatah(&mut self, regs: &mut PPURegisters) -> u8 {
         let value = *self.vram_latch.hi();
 
-        if Self::increment_after_high(*vmain) {
-            Self::increment_vmadd(*vmain, vmadd);
-            self.load_latch(*vmadd);
+        if Self::increment_after_high(regs) {
+            Self::increment_vmadd(regs);
+            self.load_latch(regs.vmadd);
         }
 
         value
@@ -200,14 +200,14 @@ mod tests {
     /// Upper bits must be ignored.
     #[test]
     fn test_increment_amount() {
-        assert_eq!(VRAM::increment_amount(0b00), 1);
-        assert_eq!(VRAM::increment_amount(0b01), 32);
-        assert_eq!(VRAM::increment_amount(0b10), 128);
-        assert_eq!(VRAM::increment_amount(0b11), 128);
+        assert_eq!(VRAM::increment_amount(&make_regs(0b00, 0)), 1);
+        assert_eq!(VRAM::increment_amount(&make_regs(0b01, 0)), 32);
+        assert_eq!(VRAM::increment_amount(&make_regs(0b10, 0)), 128);
+        assert_eq!(VRAM::increment_amount(&make_regs(0b11, 0)), 128);
         // Upper bits masked out
-        assert_eq!(VRAM::increment_amount(0xFC), 1);   // 0xFC & 0b11 == 0b00
-        assert_eq!(VRAM::increment_amount(0x85), 32);  // 0x85 & 0b11 == 0b01
-        assert_eq!(VRAM::increment_amount(0x86), 128); // 0x86 & 0b11 == 0b10
+        assert_eq!(VRAM::increment_amount(&make_regs(0xFC, 0)), 1);   // 0xFC & 0b11 == 0b00
+        assert_eq!(VRAM::increment_amount(&make_regs(0x85, 0)), 32);  // 0x85 & 0b11 == 0b01
+        assert_eq!(VRAM::increment_amount(&make_regs(0x86, 0)), 128); // 0x86 & 0b11 == 0b10
     }
 
     // ============================================================
@@ -218,15 +218,15 @@ mod tests {
     #[test]
     fn test_increment_after_low_and_high() {
         // bit 7 clear -> after low
-        assert!(VRAM::increment_after_low(0x00));
-        assert!(VRAM::increment_after_low(0x7F));
-        assert!(!VRAM::increment_after_high(0x00));
-        assert!(!VRAM::increment_after_high(0x7F));
+        assert!(VRAM::increment_after_low(&make_regs(0x00, 0)));
+        assert!(VRAM::increment_after_low(&make_regs(0x7F, 0)));
+        assert!(!VRAM::increment_after_high(&make_regs(0x00, 0)));
+        assert!(!VRAM::increment_after_high(&make_regs(0x7F, 0)));
         // bit 7 set -> after high
-        assert!(!VRAM::increment_after_low(0x80));
-        assert!(!VRAM::increment_after_low(0xFF));
-        assert!(VRAM::increment_after_high(0x80));
-        assert!(VRAM::increment_after_high(0xFF));
+        assert!(!VRAM::increment_after_low(&make_regs(0x80, 0)));
+        assert!(!VRAM::increment_after_low(&make_regs(0xFF, 0)));
+        assert!(VRAM::increment_after_high(&make_regs(0x80, 0)));
+        assert!(VRAM::increment_after_high(&make_regs(0xFF, 0)));
     }
 
     // ============================================================
@@ -250,7 +250,7 @@ mod tests {
  
         // High byte write: bit 7 masked, low byte untouched
         let mut regs = make_regs(0, 0x0042);
-        vram.write_vmadd_high(&mut regs, 0x81); // 0x81 & 0x7F == 0x01 -> vmadd = 0x0142
+        vram.write_vmadd_high(&mut regs, 0x81);
         assert_eq!(regs.vmadd, 0x0142);
         assert_eq!(vram.vram_latch, 0x1234);
     }

--- a/ppu/src/vram.rs
+++ b/ppu/src/vram.rs
@@ -21,15 +21,6 @@ impl VRAM {
     // Address increment logic
     // ============================================================
 
-    fn vmadd(vmaddl: u8, vmaddh: u8) -> u16 {
-        (vmaddl as u16) | ((vmaddh as u16 & 0x7F) << 8)
-    }
-
-    fn set_vmadd(addr: u16, vmaddl: &mut u8, vmaddh: &mut u8) {
-        *vmaddl = (addr & 0xFF) as u8;
-        *vmaddh = ((addr >> 8) & 0x7F) as u8;
-    }
-
     pub fn increment_amount(vmain: u8) -> u16 {
         match vmain & 0b11 {
             0 => 1,
@@ -47,68 +38,64 @@ impl VRAM {
         (vmain & 0x80) != 0
     }
 
-    fn increment_vmadd(vmain: u8, vmaddl: &mut u8, vmaddh: &mut u8) {
-        let addr = (Self::vmadd(*vmaddl, *vmaddh) + Self::increment_amount(vmain)) & 0x7FFF;
-        Self::set_vmadd(addr, vmaddl, vmaddh);
+    fn increment_vmadd(vmain: u8, vmadd: &mut u16) {
+        *vmadd = vmadd.wrapping_add(Self::increment_amount(vmain)) & 0x7FFF;
     }
 
     // ============================================================
     // VMADD ($2116 / $2117)
     // ============================================================
-    
-    pub fn write_vmadd(&mut self, PPURegisters { vmaddl, vmaddh, .. }: &mut PPURegisters, addr: u16) {
-        *vmaddl = *addr.lo();
-        self.load_latch(*vmaddl, *vmaddh);
 
-        *vmaddh = *addr.hi() & 0x7F;
-        self.load_latch(*vmaddl, *vmaddh);
+    pub fn write_vmadd(&mut self, PPURegisters { vmadd, .. }: &mut PPURegisters, addr: u16) {
+        *vmadd = addr & 0x7FFF;
+        self.load_latch(*vmadd);
     }
 
-    pub fn write_vmadd_low(&mut self, PPURegisters { vmaddl, vmaddh, .. }: &mut PPURegisters, value: u8) {
-        *vmaddl = value;
-        self.load_latch(*vmaddl, *vmaddh);
+    pub fn write_vmadd_low(&mut self, PPURegisters { vmadd, .. }: &mut PPURegisters, value: u8) {
+        *vmadd.lo_mut() = value;
+        self.load_latch(*vmadd);
     }
 
-    pub fn write_vmadd_high(&mut self, PPURegisters { vmaddl, vmaddh, .. }: &mut PPURegisters, value: u8) {
-        *vmaddh = value & 0x7F;
-        self.load_latch(*vmaddl, *vmaddh);
+    pub fn write_vmadd_high(&mut self, PPURegisters { vmadd, .. }: &mut PPURegisters, value: u8) {
+        *vmadd.hi_mut() = value & 0x7F;
+        self.load_latch(*vmadd);
     }
 
     // ============================================================
     // VRAM DATA WRITE ($2118 / $2119)
     // ============================================================
 
-    pub fn write_vmdata(&mut self, PPURegisters { vmain, vmaddl, vmaddh, .. }: &mut PPURegisters, value: u16) {
-        let addr = Self::vmadd(*vmaddl, *vmaddh) as usize;
+    pub fn write_vmdata(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters, value: u16) {
+        let addr = (*vmadd & 0x7FFF) as usize;
         *self.memory[addr].lo_mut() = *value.lo();
 
         if Self::increment_after_low(*vmain) {
-            Self::increment_vmadd(*vmain, vmaddl, vmaddh);
+            Self::increment_vmadd(*vmain, vmadd);
         }
 
-        let addr = Self::vmadd(*vmaddl, *vmaddh) as usize;
+        let addr = (*vmadd & 0x7FFF) as usize;
         *self.memory[addr].hi_mut() = *value.hi();
 
         if Self::increment_after_high(*vmain) {
-            Self::increment_vmadd(*vmain, vmaddl, vmaddh);
+            Self::increment_vmadd(*vmain, vmadd);
         }
     }
 
-    pub fn write_vmdatal(&mut self, PPURegisters { vmain, vmaddl, vmaddh, .. }: &mut PPURegisters, value: u8) {
-        let addr = Self::vmadd(*vmaddl, *vmaddh) as usize;
+    pub fn write_vmdatal(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters, value: u8) {
+        let addr = (*vmadd & 0x7FFF) as usize;
         *self.memory[addr].lo_mut() = value;
 
         if Self::increment_after_low(*vmain) {
-            Self::increment_vmadd(*vmain, vmaddl, vmaddh);
+            Self::increment_vmadd(*vmain, vmadd);
         }
     }
 
-    pub fn write_vmdatah(&mut self, PPURegisters { vmain, vmaddl, vmaddh, .. }: &mut PPURegisters, value: u8) {
-        let addr = Self::vmadd(*vmaddl, *vmaddh) as usize;
+    pub fn write_vmdatah(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters, value: u8) {
+        let addr = (*vmadd & 0x7FFF) as usize;
         *self.memory[addr].hi_mut() = value;
 
         if Self::increment_after_high(*vmain) {
-            Self::increment_vmadd(*vmain, vmaddl, vmaddh);
+            Self::increment_vmadd(*vmain, vmadd);
         }
     }
 
@@ -116,41 +103,41 @@ impl VRAM {
     // VRAM DATA READ ($2139 / $213A)
     // ============================================================
 
-    pub fn read_vmdata(&mut self, PPURegisters { vmain, vmaddl, vmaddh, .. }: &mut PPURegisters) -> u16 {
+    pub fn read_vmdata(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters) -> u16 {
         let lo = *self.vram_latch.lo();
 
         if Self::increment_after_low(*vmain) {
-            Self::increment_vmadd(*vmain, vmaddl, vmaddh);
-            self.load_latch(*vmaddl, *vmaddh);
+            Self::increment_vmadd(*vmain, vmadd);
+            self.load_latch(*vmadd);
         }
 
         let hi = *self.vram_latch.hi();
 
         if Self::increment_after_high(*vmain) {
-            Self::increment_vmadd(*vmain, vmaddl, vmaddh);
-            self.load_latch(*vmaddl, *vmaddh);
+            Self::increment_vmadd(*vmain, vmadd);
+            self.load_latch(*vmadd);
         }
 
         (lo as u16) | ((hi as u16) << 8)
     }
 
-    pub fn read_vmdatal(&mut self, PPURegisters { vmain, vmaddl, vmaddh, .. }: &mut PPURegisters) -> u8 {
+    pub fn read_vmdatal(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters) -> u8 {
         let value = *self.vram_latch.lo();
 
         if Self::increment_after_low(*vmain) {
-            Self::increment_vmadd(*vmain, vmaddl, vmaddh);
-            self.load_latch(*vmaddl, *vmaddh);
+            Self::increment_vmadd(*vmain, vmadd);
+            self.load_latch(*vmadd);
         }
 
         value
     }
 
-    pub fn read_vmdatah(&mut self, PPURegisters { vmain, vmaddl, vmaddh, .. }: &mut PPURegisters) -> u8 {
+    pub fn read_vmdatah(&mut self, PPURegisters { vmain, vmadd, .. }: &mut PPURegisters) -> u8 {
         let value = *self.vram_latch.hi();
 
         if Self::increment_after_high(*vmain) {
-            Self::increment_vmadd(*vmain, vmaddl, vmaddh);
-            self.load_latch(*vmaddl, *vmaddh);
+            Self::increment_vmadd(*vmain, vmadd);
+            self.load_latch(*vmadd);
         }
 
         value
@@ -160,8 +147,8 @@ impl VRAM {
     // Helpers
     // ============================================================
 
-    pub fn load_latch(&mut self, vmaddl: u8, vmaddh: u8) {
-        self.vram_latch = self.memory[Self::vmadd(vmaddl, vmaddh) as usize];
+    pub fn load_latch(&mut self, vmadd: u16) {
+        self.vram_latch = self.memory[(vmadd & 0x7FFF) as usize];
     }
 }
 
@@ -186,11 +173,10 @@ mod tests {
     // vmain = 0x83 -> increment by 128, increment after high byte write/read
     const VMAIN_INC128_AFTER_HIGH: u8 = 0x83;
 
-    fn make_regs(vmain: u8, vmaddl: u8, vmaddh: u8) -> PPURegisters {
+    fn make_regs(vmain: u8, vmadd: u16) -> PPURegisters {
         let mut regs = PPURegisters::new();
         regs.vmain = vmain;
-        regs.vmaddl = vmaddl;
-        regs.vmaddh = vmaddh;
+        regs.vmadd = vmadd;
         regs
     }
 
@@ -210,176 +196,97 @@ mod tests {
     // increment_amount
     // ============================================================
 
-    /// vmain bits[1:0] == 0b00 -> increment amount must be 1.
+    /// vmain bits[1:0] select the increment: 0b00->1, 0b01->32, 0b10->128, 0b11->128.
+    /// Upper bits must be ignored.
     #[test]
-    fn test_increment_amount_1() {
+    fn test_increment_amount() {
         assert_eq!(VRAM::increment_amount(0b00), 1);
-    }
-
-    /// vmain bits[1:0] == 0b01 -> increment amount must be 32.
-    #[test]
-    fn test_increment_amount_32() {
         assert_eq!(VRAM::increment_amount(0b01), 32);
-    }
-
-    /// vmain bits[1:0] == 0b10 -> increment amount must be 128.
-    #[test]
-    fn test_increment_amount_128_variant2() {
         assert_eq!(VRAM::increment_amount(0b10), 128);
-    }
-
-    /// vmain bits[1:0] == 0b11 -> increment amount must also be 128.
-    #[test]
-    fn test_increment_amount_128_variant3() {
         assert_eq!(VRAM::increment_amount(0b11), 128);
-    }
-
-    /// Upper bits of vmain must be masked out; only bits[1:0] matter.
-    #[test]
-    fn test_increment_amount_ignores_upper_bits() {
-        // 0xFC & 0b11 == 0b00 -> 1
-        assert_eq!(VRAM::increment_amount(0xFC), 1);
-        // 0x85 & 0b11 == 0b01 -> 32
-        assert_eq!(VRAM::increment_amount(0x85), 32);
-        // 0x86 & 0b11 == 0b10 -> 128
-        assert_eq!(VRAM::increment_amount(0x86), 128);
+        // Upper bits masked out
+        assert_eq!(VRAM::increment_amount(0xFC), 1);   // 0xFC & 0b11 == 0b00
+        assert_eq!(VRAM::increment_amount(0x85), 32);  // 0x85 & 0b11 == 0b01
+        assert_eq!(VRAM::increment_amount(0x86), 128); // 0x86 & 0b11 == 0b10
     }
 
     // ============================================================
     // increment_after_low / increment_after_high
     // ============================================================
 
-    /// When bit 7 of vmain is 0, increment must occur after the low byte access.
+    /// increment_after_low is true iff bit 7 of vmain is clear; increment_after_high is the inverse.
     #[test]
-    fn test_increment_after_low_true_when_bit7_clear() {
+    fn test_increment_after_low_and_high() {
+        // bit 7 clear -> after low
         assert!(VRAM::increment_after_low(0x00));
-        assert!(VRAM::increment_after_low(0x01));
         assert!(VRAM::increment_after_low(0x7F));
-    }
-
-    /// When bit 7 of vmain is 1, increment must NOT occur after the low byte access.
-    #[test]
-    fn test_increment_after_low_false_when_bit7_set() {
-        assert!(!VRAM::increment_after_low(0x80));
-        assert!(!VRAM::increment_after_low(0xFF));
-    }
-
-    /// When bit 7 of vmain is 1, increment must occur after the high byte access.
-    #[test]
-    fn test_increment_after_high_true_when_bit7_set() {
-        assert!(VRAM::increment_after_high(0x80));
-        assert!(VRAM::increment_after_high(0xFF));
-    }
-
-    /// When bit 7 of vmain is 0, increment must NOT occur after the high byte access.
-    #[test]
-    fn test_increment_after_high_false_when_bit7_clear() {
         assert!(!VRAM::increment_after_high(0x00));
         assert!(!VRAM::increment_after_high(0x7F));
+        // bit 7 set -> after high
+        assert!(!VRAM::increment_after_low(0x80));
+        assert!(!VRAM::increment_after_low(0xFF));
+        assert!(VRAM::increment_after_high(0x80));
+        assert!(VRAM::increment_after_high(0xFF));
     }
 
     // ============================================================
     // write_vmadd ($2116 / $2117)
     // ============================================================
-
-    /// Writing to $2116 (VMADDL) must update vmaddl and reload the latch from the new address.
+ 
+    /// write_vmadd_low updates the low byte of vmadd and reloads the latch;
+    /// write_vmadd_high strips bit 7, updates the high byte, reloads the latch,
+    /// and must not touch the low byte.
     #[test]
-    fn test_write_vmadd_low_updates_register_and_latch() {
+    fn test_write_vmadd_low_and_high_separate() {
         let mut vram = VRAM::new();
-        // Pre-load a known word at address 0x0005
         vram.memory[0x0005] = 0xABCD;
-        let mut regs = make_regs(0, 0x00, 0x00);
+        vram.memory[0x0142] = 0x1234; // address resulting from vmadd=0x0042, high write 0x81 & 0x7F = 0x01
  
+        // Low byte write
+        let mut regs = make_regs(0, 0x0000);
         vram.write_vmadd_low(&mut regs, 0x05);
- 
-        assert_eq!(regs.vmaddl, 0x05);
-        assert_eq!(regs.vmaddh, 0x00);
+        assert_eq!(regs.vmadd, 0x0005);
         assert_eq!(vram.vram_latch, 0xABCD);
-    }
-
-    /// Writing to $2117 (VMADDH) must strip bit 7, update vmaddh, and reload the latch.
-    #[test]
-    fn test_write_vmadd_high_masks_bit7_and_reloads_latch() {
-        let mut vram = VRAM::new();
-        // Address 0x0100 (vmaddh=0x01, vmaddl=0x00)
-        vram.memory[0x0100] = 0x1234;
-        let mut regs = make_regs(0, 0x00, 0x00);
-
-        // Pass 0x81 – bit 7 must be masked off, resulting in vmaddh = 0x01 
-        vram.write_vmadd_high(&mut regs, 0x81);
-
-        assert_eq!(regs.vmaddh, 0x01);
+ 
+        // High byte write: bit 7 masked, low byte untouched
+        let mut regs = make_regs(0, 0x0042);
+        vram.write_vmadd_high(&mut regs, 0x81); // 0x81 & 0x7F == 0x01 -> vmadd = 0x0142
+        assert_eq!(regs.vmadd, 0x0142);
         assert_eq!(vram.vram_latch, 0x1234);
     }
 
-    /// write_vmadd_high must not modify vmaddl.
+    /// write_vmadd sets both bytes at once, masks bit 15, reloads the latch,
+    /// and produces the same state as separate low/high writes.
     #[test]
-    fn test_write_vmadd_high_does_not_touch_vmaddl() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(0, 0x42, 0x00);
- 
-        vram.write_vmadd_high(&mut regs, 0x01);
- 
-        assert_eq!(regs.vmaddl, 0x42);
-    }
-
-    /// write_vmadd must set both vmaddl and vmaddh and reload the latch once.
-    #[test]
-    fn test_write_vmadd_sets_both_bytes_and_reloads_latch() {
+    fn test_write_vmadd_combined() {
         let mut vram = VRAM::new();
         vram.memory[0x0123] = 0xDEAD;
-        let mut regs = make_regs(0, 0x00, 0x00);
- 
+        vram.memory[0x0245] = 0x1234;
+
+        // Basic combined write
+        let mut regs = make_regs(0, 0x0000);
         vram.write_vmadd(&mut regs, 0x0123);
- 
-        assert_eq!(regs.vmaddl, 0x23);
-        assert_eq!(regs.vmaddh, 0x01);
+        assert_eq!(regs.vmadd, 0x0123);
         assert_eq!(vram.vram_latch, 0xDEAD);
-    }
 
-    /// write_vmadd must mask bit 7 of the high byte, exactly as write_vmadd_high does.
-    #[test]
-    fn test_write_vmadd_masks_high_bit7() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(0, 0x00, 0x00);
- 
+        // Bit 15 must be masked
         vram.write_vmadd(&mut regs, 0xFF00);
+        assert_eq!(regs.vmadd, 0x7F00);
 
-        // 0xFF & 0x7F == 0x7F
-        assert_eq!(regs.vmaddh, 0x7F);
-    }
+        // Equivalent to separate writes
+        let mut regs_a = make_regs(0, 0x0000);
+        vram.write_vmadd(&mut regs_a, 0x0245);
+        let mut regs_b = make_regs(0, 0x0000);
+        vram.write_vmadd_low(&mut regs_b, 0x45);
+        vram.write_vmadd_high(&mut regs_b, 0x02);
+        assert_eq!(regs_a.vmadd, regs_b.vmadd);
+        assert_eq!(vram.vram_latch, 0x1234);
 
-    /// write_vmadd must produce the same final state as write_vmadd_low followed by write_vmadd_high.
-    #[test]
-    fn test_write_vmadd_equivalent_to_separate_writes() {
-        let mut vram_a = VRAM::new();
-        let mut vram_b = VRAM::new();
-        vram_a.memory[0x0245] = 0x1234;
-        vram_b.memory[0x0245] = 0x1234;
- 
-        let mut regs_a = make_regs(0, 0x00, 0x00);
-        vram_a.write_vmadd(&mut regs_a, 0x0245);
- 
-        let mut regs_b = make_regs(0, 0x00, 0x00);
-        vram_b.write_vmadd_low(&mut regs_b, 0x45);
-        vram_b.write_vmadd_high(&mut regs_b, 0x02);
- 
-        assert_eq!(regs_a.vmaddl, regs_b.vmaddl);
-        assert_eq!(regs_a.vmaddh, regs_b.vmaddh);
-        assert_eq!(vram_a.vram_latch, vram_b.vram_latch);
-    }
-
-    /// write_vmadd at address 0 must latch memory[0].
-    #[test]
-    fn test_write_vmadd_address_zero() {
-        let mut vram = VRAM::new();
+        // Address zero
+        let mut regs = make_regs(0, 0x7FFF);
         vram.memory[0x0000] = 0xBEEF;
-        let mut regs = make_regs(0, 0xFF, 0xFF);
- 
         vram.write_vmadd(&mut regs, 0x0000);
- 
-        assert_eq!(regs.vmaddl, 0x00);
-        assert_eq!(regs.vmaddh, 0x00);
+        assert_eq!(regs.vmadd, 0x0000);
         assert_eq!(vram.vram_latch, 0xBEEF);
     }
 
@@ -387,289 +294,158 @@ mod tests {
     // write_vmdatal ($2118)
     // ============================================================
 
-    /// Writing to $2118 must update the low byte of the word at the current VRAM address.
+    /// write_vmdatal updates the low byte at the current address.
+    /// It increments after write iff vmain bit7=0, by the amount encoded in bits[1:0].
     #[test]
-    fn test_write_vmdatal_writes_low_byte() {
+    fn test_write_vmdatal() {
         let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x03, 0x00);
- 
+
+        // Writes correct byte
+        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x0003);
         vram.write_vmdatal(&mut regs, 0xBE);
-
-        // The high byte should still be 0; only lo changed.
         assert_eq!(vram.memory[0x0003] & 0x00FF, 0xBE);
-    }
 
-    /// After a low byte write with vmain bit7=0, the address must increment by the configured amount.
-    #[test]
-    fn test_write_vmdatal_increments_address_after_low() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
- 
+        // Increments by 1 after low write (bit7=0)
+        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x0000);
         vram.write_vmdatal(&mut regs, 0xFF);
+        assert_eq!(regs.vmadd, 0x0001);
 
-        // Address should have advanced by 1 -> vmaddl == 1
-        assert_eq!(regs.vmaddl, 0x01);
-        assert_eq!(regs.vmaddh, 0x00);
-    }
-
-    /// After a low byte write with vmain bit7=1, the address must NOT increment.
-    #[test]
-    fn test_write_vmdatal_no_increment_when_high_mode() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
- 
+        // No increment when bit7=1
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
         vram.write_vmdatal(&mut regs, 0xFF);
- 
-        assert_eq!(regs.vmaddl, 0x00);
-        assert_eq!(regs.vmaddh, 0x00);
-    }
+        assert_eq!(regs.vmadd, 0x0000);
 
-    /// write_vmdatal with increment-by-32 must advance the address by 32.
-    #[test]
-    fn test_write_vmdatal_increment_by_32() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC32_AFTER_LOW, 0x00, 0x00);
- 
+        // Increment by 32 and 128
+        let mut regs = make_regs(VMAIN_INC32_AFTER_LOW, 0x0000);
         vram.write_vmdatal(&mut regs, 0x00);
- 
-        let addr = (regs.vmaddl as u16) | ((regs.vmaddh as u16) << 8);
-        assert_eq!(addr, 32);
-    }
+        assert_eq!(regs.vmadd, 32);
 
-    /// write_vmdatal with increment-by-128 must advance the address by 128.
-    #[test]
-    fn test_write_vmdatal_increment_by_128() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC128_AFTER_LOW, 0x00, 0x00);
- 
+        let mut regs = make_regs(VMAIN_INC128_AFTER_LOW, 0x0000);
         vram.write_vmdatal(&mut regs, 0x00);
- 
-        let addr = (regs.vmaddl as u16) | ((regs.vmaddh as u16) << 8);
-        assert_eq!(addr, 128);
+        assert_eq!(regs.vmadd, 128);
     }
 
     // ============================================================
     // write_vmdatah ($2119)
     // ============================================================
 
-    /// Writing to $2119 must update the high byte of the word at the current VRAM address.
+    /// write_vmdatah updates the high byte at the current address.
+    /// It increments after write iff vmain bit7=1, by the amount encoded in bits[1:0].
     #[test]
-    fn test_write_vmdatah_writes_high_byte() {
+    fn test_write_vmdatah() {
         let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x03, 0x00);
- 
+
+        // Writes correct byte
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0003);
         vram.write_vmdatah(&mut regs, 0xEF);
- 
         assert_eq!((vram.memory[0x0003] >> 8) as u8, 0xEF);
-    }
 
-    /// After a high byte write with vmain bit7=1, the address must increment.
-    #[test]
-    fn test_write_vmdatah_increments_address_after_high() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
- 
+        // Increments by 1 after high write (bit7=1)
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
         vram.write_vmdatah(&mut regs, 0xFF);
- 
-        assert_eq!(regs.vmaddl, 0x01);
-        assert_eq!(regs.vmaddh, 0x00);
-    }
+        assert_eq!(regs.vmadd, 0x0001);
 
-    /// After a high byte write with vmain bit7=0, the address must NOT increment.
-    #[test]
-    fn test_write_vmdatah_no_increment_when_low_mode() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
- 
+        // No increment when bit7=0
+        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x0000);
         vram.write_vmdatah(&mut regs, 0xFF);
- 
-        assert_eq!(regs.vmaddl, 0x00);
-        assert_eq!(regs.vmaddh, 0x00);
-    }
+        assert_eq!(regs.vmadd, 0x0000);
 
-    /// write_vmdatah with increment-by-32 must advance the address by 32.
-    #[test]
-    fn test_write_vmdatah_increment_by_32() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC32_AFTER_HIGH, 0x00, 0x00);
- 
+        // Increment by 32 and 128
+        let mut regs = make_regs(VMAIN_INC32_AFTER_HIGH, 0x0000);
         vram.write_vmdatah(&mut regs, 0x00);
- 
-        let addr = (regs.vmaddl as u16) | ((regs.vmaddh as u16) << 8);
-        assert_eq!(addr, 32);
-    }
+        assert_eq!(regs.vmadd, 32);
 
-    
-    /// write_vmdatah with increment-by-128 must advance the address by 128.
-    #[test]
-    fn test_write_vmdatah_increment_by_128() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC128_AFTER_HIGH, 0x00, 0x00);
-
+        let mut regs = make_regs(VMAIN_INC128_AFTER_HIGH, 0x0000);
         vram.write_vmdatah(&mut regs, 0x00);
-
-        let addr = (regs.vmaddl as u16) | ((regs.vmaddh as u16) << 8);
-        assert_eq!(addr, 128);
+        assert_eq!(regs.vmadd, 128);
     }
 
-    /// A paired low+high write at the same address must produce the expected full 16-bit word.
+    /// A paired low+high write (bit7=1 mode) must produce the expected full 16-bit word
+    /// and increment exactly once after the high write.
     #[test]
     fn test_write_low_then_high_builds_full_word() {
         let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
- 
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
+
         vram.write_vmdatal(&mut regs, 0xCD);
         vram.write_vmdatah(&mut regs, 0xAB);
 
         assert_eq!(vram.memory[0x0000], 0xABCD);
-        // Address must have advanced exactly once (after the high write)
-        assert_eq!(regs.vmaddl, 0x01);
+        assert_eq!(regs.vmadd, 0x0001);
     }
 
     // ============================================================
     // write_vmdata lo+hi combined ($2118 / $2119)
     // ============================================================
 
-    /// write_vmdata with vmain bit7=1 must write both bytes to the same word address.
+    /// write_vmdata must produce the same result as separate low/high writes in both modes,
+    /// and advance the address by the configured increment amount.
     #[test]
-    fn test_write_vmdata_writes_full_word_in_high_mode() {
+    fn test_write_vmdata() {
         let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x05, 0x00);
- 
+
+        // High mode: both bytes go to the same word, address increments once after high
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0005);
         vram.write_vmdata(&mut regs, 0xABCD);
- 
         assert_eq!(vram.memory[0x0005], 0xABCD);
-        assert_eq!(regs.vmaddl, 0x06);
-        assert_eq!(regs.vmaddh, 0x00);
-    }
+        assert_eq!(regs.vmadd, 0x0006);
 
-    /// write_vmdata with vmain bit7=1 must produce the same result as write_vmdatal + write_vmdatah.
-    #[test]
-    fn test_write_vmdata_equivalent_to_separate_writes_high_mode() {
-        let mut vram_a = VRAM::new();
-        let mut vram_b = VRAM::new();
- 
-        let mut regs_a = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
-        vram_a.write_vmdata(&mut regs_a, 0x1234);
- 
-        let mut regs_b = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
-        vram_b.write_vmdatal(&mut regs_b, 0x34);
-        vram_b.write_vmdatah(&mut regs_b, 0x12);
- 
-        assert_eq!(vram_a.memory[0x0000], vram_b.memory[0x0000]);
-        assert_eq!(regs_a.vmaddl, regs_b.vmaddl);
-        assert_eq!(regs_a.vmaddh, regs_b.vmaddh);
-    }
+        // Equivalent to separate writes (high mode)
+        let mut vram2 = VRAM::new();
+        let mut regs_a = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
+        vram2.write_vmdata(&mut regs_a, 0x1234);
+        let mut regs_b = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
+        let mut vram3 = VRAM::new();
+        vram3.write_vmdatal(&mut regs_b, 0x34);
+        vram3.write_vmdatah(&mut regs_b, 0x12);
+        assert_eq!(vram2.memory[0x0000], vram3.memory[0x0000]);
+        assert_eq!(regs_a.vmadd, regs_b.vmadd);
 
-    /// write_vmdata with vmain bit7=0 must write lo and hi to different words,
-    /// because the address increments after the low byte write.
-    #[test]
-    fn test_write_vmdata_low_and_high_go_to_different_words_in_low_mode() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
- 
-        vram.write_vmdata(&mut regs, 0xABCD);
- 
-        assert_eq!(vram.memory[0x0000] & 0x00FF, 0xCD);
-        assert_eq!((vram.memory[0x0001] >> 8) as u8, 0xAB);
-        assert_eq!(regs.vmaddl, 0x01);
-    }
+        // Low mode: lo goes to word 0, hi goes to word 1 (address increments after lo)
+        let mut vram4 = VRAM::new();
+        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x0000);
+        vram4.write_vmdata(&mut regs, 0xABCD);
+        assert_eq!(vram4.memory[0x0000] & 0x00FF, 0xCD);
+        assert_eq!((vram4.memory[0x0001] >> 8) as u8, 0xAB);
+        assert_eq!(regs.vmadd, 0x0001);
 
-    /// write_vmdata with vmain bit7=0 must produce the same result as separate low/high writes.
-    #[test]
-    fn test_write_vmdata_equivalent_to_separate_writes_low_mode() {
-        let mut vram_a = VRAM::new();
-        let mut vram_b = VRAM::new();
- 
-        let mut regs_a = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
-        vram_a.write_vmdata(&mut regs_a, 0x5678);
- 
-        let mut regs_b = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
-        vram_b.write_vmdatal(&mut regs_b, 0x78);
-        vram_b.write_vmdatah(&mut regs_b, 0x56);
- 
-        assert_eq!(vram_a.memory[0x0000], vram_b.memory[0x0000]);
-        assert_eq!(vram_a.memory[0x0001], vram_b.memory[0x0001]);
-        assert_eq!(regs_a.vmaddl, regs_b.vmaddl);
-        assert_eq!(regs_a.vmaddh, regs_b.vmaddh);
-    }
-
-    /// write_vmdata with increment-by-32 must advance the address by 32 after the high byte.
-    #[test]
-    fn test_write_vmdata_increment_by_32() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC32_AFTER_HIGH, 0x00, 0x00);
-
+        // Increment by 32 and 128 (high mode)
+        let mut regs = make_regs(VMAIN_INC32_AFTER_HIGH, 0x0000);
         vram.write_vmdata(&mut regs, 0x0000);
+        assert_eq!(regs.vmadd, 32);
 
-        let addr = (regs.vmaddl as u16) | ((regs.vmaddh as u16) << 8);
-        assert_eq!(addr, 32);
-    }
-
-    /// write_vmdata with increment-by-128 must advance the address by 128 after the high byte.
-    #[test]
-    fn test_write_vmdata_increment_by_128() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC128_AFTER_HIGH, 0x00, 0x00);
-
+        let mut regs = make_regs(VMAIN_INC128_AFTER_HIGH, 0x0000);
         vram.write_vmdata(&mut regs, 0x0000);
-
-        let addr = (regs.vmaddl as u16) | ((regs.vmaddh as u16) << 8);
-        assert_eq!(addr, 128);
+        assert_eq!(regs.vmadd, 128);
     }
 
     // ============================================================
     // read_vmdatal ($2139)
     // ============================================================
 
-    /// read_vmdatal must return the low byte that was previously latched (pre-fetch behaviour).
+    /// read_vmdatal returns the latched low byte.
+    /// In low mode (bit7=0) it increments and refreshes the latch; in high mode it does not.
     #[test]
-    fn test_read_vmdatal_returns_latched_low_byte() {
-        let mut vram = VRAM::new();
-        vram.memory[0x0000] = 0x1234;
-        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
-
-        // Load the latch manually (simulates what write_vmadd_low would do)
-        vram.load_latch(regs.vmaddl, regs.vmaddh);
-
-        let val = vram.read_vmdatal(&mut regs);
-
-        // latch was 0x1234 -> lo byte == 0x34
-        assert_eq!(val, 0x34);
-    }
-
-    /// After read_vmdatal with vmain bit7=0, the address must increment and the latch refreshed.
-    /// The SNES pre-fetch model: the latch is reloaded with the *next* word after increment,
-    /// so vram_latch holds the word at the new address only after the read completes.
-    #[test]
-    fn test_read_vmdatal_increments_and_refreshes_latch() {
+    fn test_read_vmdatal() {
         let mut vram = VRAM::new();
         vram.memory[0x0000] = 0x1234;
         vram.memory[0x0001] = 0x5678;
-        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
 
-        vram.load_latch(regs.vmaddl, regs.vmaddh); // latch = 0x1234
+        // Returns lo byte of latch
+        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x0000);
+        vram.load_latch(regs.vmadd);
+        assert_eq!(vram.read_vmdatal(&mut regs), 0x34);
 
-        // First read: returns lo of latch(0x1234)=0x34, then increments addr to 0x0001
-        // and reloads latch with memory[0x0001]=0x5678
-        let _ = vram.read_vmdatal(&mut regs);
+        // After read: address incremented, latch refreshed with next word
+        assert_eq!(regs.vmadd, 0x0001);
+        assert_eq!(vram.vram_latch, 0x5678);
 
-        assert_eq!(regs.vmaddl, 0x01, "address must have incremented to 0x0001");
-        assert_eq!(vram.vram_latch, 0x5678, "latch must hold word at new address 0x0001");
-    }
-
-    /// read_vmdatal with vmain bit7=1 must NOT increment the address or reload the latch.
-    #[test]
-    fn test_read_vmdatal_no_increment_when_high_mode() {
-        let mut vram = VRAM::new();
+        // No increment in high mode
         vram.memory[0x0000] = 0xBEEF;
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
-
-        vram.load_latch(regs.vmaddl, regs.vmaddh);
-
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
+        vram.load_latch(regs.vmadd);
         let _ = vram.read_vmdatal(&mut regs);
-
-        assert_eq!(regs.vmaddl, 0x00);
+        assert_eq!(regs.vmadd, 0x0000);
         assert_eq!(vram.vram_latch, 0xBEEF);
     }
 
@@ -677,49 +453,29 @@ mod tests {
     // read_vmdatah ($213A)
     // ============================================================
 
-    /// read_vmdatah must return the high byte that was previously latched.
+    /// read_vmdatah returns the latched high byte.
+    /// In high mode (bit7=1) it increments and refreshes the latch; in low mode it does not.
     #[test]
-    fn test_read_vmdatah_returns_latched_high_byte() {
-        let mut vram = VRAM::new();
-        vram.memory[0x0000] = 0xABCD;
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
-        
-        vram.load_latch(regs.vmaddl, regs.vmaddh);
-
-        let val = vram.read_vmdatah(&mut regs);
-
-        // latch was 0xABCD -> hi byte == 0xAB
-        assert_eq!(val, 0xAB);
-    }
-
-    /// After read_vmdatah with vmain bit7=1, the address must increment and the latch refreshed.
-    #[test]
-    fn test_read_vmdatah_increments_and_refreshes_latch() {
+    fn test_read_vmdatah() {
         let mut vram = VRAM::new();
         vram.memory[0x0000] = 0xABCD;
         vram.memory[0x0001] = 0xDEAD;
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
-        vram.load_latch(regs.vmaddl, regs.vmaddh); // latch = 0xABCD
 
-        // First read: returns hi of latch(0xABCD)=0xAB, then increments addr to 0x0001
-        // and reloads latch with memory[0x0001]=0xDEAD
-        let _ = vram.read_vmdatah(&mut regs);
+        // Returns hi byte of latch
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
+        vram.load_latch(regs.vmadd);
+        assert_eq!(vram.read_vmdatah(&mut regs), 0xAB);
 
-        assert_eq!(regs.vmaddl, 0x01, "address must have incremented to 0x0001");
-        assert_eq!(vram.vram_latch, 0xDEAD, "latch must hold word at new address 0x0001");
-    }
+        // After read: address incremented, latch refreshed
+        assert_eq!(regs.vmadd, 0x0001);
+        assert_eq!(vram.vram_latch, 0xDEAD);
 
-    /// read_vmdatah with vmain bit7=0 must NOT increment the address or reload the latch.
-    #[test]
-    fn test_read_vmdatah_no_increment_when_low_mode() {
-        let mut vram = VRAM::new();
+        // No increment in low mode
         vram.memory[0x0000] = 0xCAFE;
-        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
-        vram.load_latch(regs.vmaddl, regs.vmaddh);
- 
+        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x0000);
+        vram.load_latch(regs.vmadd);
         let _ = vram.read_vmdatah(&mut regs);
- 
-        assert_eq!(regs.vmaddl, 0x00);
+        assert_eq!(regs.vmadd, 0x0000);
         assert_eq!(vram.vram_latch, 0xCAFE);
     }
 
@@ -727,152 +483,90 @@ mod tests {
     // read_vmdata lo+hi combined ($2139 / $213A)
     // ============================================================
 
-    /// read_vmdata with vmain bit7=1 must return the full latched word and increment once after.
+    /// read_vmdata must produce the same result as separate low/high reads in both modes,
+    /// and advance the address by the configured increment amount.
     #[test]
-    fn test_read_vmdata_returns_full_word_and_increments_in_high_mode() {
+    fn test_read_vmdata() {
         let mut vram = VRAM::new();
         vram.memory[0x0000] = 0xABCD;
         vram.memory[0x0001] = 0x1234;
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
-        vram.load_latch(regs.vmaddl, regs.vmaddh);
- 
-        let word = vram.read_vmdata(&mut regs);
- 
-        assert_eq!(word, 0xABCD);
-        assert_eq!(regs.vmaddl, 0x01);
+
+        // High mode: returns full word, increments once after hi read
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
+        vram.load_latch(regs.vmadd);
+        assert_eq!(vram.read_vmdata(&mut regs), 0xABCD);
+        assert_eq!(regs.vmadd, 0x0001);
         assert_eq!(vram.vram_latch, 0x1234);
-    }
 
-    /// read_vmdata with vmain bit7=1 must produce the same result as read_vmdatal + read_vmdatah.
-    #[test]
-    fn test_read_vmdata_equivalent_to_separate_reads_high_mode() {
-        let mut vram_a = VRAM::new();
-        let mut vram_b = VRAM::new();
-        vram_a.memory[0x0000] = 0xDEAD;
-        vram_b.memory[0x0000] = 0xDEAD;
- 
-        let mut regs_a = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
-        vram_a.load_latch(regs_a.vmaddl, regs_a.vmaddh);
-        let word = vram_a.read_vmdata(&mut regs_a);
- 
-        let mut regs_b = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
-        vram_b.load_latch(regs_b.vmaddl, regs_b.vmaddh);
-        let lo = vram_b.read_vmdatal(&mut regs_b);
-        let hi = vram_b.read_vmdatah(&mut regs_b);
- 
+        // Equivalent to separate reads (high mode)
+        vram.memory[0x0000] = 0xDEAD;
+        let mut regs_a = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
+        vram.load_latch(regs_a.vmadd);
+        let word = vram.read_vmdata(&mut regs_a);
+        let mut regs_b = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
+        vram.load_latch(regs_b.vmadd);
+        let lo = vram.read_vmdatal(&mut regs_b);
+        let hi = vram.read_vmdatah(&mut regs_b);
         assert_eq!(word, (lo as u16) | ((hi as u16) << 8));
-        assert_eq!(regs_a.vmaddl, regs_b.vmaddl);
-        assert_eq!(vram_a.vram_latch, vram_b.vram_latch);
-    }
+        assert_eq!(regs_a.vmadd, regs_b.vmadd);
 
-    /// read_vmdata with vmain bit7=0 must produce the same result as read_vmdatal + read_vmdatah,
-    /// including the latch reload between lo and hi reads.
-    #[test]
-    fn test_read_vmdata_equivalent_to_separate_reads_low_mode() {
-        let mut vram_a = VRAM::new();
-        let mut vram_b = VRAM::new();
-        vram_a.memory[0x0000] = 0x00CD;
-        vram_b.memory[0x0000] = 0x00CD;
-        vram_a.memory[0x0001] = 0xAB00;
-        vram_b.memory[0x0001] = 0xAB00;
- 
-        let mut regs_a = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
-        vram_a.load_latch(regs_a.vmaddl, regs_a.vmaddh);
-        let word = vram_a.read_vmdata(&mut regs_a);
- 
-        let mut regs_b = make_regs(VMAIN_INC1_AFTER_LOW, 0x00, 0x00);
-        vram_b.load_latch(regs_b.vmaddl, regs_b.vmaddh);
-        let lo = vram_b.read_vmdatal(&mut regs_b);
-        let hi = vram_b.read_vmdatah(&mut regs_b);
- 
+        // Equivalent to separate reads (low mode)
+        vram.memory[0x0000] = 0x00CD;
+        vram.memory[0x0001] = 0xAB00;
+        let mut regs_a = make_regs(VMAIN_INC1_AFTER_LOW, 0x0000);
+        vram.load_latch(regs_a.vmadd);
+        let word = vram.read_vmdata(&mut regs_a);
+        let mut regs_b = make_regs(VMAIN_INC1_AFTER_LOW, 0x0000);
+        vram.load_latch(regs_b.vmadd);
+        let lo = vram.read_vmdatal(&mut regs_b);
+        let hi = vram.read_vmdatah(&mut regs_b);
         assert_eq!(word, (lo as u16) | ((hi as u16) << 8));
-        assert_eq!(regs_a.vmaddl, regs_b.vmaddl);
-        assert_eq!(vram_a.vram_latch, vram_b.vram_latch);
-    }
+        assert_eq!(regs_a.vmadd, regs_b.vmadd);
 
-    /// read_vmdata with increment-by-32 must advance the address by 32.
-    #[test]
-    fn test_read_vmdata_increment_by_32() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC32_AFTER_HIGH, 0x00, 0x00);
-        vram.load_latch(regs.vmaddl, regs.vmaddh);
-
+        // Increment by 32 and 128
+        let mut regs = make_regs(VMAIN_INC32_AFTER_HIGH, 0x0000);
+        vram.load_latch(regs.vmadd);
         vram.read_vmdata(&mut regs);
+        assert_eq!(regs.vmadd, 32);
 
-        let addr = (regs.vmaddl as u16) | ((regs.vmaddh as u16) << 8);
-        assert_eq!(addr, 32);
-    }
-
-    /// read_vmdata with increment-by-128 must advance the address by 128.
-    #[test]
-    fn test_read_vmdata_increment_by_128() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC128_AFTER_HIGH, 0x00, 0x00);
-        vram.load_latch(regs.vmaddl, regs.vmaddh);
-
+        let mut regs = make_regs(VMAIN_INC128_AFTER_HIGH, 0x0000);
+        vram.load_latch(regs.vmadd);
         vram.read_vmdata(&mut regs);
-
-        let addr = (regs.vmaddl as u16) | ((regs.vmaddh as u16) << 8);
-        assert_eq!(addr, 128);
-    }
-
-    /// A full write_vmdata + read_vmdata round-trip must return the original word.
-    #[test]
-    fn test_write_vmdata_read_vmdata_round_trip() {
-        let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x10, 0x00);
-
-        vram.write_vmdata(&mut regs, 0xCAFE);
-        vram.write_vmadd(&mut regs, 0x0010);
-
-        let word = vram.read_vmdata(&mut regs);
-
-        assert_eq!(word, 0xCAFE);
+        assert_eq!(regs.vmadd, 128);
     }
 
     // ============================================================
     // load_latch
     // ============================================================
 
-    /// load_latch must copy the word at the composed address into vram_latch.
+    /// load_latch copies the word at the given address into vram_latch.
     #[test]
-    fn test_load_latch_copies_word() {
-        let mut vram = VRAM::new();
-        vram.memory[0x0200] = 0xF00D;
-
-        vram.load_latch(0x00, 0x02); // address = 0x0200
-
-        assert_eq!(vram.vram_latch, 0xF00D);
-    }
-
-    /// load_latch at address 0 must latch the first word.
-    #[test]
-    fn test_load_latch_address_zero() {
+    fn test_load_latch() {
         let mut vram = VRAM::new();
         vram.memory[0x0000] = 0x1111;
+        vram.memory[0x0200] = 0xF00D;
 
-        vram.load_latch(0x00, 0x00);
-
+        vram.load_latch(0x0000);
         assert_eq!(vram.vram_latch, 0x1111);
+
+        vram.load_latch(0x0200);
+        assert_eq!(vram.vram_latch, 0xF00D);
     }
 
     // ============================================================
     // Address wrap-around
     // ============================================================
 
-    /// The effective VRAM address is 15-bit (0x0000–0x7FFF); incrementing past 0x7FFF must wrap to 0x0000.
+    /// The effective VRAM address is 15-bit (0x0000–0x7FFF);
+    /// incrementing past 0x7FFF must wrap to 0x0000.
     #[test]
     fn test_address_wraps_at_0x7fff() {
         let mut vram = VRAM::new();
-        vram.memory[0x0000] = 0xFFFF;
-        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0xFF, 0x7F);
+        let mut regs = make_regs(VMAIN_INC1_AFTER_LOW, 0x7FFF);
 
-        // Write something at 0x7FFF
         vram.write_vmdatal(&mut regs, 0xAA);
 
-        // Address must have wrapped to 0x0000
-        assert_eq!(regs.vmaddl, 0x00);
-        assert_eq!(regs.vmaddh, 0x00);
+        assert_eq!(regs.vmadd, 0x0000);
     }
 
     // ============================================================
@@ -883,31 +577,34 @@ mod tests {
     #[test]
     fn test_round_trip_write_then_read() {
         let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x10, 0x00);
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0010);
 
-        // Write low byte (no increment yet: high-byte mode)
         vram.write_vmdatal(&mut regs, 0x56);
-        // Write high byte (increments here)
         vram.write_vmdatah(&mut regs, 0x78);
+        vram.write_vmadd(&mut regs, 0x0010);
 
-        // Reset address back to 0x0010 to read
-        vram.write_vmadd_low(&mut regs, 0x10);
-        vram.write_vmadd_high(&mut regs, 0x00);
+        assert_eq!(vram.read_vmdatal(&mut regs), 0x56);
+        assert_eq!(vram.read_vmdatah(&mut regs), 0x78);
+    }
 
-        let lo = vram.read_vmdatal(&mut regs);
-        let hi = vram.read_vmdatah(&mut regs);
+    /// write_vmdata + read_vmdata round-trip must return the original word.
+    #[test]
+    fn test_write_vmdata_read_vmdata_round_trip() {
+        let mut vram = VRAM::new();
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0010);
 
-        assert_eq!(lo, 0x56);
-        assert_eq!(hi, 0x78);
+        vram.write_vmdata(&mut regs, 0xCAFE);
+        vram.write_vmadd(&mut regs, 0x0010);
+
+        assert_eq!(vram.read_vmdata(&mut regs), 0xCAFE);
     }
 
     /// Sequential writes at incrementing addresses must not corrupt adjacent words.
     #[test]
     fn test_sequential_writes_dont_corrupt_neighbours() {
         let mut vram = VRAM::new();
-        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x00, 0x00);
+        let mut regs = make_regs(VMAIN_INC1_AFTER_HIGH, 0x0000);
 
-        // Write 0xAABB at address 0, 0xCCDD at address 1, using low-byte increment mode.
         vram.write_vmdatal(&mut regs, 0xBB);
         vram.write_vmdatah(&mut regs, 0xAA);
         vram.write_vmdatal(&mut regs, 0xDD);


### PR DESCRIPTION
## 📝 Description

The PPURegisters struct has been reorganized to reflect the groupings visible in the [PPU register table](https://snes.nesdev.org/wiki/PPU_registers):
`oamaddl` + `oamaddh` -> `oamadd`: u16
`bg1sc` / `bg2sc` / `bg3sc` / `bg4sc` -> `bgsc`: [u8; 4]
`bg2hofs` / `bg3hofs` / `bg4hofs` -> bghofs: [u16; 3]
`bg2vofs` / `bg3vofs` /  `bg4vofs` -> bgvofs: [u16; 3]
`vmaddl` + `vmaddh` -> `vmadd`: u16
`vmdatal` + `vmdatah` -> `vmdata`: u16
`vmdatalread` + `vmdatahread` -> `vmdataread`: u16
`mpyl` + `mpym` + `mpyh` -> `mpy`: u32

The latch fields have also been corrected: `bg1hofs_latch` / `bg1vofs_latch` / `cgdata_latch` are replaced by `bgofs_latch`, `bghofs_latch`, `mode7_latch`, `cgram_latch`, `ophct_latch`, and `opvct_latch`, covering all registers that share a latch.

Access type annotations (W8, W16, W8x2, R8, R16, R24, R8x2) have been added in every register comment.

⚠️ This branch depends on PR#67 to be tested properly.

## 🔍 Related Issues

Closes EpitechPromo2027/G-EIP-600-NAN-6-1-eip-florent.charpentier#70
