### PR TITLE
:sparkles: Link main program <-> plugins <-> CPU

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v5.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.92.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Install SDL2
         uses: libsdl-org/setup-sdl@main
@@ -57,7 +57,7 @@ jobs:
           key: ${{ runner.os }}-cargo-tarpaulin
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@1.92.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Install cargo-tarpaulin if not cached
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,6 +2701,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "plugins"
 version = "0.1.0"
 dependencies = [
+ "common",
  "derive_aliases",
  "eframe",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "perm_tree_node_derive",
  "permission_derive_macro",
  "piccolo",
+ "product_order",
  "strict_partial_ord_derive",
 ]
 
@@ -2830,6 +2831,24 @@ dependencies = [
  "quote",
  "syn",
  "version_check",
+]
+
+[[package]]
+name = "product_order"
+version = "0.1.0"
+dependencies = [
+ "duplicate",
+ "product_order_derive",
+]
+
+[[package]]
+name = "product_order_derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "runtime-macros",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,6 +2638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "piccolo-util"
+version = "0.3.3"
+source = "git+https://github.com/kyren/piccolo#ce709eb1dae5c543cbc78e7e12bb80249d88c55f"
+dependencies = [
+ "gc-arena",
+ "piccolo",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,6 +2898,9 @@ dependencies = [
  "clap",
  "common",
  "cpu",
+ "piccolo",
+ "piccolo-util",
+ "plugins",
  "ppu",
  "rfd",
  "sdl2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,7 +2710,6 @@ dependencies = [
  "permission_derive_macro",
  "piccolo",
  "product_order",
- "strict_partial_ord_derive",
 ]
 
 [[package]]
@@ -2846,6 +2845,7 @@ name = "product_order_derive"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
+ "product_order",
  "quote",
  "runtime-macros",
  "syn",
@@ -3446,16 +3446,6 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
-
-[[package]]
-name = "strict_partial_ord_derive"
-version = "0.1.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "runtime-macros",
- "syn",
-]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "plugins/strict_partial_ord_derive",
     "plugins/perm_tree_node_derive",
     "ppu",
+    "product_order",
 ]
 
 # common dependencies used across the workspace
@@ -22,6 +23,7 @@ members = [
 piccolo = { git = "https://github.com/kyren/piccolo" }
 piccolo-util = { git = "https://github.com/kyren/piccolo" }
 common = { version = "0.1.0", path = "./common"}
+duplicate = "2.0.1"
 
 [dependencies]
 common.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
 # common dependencies used across the workspace
 [workspace.dependencies]
 piccolo = { git = "https://github.com/kyren/piccolo" }
+piccolo-util = { git = "https://github.com/kyren/piccolo" }
 
 [dependencies]
 common = { version = "0.1.0", path = "./common"}
@@ -27,6 +28,10 @@ bus = { version = "0.1.0", path = "./bus"}
 cpu = { version = "0.1.0", path = "./cpu"}
 ppu = { version = "0.1.0", path = "./ppu"}
 apu = { version = "0.1.0", path = "./apu"}
+
+plugins = { version = "0.1.0", path = "./plugins", optional = true }
+piccolo = { workspace = true, optional = true }
+piccolo-util = { workspace = true, optional = true }
 
 rfd = "0.17.2"
 clap = { version = "^4.6.0", features = ["derive"], optional = true }
@@ -39,7 +44,8 @@ sdl2 = { version = "0.38.0"}
 
 [features]
 cli = ["dep:clap"]
-default = ["cli"]
+plugins = ["dep:piccolo", "dep:piccolo-util", "dep:plugins"]
+default = ["cli", "plugins"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ members = [
 [workspace.dependencies]
 piccolo = { git = "https://github.com/kyren/piccolo" }
 piccolo-util = { git = "https://github.com/kyren/piccolo" }
+common = { version = "0.1.0", path = "./common"}
 
 [dependencies]
-common = { version = "0.1.0", path = "./common"}
+common.workspace = true
 bus = { version = "0.1.0", path = "./bus"}
 cpu = { version = "0.1.0", path = "./cpu"}
 ppu = { version = "0.1.0", path = "./ppu"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
     "cpu/instr_metalang_procmacro",
     "plugins",
     "plugins/permission_derive_macro",
-    "plugins/strict_partial_ord_derive",
     "plugins/perm_tree_node_derive",
     "ppu",
     "product_order",
+    "product_order/product_order_derive",
 ]
 
 # common dependencies used across the workspace

--- a/cpu/Cargo.toml
+++ b/cpu/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 common = { version = "0.1.0", path = "../common"}
 instr_metalang_procmacro = { path = "./instr_metalang_procmacro" }
-duplicate = "2.0.0"
+duplicate.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/cpu/src/cpu.rs
+++ b/cpu/src/cpu.rs
@@ -82,6 +82,13 @@ impl CPU {
         &self.addr_bus
     }
 
+    pub fn is_instr_start(&self) -> bool {
+        std::ptr::fn_addr_eq(
+            self.next_cycle.0,
+            opcode_dispatch as for<'a> fn(&'a mut CPU) -> (CycleResult, InstrCycle),
+        )
+    }
+
     /// Execute a single CPU cycle.
     ///
     /// This function is the core part of the public API to this struct.

--- a/cpu/src/cpu.rs
+++ b/cpu/src/cpu.rs
@@ -82,6 +82,8 @@ impl CPU {
         &self.addr_bus
     }
 
+    /// Checks if the next cycle that will be executed is the
+    /// first cycle of an instruction
     pub fn is_instr_start(&self) -> bool {
         std::ptr::fn_addr_eq(
             self.next_cycle.0,

--- a/cpu/src/instrs/algorithms.rs
+++ b/cpu/src/instrs/algorithms.rs
@@ -30,7 +30,7 @@ pub fn cmp<T: Reg>(a: &mut T, idb: T, p: &mut RegisterP) {
 
 pub fn adc<T: Reg>(a: &mut T, idb: T, p: &mut RegisterP) {
     if p.D {
-        todo!("decimal mode is not supported yet");
+        eprintln!("decimal mode is not supported yet");
     } else {
         let (res, carry_out) = a.carrying_add(idb, p.C);
 

--- a/cpu/src/instrs/instr_tab.rs
+++ b/cpu/src/instrs/instr_tab.rs
@@ -125,7 +125,7 @@ const INSTR_CYC1: [InstrCycle; 256] = [
     /* 4b */ InstrCycle(phk_cyc1),
     /* 4c */ InstrCycle(jmp_abs_cyc1),
     /* 4d */ InstrCycle(eor::abs_cyc1),
-    /* 4e */ InstrCycle(lsr_d_cyc1),
+    /* 4e */ InstrCycle(lsr_abs_cyc1),
     /* 4f */ InstrCycle(eor::absl_cyc1),
     /* 50 */ InstrCycle(bvc_cyc1),
     /* 51 */ InstrCycle(eor::dindy_cyc1),

--- a/cpu/src/instrs/instr_tab.rs
+++ b/cpu/src/instrs/instr_tab.rs
@@ -30,8 +30,12 @@ pub(crate) fn opcode_fetch(cpu: &mut CPU) -> (CycleResult, InstrCycle) {
 
     (
         CycleResult::Read,
-        InstrCycle(|next_cyc_cpu| (INSTR_CYC1[next_cyc_cpu.data_bus as usize].0)(next_cyc_cpu)),
+        InstrCycle(opcode_dispatch),
     )
+}
+
+pub(crate) fn opcode_dispatch(cpu: &mut CPU) -> (CycleResult, InstrCycle) {
+    (INSTR_CYC1[cpu.data_bus as usize].0)(cpu)
 }
 
 macro_rules! todo_opcode {

--- a/cpu/src/registers.rs
+++ b/cpu/src/registers.rs
@@ -127,16 +127,16 @@ impl From<u8> for RegisterP {
     }
 }
 
-impl Into<u8> for RegisterP {
-    fn into(self) -> u8 {
-        u8::from(self.C) << 0
-            | u8::from(self.Z) << 1
-            | u8::from(self.I) << 2
-            | u8::from(self.D) << 3
-            | u8::from(self.X) << 4
-            | u8::from(self.M) << 5
-            | u8::from(self.V) << 6
-            | u8::from(self.N) << 7
+impl From<RegisterP> for u8 {
+    fn from(val: RegisterP) -> Self {
+        u8::from(val.C) << 0
+            | u8::from(val.Z) << 1
+            | u8::from(val.I) << 2
+            | u8::from(val.D) << 3
+            | u8::from(val.X) << 4
+            | u8::from(val.M) << 5
+            | u8::from(val.V) << 6
+            | u8::from(val.N) << 7
     }
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -43,16 +43,16 @@
     },
     "rust-nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
-    rust-nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
+    rust-nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
   };
 
   outputs =
@@ -25,10 +25,10 @@
           libGL
           SDL2
 
-          xorg.libXcursor
-          xorg.libXrandr
-          xorg.libXi
-          xorg.libX11
+          libXcursor
+          libXrandr
+          libXi
+          libX11
           SDL2
         ];
       in

--- a/plugin.lua
+++ b/plugin.lua
@@ -1,0 +1,1 @@
+plugins/plugin.lua

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-strict_partial_ord_derive = { path = "strict_partial_ord_derive" }
+product_order = { version = "0.1.0", path = "../product_order" }
 permission_derive_macro = { path = "permission_derive_macro" }
 perm_tree_node_derive = { path = "perm_tree_node_derive" }
 common.workspace = true

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 strict_partial_ord_derive = { path = "strict_partial_ord_derive" }
 permission_derive_macro = { path = "permission_derive_macro" }
 perm_tree_node_derive = { path = "perm_tree_node_derive" }
+common.workspace = true
 
 egui = "0.34.1"
 eframe = { version = "0.34.1", optional = true, features = ["wgpu"] }

--- a/plugins/perm_tree_node_derive/src/lib.rs
+++ b/plugins/perm_tree_node_derive/src/lib.rs
@@ -54,13 +54,13 @@ impl ToTokens for PermTreeNodeDerive {
                 // `<root> = { internal = { ... }, external = { ... } }
                 (piccolo::Value::String(s), _) if s.as_bytes() == #bytestring => {
                     // recurse in the named field's `from_lua` implementation
-                    ret.#ident = <#typ>::from_lua(ctx, val)?;
+                    ret.#ident = <#typ as PermTreeNode>::from_lua(ctx, val)?;
                 }
 
                 // match arms for indexed fields (implicit = "all"):
                 // `<root> = { "internal", "external" }
                 (_, piccolo::Value::String(s)) if s.as_bytes() == #bytestring => {
-                    ret.#ident = <#typ>::all();
+                    ret.#ident = <#typ as Permission>::all();
                 }
             }
         });

--- a/plugins/permission_derive_macro/src/lib.rs
+++ b/plugins/permission_derive_macro/src/lib.rs
@@ -47,13 +47,13 @@ impl ToTokens for PermDerive {
             let ident = &f.ident;
             let typ = &f.ty;
 
-            quote! { #ident: #typ::all() }
+            quote! { #ident: <#typ as Permission>::all() }
         });
         let members_none_call = self.item.fields.iter().map(|f| {
             let ident = &f.ident;
             let typ = &f.ty;
 
-            quote! { #ident: #typ::none() }
+            quote! { #ident: <#typ as Permission>::none() }
         });
 
         tokens.extend(quote!(

--- a/plugins/plugin.lua
+++ b/plugins/plugin.lua
@@ -23,23 +23,15 @@ function print_results()
             ko = ko + 1
         end
     end
-    print(ok .. " successes; " .. ko .. " failures")
+
+    local total = ok + ko
+    print(ok .. "/" .. total .. " passed (" .. (ok*100)/total .. "%), " .. ko .. " failures")
 end
 
 return {
     permissions = { internal = { "cpu", "input" } },
 
     init = function()
-        print("loaded rsnes? type: " .. type(rsnes))
-        print("loaded regs? type: " .. type(rsnes.cpu))
-        print("loaded regs? type: " .. type(rsnes.input))
-        print("loaded require? type: " .. type(require))
-
-        print("plugin: addrbus is currently " .. rsnes.cpu.bus_bank .. ":" .. rsnes.cpu.bus_addr)
-        print("plugin: PB:PC is currently " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc)
-        rsnes.cpu.pb = 0xaa
-        print("plugin: PB:PC is currently " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc)
-
         test_results = {}
         test_idx = 0
     end,
@@ -49,6 +41,8 @@ return {
     actions = {
         default = function()
             print("Current PB:PC: " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc .. "; test_idx: " .. test_idx)
+
+            print_results()
         end,
     },
 

--- a/plugins/plugin.lua
+++ b/plugins/plugin.lua
@@ -1,14 +1,18 @@
 return {
     permissions = "all",
     init = function()
-        i = 10
-        print("plugin initialised: i =", i)
+        print("loaded rsnes? type: " .. type(rsnes))
+        print("loaded regs? type: " .. type(regs))
+
+        print("plugin: addrbus is currently " .. regs.bus_bank .. ":" .. regs.bus_addr)
+        print("plugin: PB:PC is currently " .. regs.pb .. ":" .. regs.pc)
+        regs.pb = 0xaa
+        print("plugin: PB:PC is currently " .. regs.pb .. ":" .. regs.pc)
     end,
 
     actions = {
         default = function()
-            i = i + 1
-            print("ran plugin default action, i =", i)
+            print("ran plugin default action")
         end,
     }
 }

--- a/plugins/plugin.lua
+++ b/plugins/plugin.lua
@@ -2,17 +2,17 @@ return {
     permissions = "all",
     init = function()
         print("loaded rsnes? type: " .. type(rsnes))
-        print("loaded regs? type: " .. type(regs))
+        print("loaded regs? type: " .. type(rsnes.cpu))
 
-        print("plugin: addrbus is currently " .. regs.bus_bank .. ":" .. regs.bus_addr)
-        print("plugin: PB:PC is currently " .. regs.pb .. ":" .. regs.pc)
-        regs.pb = 0xaa
-        print("plugin: PB:PC is currently " .. regs.pb .. ":" .. regs.pc)
+        print("plugin: addrbus is currently " .. rsnes.cpu.bus_bank .. ":" .. rsnes.cpu.bus_addr)
+        print("plugin: PB:PC is currently " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc)
+        rsnes.cpu.pb = 0xaa
+        print("plugin: PB:PC is currently " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc)
     end,
 
     actions = {
         default = function()
-            print("ran plugin default action")
+            print("ran plugin default action, addr: " .. rsnes.cpu.bus_addr)
         end,
     }
 }

--- a/plugins/plugin.lua
+++ b/plugins/plugin.lua
@@ -1,15 +1,15 @@
 return {
-    permissions = "all",
+    permissions = { internal = { "cpu", "input" } },
+
     init = function()
         print("loaded rsnes? type: " .. type(rsnes))
         print("loaded regs? type: " .. type(rsnes.cpu))
+        print("loaded regs? type: " .. type(rsnes.input))
 
         print("plugin: addrbus is currently " .. rsnes.cpu.bus_bank .. ":" .. rsnes.cpu.bus_addr)
         print("plugin: PB:PC is currently " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc)
         rsnes.cpu.pb = 0xaa
         print("plugin: PB:PC is currently " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc)
-
-        instrs = {}
 
         test_results = {}
         test_idx = 0
@@ -17,12 +17,6 @@ return {
 
     actions = {
         default = function()
-            -- print("program so far:")
-
-            -- for addr,data in pairs(instrs) do
-            --     print(addr, data[1] .. "×" .. data[2])
-            -- end
-
             print("test results:")
             local ok=0
             local ko=0
@@ -42,9 +36,6 @@ return {
 
     autoactions = {
         on_instr = function(opcode, pb, pc)
-            -- -- we're never interested in anything where pb is not 0
-            -- if (pb ~= 0) then return end
-
             -- init_test addr: start of a test mark as success by default
             if (pc == 0x8132) then
                 test_results[test_idx] = true
@@ -54,16 +45,14 @@ return {
             -- fail addr: test completed and failed, mark as failed
             if (pc == 0x81AE) then
                 test_results[test_idx - 1] = false
+                rsnes.input.press_a() -- we need to press then release to go next
                 return
             end
-
-            -- local addr = (pb << 16) + pc
-
-            -- if (instrs[addr] == nil) then
-            --     instrs[addr] = { opcode, 1 }
-            -- else
-            --     instrs[addr][2] = instrs[addr][2] + 1
-            -- end
+            -- wait_release addr: test ROM is waiting for A to be released
+            if (pc == 0x824E) then
+                rsnes.input.release_a() -- release A to go to next test
+                return
+            end
         end,
     },
 }

--- a/plugins/plugin.lua
+++ b/plugins/plugin.lua
@@ -8,11 +8,62 @@ return {
         print("plugin: PB:PC is currently " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc)
         rsnes.cpu.pb = 0xaa
         print("plugin: PB:PC is currently " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc)
+
+        instrs = {}
+
+        test_results = {}
+        test_idx = 0
     end,
 
     actions = {
         default = function()
-            print("ran plugin default action, addr: " .. rsnes.cpu.bus_addr)
+            -- print("program so far:")
+
+            -- for addr,data in pairs(instrs) do
+            --     print(addr, data[1] .. "×" .. data[2])
+            -- end
+
+            print("test results:")
+            local ok=0
+            local ko=0
+
+            for i=0,(test_idx-1) do
+                local res = test_results[i]
+                print(i, res)
+                if (res) then
+                    ok = ok + 1
+                else
+                    ko = ko + 1
+                end
+            end
+            print("OK: " .. ok .. ", KO: " .. ko)
         end,
-    }
+    },
+
+    autoactions = {
+        on_instr = function(opcode, pb, pc)
+            -- -- we're never interested in anything where pb is not 0
+            -- if (pb ~= 0) then return end
+
+            -- init_test addr: start of a test mark as success by default
+            if (pc == 0x8132) then
+                test_results[test_idx] = true
+                test_idx = test_idx + 1
+                return
+            end
+            -- fail addr: test completed and failed, mark as failed
+            if (pc == 0x81AE) then
+                test_results[test_idx - 1] = false
+                return
+            end
+
+            -- local addr = (pb << 16) + pc
+
+            -- if (instrs[addr] == nil) then
+            --     instrs[addr] = { opcode, 1 }
+            -- else
+            --     instrs[addr][2] = instrs[addr][2] + 1
+            -- end
+        end,
+    },
 }

--- a/plugins/plugin.lua
+++ b/plugins/plugin.lua
@@ -1,3 +1,31 @@
+function print_results()
+    -- $0:81A2 is the address of the @end label of both test ROMs,
+    -- which is a JMP instruction that jumps to itself (creating an
+    -- infinite loop)
+    if test_idx == 0x453 and rsnes.cpu.pb == 0 and rsnes.cpu.pc == 0x81A2 then
+        print("Successfully reached end of cputest-basic, ran 0x453 (1107) tests")
+    elseif test_idx == 0x64A and rsnes.cpu.pb == 0 and rsnes.cpu.pc == 0x81A2 then
+        print("Successfully reached end of cputest-full, ran 0x64A (1610) tests")
+    else
+        print("Early exit: ROM did not complete")
+        return
+    end
+
+    local ok=0
+    local ko=0
+
+    for i=0,(test_idx-1) do
+        local res = test_results[i]
+        -- print(i, res)
+        if res then
+            ok = ok + 1
+        else
+            ko = ko + 1
+        end
+    end
+    print(ok .. " successes; " .. ko .. " failures")
+end
+
 return {
     permissions = { internal = { "cpu", "input" } },
 
@@ -5,6 +33,7 @@ return {
         print("loaded rsnes? type: " .. type(rsnes))
         print("loaded regs? type: " .. type(rsnes.cpu))
         print("loaded regs? type: " .. type(rsnes.input))
+        print("loaded require? type: " .. type(require))
 
         print("plugin: addrbus is currently " .. rsnes.cpu.bus_bank .. ":" .. rsnes.cpu.bus_addr)
         print("plugin: PB:PC is currently " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc)
@@ -15,41 +44,34 @@ return {
         test_idx = 0
     end,
 
+    exit = print_results,
+
     actions = {
         default = function()
-            print("test results:")
-            local ok=0
-            local ko=0
-
-            for i=0,(test_idx-1) do
-                local res = test_results[i]
-                print(i, res)
-                if (res) then
-                    ok = ok + 1
-                else
-                    ko = ko + 1
-                end
-            end
-            print("OK: " .. ok .. ", KO: " .. ko)
+            print("Current PB:PC: " .. rsnes.cpu.pb .. ":" .. rsnes.cpu.pc .. "; test_idx: " .. test_idx)
         end,
     },
 
     autoactions = {
         on_instr = function(opcode, pb, pc)
+            if pb ~= 0 then return end
+
             -- init_test addr: start of a test mark as success by default
-            if (pc == 0x8132) then
+            if pc == 0x8132 then
                 test_results[test_idx] = true
                 test_idx = test_idx + 1
                 return
             end
+
             -- fail addr: test completed and failed, mark as failed
-            if (pc == 0x81AE) then
+            if pc == 0x81AE then
                 test_results[test_idx - 1] = false
                 rsnes.input.press_a() -- we need to press then release to go next
                 return
             end
+
             -- wait_release addr: test ROM is waiting for A to be released
-            if (pc == 0x824E) then
+            if pc == 0x824E then
                 rsnes.input.release_a() -- release A to go to next test
                 return
             end

--- a/plugins/src/derive_alias.rs
+++ b/plugins/src/derive_alias.rs
@@ -4,7 +4,7 @@ derive_aliases::define! {
         ::core::cmp::PartialEq,
         ::core::cmp::Eq,
         ::core::fmt::Debug,
-        ::strict_partial_ord_derive::PartialOrd,
+        ::product_order::PartialOrd,
         ::permission_derive_macro::Permission,
         ::perm_tree_node_derive::PermTreeNode;
 }

--- a/plugins/src/perm_tree.rs
+++ b/plugins/src/perm_tree.rs
@@ -71,6 +71,7 @@ pub struct InternalPermissions {
     pub cpu: CpuPermissions,
     pub ppu: PpuPermissions,
     pub bus: BusPermissions,
+    pub input: bool,
 }
 
 #[derive(..PermTree)]

--- a/plugins/src/perm_tree.rs
+++ b/plugins/src/perm_tree.rs
@@ -27,7 +27,7 @@ use piccolo::{Context, Value};
 
 /// Permission tree nodes can be constructed from lua values
 /// read from plugin files.
-pub trait PermTreeNode : Sized {
+pub trait PermTreeNode: Sized {
     fn from_lua<'gc>(ctx: Context<'gc>, value: Value<'gc>) -> Option<Self>;
 }
 
@@ -39,7 +39,7 @@ pub trait PermTreeNode : Sized {
 /// By default, lua values other than these two strings will fail to
 /// build the permission node, additional cases can be added by overriding
 /// the default implementation of [`from_lua_leaf`].
-trait PermTreeLeafNode : Permission {
+trait PermTreeLeafNode: Permission {
     /// Fallback method for when the leaf node is constructed with something
     /// other than `"all"` and `"none"`.
     fn from_lua_leaf<'gc>(_: Context<'gc>, _: Value<'gc>) -> Option<Self> {
@@ -111,23 +111,28 @@ pub struct FileSystemPermissions {
 #[cfg(test)]
 mod test {
     use super::*;
-    use piccolo::{Lua, Closure, Executor, Value};
+    use piccolo::{Closure, Executor, Lua, Value};
 
     fn build_from_lua<T, F>(lua_str: &str, f: F) -> T
-    where F: for<'gc> FnOnce(Context<'gc>, Value<'gc>) -> T {
+    where
+        F: for<'gc> FnOnce(Context<'gc>, Value<'gc>) -> T,
+    {
         let mut lua = Lua::empty();
 
-        let ex = lua.try_enter(|ctx| {
-            let closure = Closure::load(ctx, None, format!("return {}", lua_str).as_bytes())?;
-            let ex = Executor::start(ctx, closure.into(), ());
+        let ex = lua
+            .try_enter(|ctx| {
+                let closure = Closure::load(ctx, None, format!("return {}", lua_str).as_bytes())?;
+                let ex = Executor::start(ctx, closure.into(), ());
 
-            Ok(ctx.stash(ex))
-        }).expect("a valid executor");
+                Ok(ctx.stash(ex))
+            })
+            .expect("a valid executor");
 
         lua.finish(&ex).expect("successful execution");
         lua.enter(|ctx| {
             let ex = ctx.fetch(&ex);
-            let val: Value = ex.take_result(ctx)
+            let val: Value = ex
+                .take_result(ctx)
                 .expect("correct executor mode")
                 .expect("no lua error");
 
@@ -148,19 +153,21 @@ mod test {
 
     #[test]
     fn detailed_tree_construction() {
-        let tree = build_perm_tree(r#"{
-            internal = {
-                control = "all",
-                bus = { "read" },
-                "cpu",
-            },
-            external = {
-                filesystem = {
-                    read = "all",
-                    write = "none",
+        let tree = build_perm_tree(
+            r#"{
+                internal = {
+                    control = "all",
+                    bus = { "read" },
+                    "cpu",
                 },
-            },
-        }"#);
+                external = {
+                    filesystem = {
+                        read = "all",
+                        write = "none",
+                    },
+                },
+            }"#,
+        );
 
         let expected_tree = RSnesPermissions {
             internal: InternalPermissions {

--- a/plugins/src/permission.rs
+++ b/plugins/src/permission.rs
@@ -1,3 +1,5 @@
+pub mod helpers;
+
 /// Trait representing any kind of permission, with varying degrees
 ///
 /// [`Permission`] requires the implementor to define two levels of granted permissions:

--- a/plugins/src/permission/helpers.rs
+++ b/plugins/src/permission/helpers.rs
@@ -1,0 +1,136 @@
+use super::Permission;
+
+/// Helper enum to make it easier to implement
+/// [`Permission`] on types which don't have a fitting
+/// value to represent [`Permission::all`], but already
+/// have a notion of "none".
+/// T's [`Default`] implementation will be used to represent "none"
+///
+/// For example, a Vec can use the empty vector as a representation
+/// of "none", but does not have a fitting representation of "all"
+#[derive(Debug)]
+pub enum AllOr<T> {
+    /// Artificially added "all" value
+    All,
+
+    /// The wrapped type, which already has a notion of "none"
+    Inner(T),
+}
+
+impl<T: Default> Default for AllOr<T> {
+    fn default() -> Self {
+        Self::Inner(T::default())
+    }
+}
+
+impl<T: PartialEq> PartialEq for AllOr<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::All, Self::All) => true,
+            (Self::Inner(i1), Self::Inner(i2)) => i1.eq(i2),
+
+            _ => false,
+        }
+    }
+}
+impl<T: Eq> Eq for AllOr<T> {}
+
+impl<T: PartialOrd> PartialOrd for AllOr<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (self, other) {
+            (Self::All, Self::All) => Some(std::cmp::Ordering::Equal),
+
+            (_, Self::All) => Some(std::cmp::Ordering::Less),
+            (Self::All, _) => Some(std::cmp::Ordering::Greater),
+
+            (Self::Inner(i1), Self::Inner(i2)) => i1.partial_cmp(i2),
+        }
+    }
+}
+
+impl<T: Eq + PartialOrd + Default> Permission for AllOr<T> {
+    fn all() -> Self {
+        Self::All
+    }
+
+    fn none() -> Self {
+        Self::Inner(T::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Permission;
+    use std::collections::HashSet;
+
+    use crate::permission::helpers::AllOr;
+
+    #[derive(Default, PartialEq, Eq)]
+    struct ListOfAllowedThings {
+        pub things: HashSet<String>,
+    }
+
+    impl PartialOrd for ListOfAllowedThings {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            // simple case for equality: compare equal
+            if self == other {
+                return Some(std::cmp::Ordering::Equal);
+            }
+
+            // subset / superset relations define a partial order, use them
+            if self.things.is_superset(&other.things) {
+                return Some(std::cmp::Ordering::Greater);
+            }
+            if self.things.is_subset(&other.things) {
+                return Some(std::cmp::Ordering::Less);
+            }
+
+            // otherwise, no real order can be decided between the elements
+            None
+        }
+    }
+
+    type AllowedThingsPerm = AllOr<ListOfAllowedThings>;
+
+    #[test]
+    fn can_build_as_perm() {
+        let all: AllowedThingsPerm = Permission::all();
+        let none: AllowedThingsPerm = Permission::none();
+
+        assert!(all.is_all());
+        assert!(none.is_none());
+
+        assert!(all != none);
+
+        assert!(all > none);
+        assert!(all >= none);
+
+        assert!(none < all);
+        assert!(none <= all);
+    }
+
+    #[test]
+    fn comparisons_work() {
+        let all: AllowedThingsPerm = Permission::all();
+        let none: AllowedThingsPerm = Permission::none();
+
+        let abc = AllowedThingsPerm::Inner(ListOfAllowedThings {
+            things: HashSet::from(["a".into(), "b".into(), "c".into()]),
+        });
+        let ab = AllowedThingsPerm::Inner(ListOfAllowedThings {
+            things: HashSet::from(["a".into(), "b".into()]),
+        });
+
+        assert!(all > abc);
+        assert!(all > ab);
+
+        assert!(none < abc);
+        assert!(none < ab);
+
+        assert!(abc > ab);
+        assert!(abc >= ab);
+
+        assert!(ab < abc);
+        assert!(ab <= abc);
+    }
+}

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -41,6 +41,10 @@ pub struct PluginTable {
     /// The lua function that will be run when the plugin is successfully
     /// loaded, right after the user accepted the permission request
     pub init: Option<picc::StashedClosure>,
+
+    /// The lua function that will be run when the plugin is
+    /// unloaded from the emulator
+    pub exit: Option<picc::StashedClosure>,
 }
 
 /// The plugin "actions" (lua functions) which can be manually
@@ -86,6 +90,14 @@ impl<'gc> picc::FromValue<'gc> for PluginTable {
                     Value::Function(Function::Closure(c)) => Some(ctx.stash(c)),
                     v => return Err(picc::TypeError {
                         expected: "init function or nil",
+                        found: v.type_name(),
+                    }),
+                },
+                b"exit" => ret.exit = match value {
+                    Value::Nil => None,
+                    Value::Function(Function::Closure(c)) => Some(ctx.stash(c)),
+                    v => return Err(picc::TypeError {
+                        expected: "exit function or nil",
                         found: v.type_name(),
                     }),
                 },
@@ -220,6 +232,11 @@ impl Plugin {
             plugin: self,
             allow_all: false,
         }
+    }
+
+    /// Run the exit action registered in the plugin table
+    pub fn run_exit(&mut self) -> Result<(), picc::ExternError> {
+        Self::run_option_lua(&mut self.lua, &self.table.exit)
     }
 
     /// Run the init action registered in the plugin table

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -34,7 +34,7 @@ pub struct PluginTable {
     /// Actions which can be run manually by the user
     pub actions: PluginActions,
 
-    /// The lua function that will be run when the plugin is successully
+    /// The lua function that will be run when the plugin is successfully
     /// loaded, right after the user accepted the permission request
     pub init: Option<picc::StashedClosure>,
 }
@@ -174,28 +174,37 @@ impl Plugin {
         }
     }
 
+    /// Run the init action registered in the plugin table
     pub fn run_init(&mut self) -> Result<(), picc::ExternError> {
-        if let Some(ref init) = self.table.init {
-            return Self::run_lua(&mut self.lua, init);
-        }
-        Ok(())
+        Self::run_option_lua(&mut self.lua, &self.table.init)
     }
 
+    /// Run the default action registered in the plugin table
     pub fn run_default(&mut self) -> Result<(), picc::ExternError> {
-        if let Some(ref default) = self.table.actions.default {
-            return Self::run_lua(&mut self.lua, default);
-        }
-        Ok(())
+        Self::run_option_lua(&mut self.lua, &self.table.actions.default)
     }
 
+    /// Run an Option-wrapped stashed lua function, returning Ok(())
+    /// in case there was None
+    pub fn run_option_lua<F>(lua: &mut picc::Lua, stashed: &Option<F>) -> Result<(), picc::ExternError>
+    where
+        F: for<'gc> picc::stash::Fetchable<Fetched<'gc>: Into<picc::Function<'gc>>>,
+    {
+        let Some(stashed) = stashed.as_ref() else {
+            return Ok(());
+        };
+        Self::run_lua(lua, stashed)
+    }
+
+    /// Runs a stashed lua function in the given lua context
     pub fn run_lua<F, R>(lua: &mut picc::Lua, stashed: &F) -> Result<R, picc::ExternError>
     where
         F: for<'gc> picc::stash::Fetchable<Fetched<'gc>: Into<picc::Function<'gc>>>,
         R: for<'gc> picc::FromMultiValue<'gc>
     {
         let ex = lua.enter(|ctx| {
-            let func = ctx.fetch(stashed);
-            let ex = piccolo::Executor::start(ctx, func.into(), ());
+            let func = ctx.fetch(stashed).into();
+            let ex = piccolo::Executor::start(ctx, func, ());
 
             ctx.stash(ex)
         });

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -7,6 +7,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use std::fs as fs;
+use common::snes_address::SnesAddress;
 use piccolo as picc;
 use piccolo::io as p_io;
 
@@ -34,6 +35,9 @@ pub struct PluginTable {
     /// Actions which can be run manually by the user
     pub actions: PluginActions,
 
+    /// Actions which are run automatically on certain events
+    pub autoactions: PluginAutoActions,
+
     /// The lua function that will be run when the plugin is successfully
     /// loaded, right after the user accepted the permission request
     pub init: Option<picc::StashedClosure>,
@@ -48,6 +52,13 @@ pub struct PluginActions {
     /// The "default" action of the plugin, which can be called manually
     /// by the user as many times as they want
     pub default: Option<picc::StashedClosure>,
+}
+
+/// Plugin "autoactions" (lua functions) which are to be run
+/// automatically on certain events
+#[derive(Debug, Default)]
+pub struct PluginAutoActions {
+    pub on_instr: Option<picc::StashedClosure>,
 }
 
 impl<'gc> picc::FromValue<'gc> for PluginTable {
@@ -85,6 +96,7 @@ impl<'gc> picc::FromValue<'gc> for PluginTable {
                     })?,
 
                 b"actions" => ret.actions = FromValue::from_value(ctx, value)?,
+                b"autoactions" => ret.autoactions = FromValue::from_value(ctx, value)?,
 
                 _ => eprintln!("found unknow key in plugin table: [{:?}]", key.debug_lossy()),
             }
@@ -119,6 +131,42 @@ impl<'gc> picc::FromValue<'gc> for PluginActions {
                     Value::Function(Function::Closure(c)) => Some(ctx.stash(c)),
                     v => return Err(picc::TypeError {
                         expected: "default function or nil",
+                        found: v.type_name(),
+                    }),
+                },
+                _ => eprintln!("found unknow key in plugin table: [{:?}]", key.debug_lossy()),
+            }
+        }
+
+        Ok(ret)
+    }
+}
+
+impl<'gc> picc::FromValue<'gc> for PluginAutoActions {
+    fn from_value(ctx: picc::Context<'gc>, value: picc::Value<'gc>) -> Result<Self, picc::TypeError> {
+        use picc::*;
+
+        let picc::Value::Table(tab) = value else {
+            return Err(picc::TypeError {
+                expected: "table",
+                found: value.type_name()
+            });
+        };
+
+        let mut ret = Self::default();
+
+        for (key, value) in tab {
+            let Value::String(key) = key else {
+                eprintln!("found unexpected non-string key [{}]", key.display());
+                continue;
+            };
+
+            match key.as_bytes() {
+                b"on_instr" => ret.on_instr = match value {
+                    Value::Nil => None,
+                    Value::Function(Function::Closure(c)) => Some(ctx.stash(c)),
+                    v => return Err(picc::TypeError {
+                        expected: "on_instr function or nil",
                         found: v.type_name(),
                     }),
                 },
@@ -184,9 +232,21 @@ impl Plugin {
         Self::run_option_lua(&mut self.lua, &self.table.actions.default)
     }
 
+    /// Run the default action registered in the plugin table
+    pub fn run_on_instr(&mut self, opcode: u8, addr: SnesAddress) -> Result<(), picc::ExternError> {
+        Self::run_option_lua_with_args(
+            &mut self.lua,
+            &self.table.autoactions.on_instr,
+            (opcode, addr.bank, addr.addr),
+        )
+    }
+
     /// Run an Option-wrapped stashed lua function, returning Ok(())
     /// in case there was None
-    pub fn run_option_lua<F>(lua: &mut picc::Lua, stashed: &Option<F>) -> Result<(), picc::ExternError>
+    pub fn run_option_lua<F>(
+        lua: &mut picc::Lua,
+        stashed: &Option<F>
+    ) -> Result<(), picc::ExternError>
     where
         F: for<'gc> picc::stash::Fetchable<Fetched<'gc>: Into<picc::Function<'gc>>>,
     {
@@ -196,15 +256,48 @@ impl Plugin {
         Self::run_lua(lua, stashed)
     }
 
-    /// Runs a stashed lua function in the given lua context
-    pub fn run_lua<F, R>(lua: &mut picc::Lua, stashed: &F) -> Result<R, picc::ExternError>
+    /// Run an Option-wrapped stashed lua function, returning Ok(())
+    /// in case there was None
+    pub fn run_option_lua_with_args<F, A>(
+        lua: &mut picc::Lua,
+        stashed: &Option<F>,
+        args: A
+    ) -> Result<(), picc::ExternError>
     where
         F: for<'gc> picc::stash::Fetchable<Fetched<'gc>: Into<picc::Function<'gc>>>,
-        R: for<'gc> picc::FromMultiValue<'gc>
+        A: for<'gc> picc::IntoMultiValue<'gc>,
+    {
+        let Some(stashed) = stashed.as_ref() else {
+            return Ok(());
+        };
+        Self::run_lua_with_args(lua, stashed, args)
+    }
+
+    pub fn run_lua<F, R>(
+        lua: &mut picc::Lua,
+        stashed: &F
+    ) -> Result<R, picc::ExternError>
+    where
+        F: for<'gc> picc::stash::Fetchable<Fetched<'gc>: Into<picc::Function<'gc>>>,
+        R: for<'gc> picc::FromMultiValue<'gc>,
+    {
+        Self::run_lua_with_args(lua, stashed, ())
+    }
+
+    /// Runs a stashed lua function in the given lua context
+    pub fn run_lua_with_args<F, R, A>(
+        lua: &mut picc::Lua,
+        stashed: &F,
+        args: A
+    ) -> Result<R, picc::ExternError>
+    where
+        F: for<'gc> picc::stash::Fetchable<Fetched<'gc>: Into<picc::Function<'gc>>>,
+        R: for<'gc> picc::FromMultiValue<'gc>,
+        A: for<'gc> picc::IntoMultiValue<'gc>,
     {
         let ex = lua.enter(|ctx| {
             let func = ctx.fetch(stashed).into();
-            let ex = piccolo::Executor::start(ctx, func, ());
+            let ex = piccolo::Executor::start(ctx, func, args);
 
             ctx.stash(ex)
         });

--- a/plugins/strict_partial_ord_derive/src/lib.rs
+++ b/plugins/strict_partial_ord_derive/src/lib.rs
@@ -79,6 +79,7 @@ impl ToTokens for StrictPartialOrd {
                 let member_ord = self.#member.partial_cmp(&other.#member)?;
                 match (#acc_varname, member_ord) {
                     (std::cmp::Ordering::Equal, x) => #acc_varname = x,
+                    (_, std::cmp::Ordering::Equal) => (),
                     (std::cmp::Ordering::Less, std::cmp::Ordering::Less) => (),
                     (std::cmp::Ordering::Greater, std::cmp::Ordering::Greater) => (),
                     _ => return None,

--- a/plugins/strict_partial_ord_derive/tests/lib.rs
+++ b/plugins/strict_partial_ord_derive/tests/lib.rs
@@ -46,3 +46,8 @@ fn not_comparable() {
     p3_pcmp_test((-1., 0., 1.), (0., 0., 0.), None);
     p3_pcmp_test((0., 0., 0.), (0., NAN, 0.), None);
 }
+
+#[test]
+fn less_eq_less() {
+    p3_pcmp_test((0., 0., 0.), (1., 0., 1.), Some(Less));
+}

--- a/product_order/Cargo.toml
+++ b/product_order/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+product_order_derive = { version = "0.1.0", path = "product_order_derive" }
 
 [dev-dependencies]
 duplicate.workspace = true

--- a/product_order/Cargo.toml
+++ b/product_order/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "product_order"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[dev-dependencies]
+duplicate.workspace = true

--- a/product_order/product_order_derive/Cargo.toml
+++ b/product_order/product_order_derive/Cargo.toml
@@ -2,7 +2,7 @@
 proc-macro = true
 
 [package]
-name = "strict_partial_ord_derive"
+name = "product_order_derive"
 version = "0.1.0"
 edition = "2024"
 

--- a/product_order/product_order_derive/Cargo.toml
+++ b/product_order/product_order_derive/Cargo.toml
@@ -13,3 +13,4 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 runtime-macros = "^1.1.1"
+product_order = { path = "../" }

--- a/product_order/product_order_derive/src/lib.rs
+++ b/product_order/product_order_derive/src/lib.rs
@@ -1,14 +1,10 @@
 use {
     proc_macro::TokenStream,
-    quote::{
-        ToTokens,
-        format_ident,
-        quote,
-    },
+    quote::{ToTokens, format_ident, quote},
     syn::{
         ItemStruct,
         parse::{self, Parse, ParseStream},
-    }
+    },
 };
 
 /// Custom derive macro which implements [`std::cmp::PartialOrd`]
@@ -48,7 +44,7 @@ fn derive_partial_ord(input: proc_macro2::TokenStream) -> proc_macro2::TokenStre
     // Parse the annotated item.
     let ast: StrictPartialOrd = match syn::parse2(input) {
         Ok(parsed) => parsed,
-        Err(e) => return e.into_compile_error()
+        Err(e) => return e.into_compile_error(),
     };
 
     // Return the macro's expanded form (the main logic is in `Pod::to_tokens`).
@@ -63,7 +59,9 @@ struct StrictPartialOrd {
 
 impl Parse for StrictPartialOrd {
     fn parse(input: ParseStream) -> parse::Result<Self> {
-        Ok(Self { item: input.call(ItemStruct::parse)? })
+        Ok(Self {
+            item: input.call(ItemStruct::parse)?,
+        })
     }
 }
 
@@ -103,8 +101,8 @@ impl ToTokens for StrictPartialOrd {
 
 #[cfg(test)]
 mod tests {
-    use runtime_macros::emulate_derive_macro_expansion;
     use super::derive_partial_ord;
+    use runtime_macros::emulate_derive_macro_expansion;
     use std::{env, fs};
 
     #[test]
@@ -115,6 +113,10 @@ mod tests {
         path.push("tests");
         path.push("lib.rs");
         let file = fs::File::open(path).unwrap();
-        emulate_derive_macro_expansion(file, &[("strict::PartialOrd", derive_partial_ord)]).unwrap();
+        emulate_derive_macro_expansion(
+            file,
+            &[("product_order_derive::PartialOrd", derive_partial_ord)],
+        )
+        .unwrap();
     }
 }

--- a/product_order/product_order_derive/src/lib.rs
+++ b/product_order/product_order_derive/src/lib.rs
@@ -72,16 +72,12 @@ impl ToTokens for StrictPartialOrd {
         let (impl_generics, ty_generics, where_clause) = self.item.generics.split_for_impl();
 
         let acc_varname = format_ident!("{}", "acc");
-        let members_match_blocks = members.map(|member| {
+        let member_wise_comparisons = members.map(|member| {
             quote! {
-                let member_ord = self.#member.partial_cmp(&other.#member)?;
-                match (#acc_varname, member_ord) {
-                    (std::cmp::Ordering::Equal, x) => #acc_varname = x,
-                    (_, std::cmp::Ordering::Equal) => (),
-                    (std::cmp::Ordering::Less, std::cmp::Ordering::Less) => (),
-                    (std::cmp::Ordering::Greater, std::cmp::Ordering::Greater) => (),
-                    _ => return None,
-                };
+                #acc_varname = ::product_order::combine_ordering(
+                    #acc_varname,
+                    self.#member.partial_cmp(&other.#member)?
+                )?;
             }
         });
 
@@ -90,7 +86,7 @@ impl ToTokens for StrictPartialOrd {
                 fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
                     let mut #acc_varname = std::cmp::Ordering::Equal;
 
-                    #(#members_match_blocks)*
+                    #(#member_wise_comparisons)*
 
                     Some(#acc_varname)
                 }

--- a/product_order/product_order_derive/tests/lib.rs
+++ b/product_order/product_order_derive/tests/lib.rs
@@ -3,9 +3,7 @@ use std::cmp::Ordering;
 use std::cmp::Ordering::*;
 use std::f32::NAN;
 
-use strict_partial_ord_derive as strict;
-
-#[derive(Debug, PartialEq, strict::PartialOrd)]
+#[derive(Debug, PartialEq, product_order_derive::PartialOrd)]
 struct Point3 {
     x: f32,
     y: f32,

--- a/product_order/src/lib.rs
+++ b/product_order/src/lib.rs
@@ -1,3 +1,6 @@
+#[doc(inline)]
+pub use product_order_derive::PartialOrd;
+
 use std::cmp::Ordering;
 
 /// Combine two [`std::cmp::Ordering`]s as per product order

--- a/product_order/src/lib.rs
+++ b/product_order/src/lib.rs
@@ -1,0 +1,86 @@
+use std::cmp::Ordering;
+
+/// Combine two [`std::cmp::Ordering`]s as per product order
+/// logic:
+/// - only return Equal when both elements are Equal
+/// - return Less when we have only Less or Less and Equal
+/// - same as above Greater
+/// - return None in case we have a combination of Greater and Less
+///
+/// This function is commutative: the order of the arguments
+/// doesn't impact the return value
+pub fn combine_ordering(o1: Ordering, o2: Ordering) -> Option<Ordering> {
+    use Ordering::*;
+
+    match (o1, o2) {
+        (Equal, x) | (x, Equal) => Some(x),
+        (Less, Less) => Some(Less),
+        (Greater, Greater) => Some(Greater),
+        _ => None,
+    }
+}
+
+/// Reduce an iterator of [`std::cmp::Ordering`] into a single
+/// `Option<Ordering>`, as per the product order rules described
+/// for [`combine_ordering`].
+///
+/// The order of elements in the iterator don't impact the return
+/// value of this function
+pub fn combine_orderings<I>(iter: I) -> Option<Ordering>
+where
+    I: IntoIterator<Item = Ordering>,
+{
+    let mut acc = Ordering::Equal;
+
+    for i in iter {
+        acc = combine_ordering(acc, i)?;
+    }
+    Some(acc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use Ordering::*;
+    use duplicate::duplicate_item;
+
+    #[test]
+    fn equalities() {
+        assert_eq!(combine_ordering(Equal, Equal), Some(Equal));
+        assert_eq!(combine_orderings([Equal, Equal, Equal, Equal]), Some(Equal));
+    }
+
+    #[duplicate_item(
+        DUP_name    DUP_order;
+        [greater]   [Greater];
+        [less]      [Less];
+    )]
+    #[test]
+    fn DUP_name() {
+        assert_eq!(combine_ordering(Less, Less), Some(Less));
+        assert_eq!(combine_ordering(Equal, Less), Some(Less));
+        assert_eq!(combine_ordering(Less, Equal), Some(Less));
+
+        assert_eq!(combine_orderings([Less]), Some(Less));
+        assert_eq!(
+            combine_orderings([Less, Equal, Equal, Less]),
+            Some(Less)
+        );
+        assert_eq!(
+            combine_orderings([Less, Less, Equal, Less, Equal, Less]),
+            Some(Less)
+        );
+    }
+
+    #[test]
+    fn not_comparable() {
+        assert_eq!(combine_ordering(Less, Greater), None);
+        assert_eq!(combine_ordering(Greater, Less), None);
+
+        assert_eq!(combine_orderings([Greater, Less]), None);
+        assert_eq!(combine_orderings([Less, Greater]), None);
+        assert_eq!(combine_orderings([Less, Greater, Equal, Equal]), None);
+        assert_eq!(combine_orderings([Less, Equal, Equal, Greater]), None);
+        assert_eq!(combine_orderings([Equal, Less, Equal, Greater]), None);
+    }
+}

--- a/product_order/src/lib.rs
+++ b/product_order/src/lib.rs
@@ -3,8 +3,8 @@ pub use product_order_derive::PartialOrd;
 
 use std::cmp::Ordering;
 
-/// Combine two [`std::cmp::Ordering`]s as per product order
-/// logic:
+/// Combine two [`std::cmp::Ordering`]s as per
+/// [product order](https://en.wikipedia.org/wiki/Product_order) logic:
 /// - only return Equal when both elements are Equal
 /// - return Less when we have only Less or Less and Equal
 /// - same as above Greater

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -11,7 +11,7 @@ pub struct Gui {
     event_pump: sdl2::EventPump,
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum RSnesEvent {
     /// Load a new ROM, showing a file picker (closes current game)
     LoadRom { path: PathBuf },

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -14,7 +14,9 @@ pub struct Gui {
 #[derive(PartialEq, Eq, Debug)]
 pub enum RSnesEvent {
     /// Load a new ROM, showing a file picker (closes current game)
-    LoadRom { path: PathBuf },
+    LoadRom {
+        path: PathBuf,
+    },
 
     /// Close the currently open game (or quit if no game open)
     Close,
@@ -27,6 +29,9 @@ pub enum RSnesEvent {
 
     /// An key mapped to an emulated button has been released
     ButtonUp,
+
+    /// Run the `default` action of a plugin (if a plugin is loaded, and if it defines one)
+    RunPluginDefault,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -112,6 +117,16 @@ impl Gui {
                 keycode: Some(Keycode::Space),
                 ..
             } => Some(RSnesEvent::ButtonUp),
+
+            Event::KeyDown {
+                keycode: Some(Keycode::R),
+                keymod,
+                ..
+            } if !keymod
+                .intersects(Mod::LCTRLMOD | Mod::RCTRLMOD | Mod::LALTMOD | Mod::RALTMOD) =>
+            {
+                Some(RSnesEvent::RunPluginDefault)
+            }
 
             _ => None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,90 @@ use ppu::constants::SCREEN_HEIGHT;
 #[cfg(feature = "plugins")]
 use std::{cell::RefCell, rc::Rc};
 use std::{
-    ops::DerefMut, path::{Path, PathBuf}, time::{Duration, Instant}
+    ops::DerefMut,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
 };
 
-fn gui_emu_loop(gui: &mut gui::Gui, emu: rsnes::RSnes) -> Option<RSnesEvent> {
+struct Emu {
+    #[cfg(not(feature = "plugins"))]
+    rsnes: RSnes,
+
+    #[cfg(feature = "plugins")]
+    rsnes: Rc<RefCell<RSnes>>,
+
+    #[cfg(feature = "plugins")]
+    plugin: Option<Plugin>,
+}
+
+impl Emu {
+    pub fn new(rsnes: RSnes) -> Self {
+        cfg_select! {
+            feature = "plugins" => Self {
+                rsnes: Rc::new(RefCell::new(rsnes)),
+                plugin: None,
+            },
+            _ => Self { rsnes },
+        }
+    }
+
+    #[cfg(feature = "plugins")]
+    pub fn new_with_plugin(
+        rsnes: RSnes,
+        mut plugin: Option<Plugin>,
+    ) -> Result<Self, piccolo::ExternError> {
+        let rc = Rc::new(RefCell::new(rsnes));
+
+        if let Some(plugin) = &mut plugin {
+            RSnes::inject_into_lua(&rc, plugin);
+            plugin.run_init()?;
+        }
+        Ok(Self { rsnes: rc, plugin })
+    }
+
+    pub fn rsnes_mut(&mut self) -> impl DerefMut<Target = RSnes> {
+        #[cfg(feature = "plugins")]
+        return self.rsnes.borrow_mut();
+
+        #[cfg(not(feature = "plugins"))]
+        return &mut self.rsnes;
+    }
+
+    #[cfg(feature = "plugins")]
+    pub fn plugin_mut(&mut self) -> Option<&mut Plugin> {
+        self.plugin.as_mut()
+    }
+
+    #[cfg(not(feature = "plugins"))]
+    pub fn update(&mut self) {
+        self.rsnes.update();
+    }
+
+    #[cfg(feature = "plugins")]
+    pub fn update(&mut self) -> Result<(), piccolo::ExternError> {
+        let mut rsnes_mut = self.rsnes.borrow_mut();
+
+        rsnes_mut.update();
+
+        if let Some(plugin) = self.plugin.as_mut() {
+            if let Some(opcode) = rsnes_mut.is_cpu_instr_start() {
+                let addr = *rsnes_mut.cpu.addr_bus();
+                drop(rsnes_mut);
+                return plugin.run_on_instr(opcode, addr);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn gui_emu_loop(
+    gui: &mut gui::Gui,
+    rsnes: RSnes,
+
+    #[cfg(feature = "plugins")]
+    plugin: Option<Plugin>,
+) -> Option<RSnesEvent> {
     let mut frame_nb = 0_u64;
     let exec_start = Instant::now();
 
@@ -24,44 +104,12 @@ fn gui_emu_loop(gui: &mut gui::Gui, emu: rsnes::RSnes) -> Option<RSnesEvent> {
     let mut frame_accum: f64 = 0.0;
     let mut master_cycle_accum: f64 = 0.0;
 
-    #[cfg(feature = "plugins")]
-    let mut plugin = Plugin::load_from_file(Path::new("./plugin.lua")).unwrap();
-
-    #[cfg(feature = "plugins")]
-    let emu_rc = Rc::new(RefCell::new(emu));
-
-    #[cfg(feature = "plugins")]
-    {
-        RSnes::inject_into_lua(&emu_rc, &mut plugin);
-        plugin.run_init().unwrap();
-    }
-
-    struct Emu {
-        #[cfg(not(feature="plugins"))]
-        emu: RSnes,
-
-        #[cfg(feature="plugins")]
-        emu: Rc<RefCell<RSnes>>,
-    }
-
-    impl Emu {
-        fn get_mut(&mut self) -> impl DerefMut<Target = RSnes> {
-            #[cfg(feature= "plugins")]
-            return self.emu.borrow_mut();
-
-            #[cfg(not(feature= "plugins"))]
-            return &mut self.emu;
-        }
-    }
-
-    #[cfg(feature = "plugins")]
-    let mut emu = Emu { emu: emu_rc };
-    #[cfg(not(feature = "plugins"))]
-    let mut emu = Emu { emu };
+    let mut emu = cfg_select! {
+        feature = "plugins" => Emu::new_with_plugin(rsnes, plugin).unwrap(),
+        _ => Emu::new(rsnes),
+    };
 
     let closing_ev = 'emu_loop: loop {
-        let mut emu_mut = emu.get_mut();
-
         // Get new delta based on current Instant::now()
         let current_instant = Instant::now();
         let delta = current_instant.duration_since(last_instant).as_secs_f64();
@@ -80,18 +128,12 @@ fn gui_emu_loop(gui: &mut gui::Gui, emu: rsnes::RSnes) -> Option<RSnesEvent> {
             ));
         }
 
-        drop(emu_mut); // release to be able to run plugin `on_instr`
         while master_cycle_accum >= RSnes::MASTER_CYCLE_DURATION {
-            let mut emu_mut = emu.get_mut();
-
             master_cycle_accum -= RSnes::MASTER_CYCLE_DURATION;
-            emu_mut.update();
 
-            let cond = emu_mut.is_cpu_instr_start();
-            if let Some(opcode) = cond {
-                let addr = *emu_mut.cpu.addr_bus();
-                drop(emu_mut);
-                plugin.run_on_instr(opcode, addr).unwrap();
+            cfg_select! {
+                feature = "plugins" => emu.update().unwrap(),
+                _ => emu.update(),
             }
         }
 
@@ -101,11 +143,13 @@ fn gui_emu_loop(gui: &mut gui::Gui, emu: rsnes::RSnes) -> Option<RSnesEvent> {
         }
         frame_accum -= Gui::FRAME_DURATION;
 
-        let mut emu_mut = emu.get_mut();
+        let mut emu_mut = emu.rsnes_mut();
 
         // temporary: render full PPU frame for each GUI frame
         for y in 0..SCREEN_HEIGHT {
-            let RSnes { ppu, ppu_renderer, .. } = &mut *emu_mut;
+            let RSnes {
+                ppu, ppu_renderer, ..
+            } = &mut *emu_mut;
             ppu_renderer.render_scanline(ppu, y);
             emu_mut.ppu.step_scanline();
         }
@@ -123,19 +167,21 @@ fn gui_emu_loop(gui: &mut gui::Gui, emu: rsnes::RSnes) -> Option<RSnesEvent> {
                 RSnesEvent::Quit => break 'emu_loop Some(RSnesEvent::Quit),
                 RSnesEvent::Close => break 'emu_loop None,
                 RSnesEvent::ButtonDown => {
-                    let mut emu_mut = emu.get_mut();
+                    let mut emu_mut = emu.rsnes_mut();
                     emu_mut.bus.io.hvbjoy = 0;
                     emu_mut.bus.io.joy1 = !0;
                 }
                 RSnesEvent::ButtonUp => {
-                    let mut emu_mut = emu.get_mut();
+                    let mut emu_mut = emu.rsnes_mut();
                     emu_mut.bus.io.hvbjoy = 0;
                     emu_mut.bus.io.joy1 = 0;
                 }
 
                 #[cfg(feature = "plugins")]
                 RSnesEvent::RunPluginDefault => {
-                    plugin.run_default().unwrap();
+                    if let Some(ref mut p) = emu.plugin_mut() {
+                        p.run_default().unwrap();
+                    }
                 }
 
                 e => println!("ignored event: {e:?}"),
@@ -152,7 +198,12 @@ fn gui_emu_loop(gui: &mut gui::Gui, emu: rsnes::RSnes) -> Option<RSnesEvent> {
     closing_ev
 }
 
-fn gui_loop(mut emu: Option<RSnes>) -> Result<(), String> {
+fn gui_loop(
+    mut emu: Option<RSnes>,
+
+    #[cfg(feature = "plugins")]
+    mut plugin: Option<Plugin>,
+) -> Result<(), String> {
     let mut gui = gui::Gui::new()?;
     const DEFAULT_FRAMEBUFFER: &ppu::rendering::RawFramebuffer =
         include_bytes!("../logo_framebuffer.raw");
@@ -169,7 +220,10 @@ fn gui_loop(mut emu: Option<RSnes>) -> Result<(), String> {
             None => Some(gui.wait_for_event()),
 
             Some(emu) => {
-                let ret_ev = gui_emu_loop(&mut gui, emu);
+                let ret_ev = cfg_select! {
+                    feature = "plugins" => gui_emu_loop(&mut gui, emu, plugin.take()),
+                    _ => gui_emu_loop(&mut gui, emu),
+                };
 
                 if ret_ev != Some(RSnesEvent::Quit) {
                     // re-render default framebuffer after game has exited
@@ -224,5 +278,8 @@ fn main() -> Result<(), String> {
         Some(rom_path) => Some(RSnes::load_rom(&rom_path).map_err(|e| e.to_string())?),
     };
 
-    gui_loop(emu)
+    cfg_select! {
+        feature = "plugins" => gui_loop(emu, Some(Plugin::load_from_file(Path::new("plugin.lua")).unwrap())),
+        _ => gui_loop(emu)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,7 @@ fn gui_emu_loop(
 
                 #[cfg(feature = "plugins")]
                 RSnesEvent::RunPluginDefault => {
-                    if let Some(ref mut p) = emu.plugin_mut() {
+                    if let Some(p) = emu.plugin_mut() {
                         p.run_default().unwrap();
                     }
                 }
@@ -189,6 +189,11 @@ fn gui_emu_loop(
         }
         frame_nb += 1;
     };
+
+    #[cfg(feature = "plugins")]
+    if let Some(p) = emu.plugin_mut() {
+        p.run_exit().unwrap();
+    }
 
     let time = Instant::now();
     let program_duration = time.duration_since(exec_start).as_secs_f64();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use ppu::constants::SCREEN_HEIGHT;
 use std::{cell::RefCell, rc::Rc};
 use std::{
     ops::DerefMut,
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::{Duration, Instant},
 };
 
@@ -254,28 +254,26 @@ fn gui_loop(
 #[cfg_attr(feature = "cli", command(about, long_about = None))]
 #[derive(Default)]
 struct Cli {
+    /// A SNES ROM to load at startup
     pub rom: Option<PathBuf>,
 
+    /// A plugin to load at startup, **without any confirmation
+    /// for requested permissions**
     #[cfg(feature = "plugins")]
-    #[arg(long)]
+    #[arg(long, value_name = "PLUGIN.lua")]
     pub load_plugin_noconfirm: Option<PathBuf>,
 }
 
 fn main() -> Result<(), String> {
-    let cli;
-    #[cfg(feature = "cli")]
-    {
-        cli = Cli::parse();
-    }
-
-    #[cfg(not(feature = "cli"))]
-    {
-        cli = Cli::default();
-
-        if std::env::args().len() != 0 {
-            eprintln!("CLI feature disabled at compile time, CLI arguments are ignored");
-        }
-    }
+    let cli = cfg_select! {
+        feature = "cli" => Cli::parse(),
+        _ => {{
+            if std::env::args().len() != 0 {
+                eprintln!("CLI feature disabled at compile time, CLI arguments are ignored");
+            }
+            Cli::default()
+        }}
+    };
 
     let emu = match cli.rom {
         None => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn gui_emu_loop(gui: &mut gui::Gui, emu: rsnes::RSnes) -> Option<RSnesEvent> {
 
     #[cfg(feature = "plugins")]
     {
-        RSnes::inject_into_lua(emu_rc.clone(), &mut plugin);
+        RSnes::inject_into_lua(&emu_rc, &mut plugin);
         plugin.run_init().unwrap();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,14 +40,32 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
         plugin.run_init().unwrap();
     }
 
-    #[cfg(feature = "plugins")]
-    let mut emu = emu_rc.borrow_mut();
-    #[cfg(not(feature = "plugins"))]
-    let mut emu = &mut emu;
+    struct Emu {
+        #[cfg(not(feature="plugins"))]
+        emu: RSnes,
 
-    println!("actual addr is {:?}", emu.cpu.addr_bus());
+        #[cfg(feature="plugins")]
+        emu: Rc<RefCell<RSnes>>,
+    }
+
+    impl Emu {
+        fn get_mut(&mut self) -> impl DerefMut<Target = RSnes> {
+            #[cfg(feature= "plugins")]
+            return self.emu.borrow_mut();
+
+            #[cfg(not(feature= "plugins"))]
+            return &mut self.emu;
+        }
+    }
+
+    #[cfg(feature = "plugins")]
+    let mut emu = Emu { emu: emu_rc };
+    #[cfg(not(feature = "plugins"))]
+    let mut emu = Emu { emu };
 
     let closing_ev = 'emu_loop: loop {
+        let mut emu_mut = emu.get_mut();
+
         // Get new delta based on current Instant::now()
         let current_instant = Instant::now();
         let delta = current_instant.duration_since(last_instant).as_secs_f64();
@@ -68,7 +86,7 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
 
         while master_cycle_accum >= RSnes::MASTER_CYCLE_DURATION {
             master_cycle_accum -= RSnes::MASTER_CYCLE_DURATION;
-            emu.update();
+            emu_mut.update();
         }
 
         // Window update if frame treshold is crossed
@@ -79,14 +97,16 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
 
         // temporary: render full PPU frame for each GUI frame
         for y in 0..SCREEN_HEIGHT {
-            let RSnes { ppu, ppu_renderer, .. } = &mut *emu;
+            let RSnes { ppu, ppu_renderer, .. } = &mut *emu_mut;
             ppu_renderer.render_scanline(ppu, y);
-            emu.ppu.step_scanline();
+            emu_mut.ppu.step_scanline();
         }
         // temporary: toggle VBLANK each rendered frame
-        emu.bus.io.rdnmi = !emu.bus.io.rdnmi;
+        emu_mut.bus.io.rdnmi = !emu_mut.bus.io.rdnmi;
 
-        for state_event in gui.update(&emu.ppu_renderer.framebuffer) {
+        let events = gui.update(&emu_mut.ppu_renderer.framebuffer);
+        drop(emu_mut); // release the RefCell so that we're able to call plugins
+        for state_event in events {
             match state_event {
                 // RSnesEvent::LoadRom { path } => match rsnes::RSnes::load_rom(&path) {
                 //     Ok(emu_) => emu = emu_,
@@ -95,13 +115,21 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
                 RSnesEvent::Quit => break 'emu_loop Some(RSnesEvent::Quit),
                 RSnesEvent::Close => break 'emu_loop None,
                 RSnesEvent::ButtonDown => {
-                    emu.bus.io.hvbjoy = 0;
-                    emu.bus.io.joy1 = !0;
+                    let mut emu_mut = emu.get_mut();
+                    emu_mut.bus.io.hvbjoy = 0;
+                    emu_mut.bus.io.joy1 = !0;
                 }
                 RSnesEvent::ButtonUp => {
-                    emu.bus.io.hvbjoy = 0;
-                    emu.bus.io.joy1 = 0;
+                    let mut emu_mut = emu.get_mut();
+                    emu_mut.bus.io.hvbjoy = 0;
+                    emu_mut.bus.io.joy1 = 0;
                 }
+
+                #[cfg(feature = "plugins")]
+                RSnesEvent::RunPluginDefault => {
+                    plugin.run_default().unwrap();
+                }
+
                 e => println!("ignored event: {e:?}"),
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,10 @@ fn gui_loop(
 #[derive(Default)]
 struct Cli {
     pub rom: Option<PathBuf>,
+
+    #[cfg(feature = "plugins")]
+    #[arg(long)]
+    pub load_plugin_noconfirm: Option<PathBuf>,
 }
 
 fn main() -> Result<(), String> {
@@ -279,7 +283,10 @@ fn main() -> Result<(), String> {
     };
 
     cfg_select! {
-        feature = "plugins" => gui_loop(emu, Some(Plugin::load_from_file(Path::new("plugin.lua")).unwrap())),
+        feature = "plugins" => gui_loop(
+            emu,
+            cli.load_plugin_noconfirm.map(|p| Plugin::load_from_file(&p).unwrap())
+        ),
         _ => gui_loop(emu)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::{
     ops::DerefMut, path::{Path, PathBuf}, time::{Duration, Instant}
 };
 
-fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent> {
+fn gui_emu_loop(gui: &mut gui::Gui, emu: rsnes::RSnes) -> Option<RSnesEvent> {
     let mut frame_nb = 0_u64;
     let exec_start = Instant::now();
 
@@ -26,10 +26,6 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
 
     #[cfg(feature = "plugins")]
     let mut plugin = Plugin::load_from_file(Path::new("./plugin.lua")).unwrap();
-
-    for _ in 0..100 {
-        emu.update();
-    }
 
     #[cfg(feature = "plugins")]
     let emu_rc = Rc::new(RefCell::new(emu));
@@ -84,9 +80,19 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
             ));
         }
 
+        drop(emu_mut); // release to be able to run plugin `on_instr`
         while master_cycle_accum >= RSnes::MASTER_CYCLE_DURATION {
+            let mut emu_mut = emu.get_mut();
+
             master_cycle_accum -= RSnes::MASTER_CYCLE_DURATION;
             emu_mut.update();
+
+            let cond = emu_mut.is_cpu_instr_start();
+            if let Some(opcode) = cond {
+                let addr = *emu_mut.cpu.addr_bus();
+                drop(emu_mut);
+                plugin.run_on_instr(opcode, addr).unwrap();
+            }
         }
 
         // Window update if frame treshold is crossed
@@ -94,6 +100,8 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
             continue;
         }
         frame_accum -= Gui::FRAME_DURATION;
+
+        let mut emu_mut = emu.get_mut();
 
         // temporary: render full PPU frame for each GUI frame
         for y in 0..SCREEN_HEIGHT {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,13 @@ use crate::{
 };
 #[cfg(feature = "cli")]
 use clap::Parser;
+#[cfg(feature = "plugins")]
+use plugins::plugin::Plugin;
 use ppu::constants::SCREEN_HEIGHT;
+#[cfg(feature = "plugins")]
+use std::{cell::RefCell, rc::Rc};
 use std::{
-    path::PathBuf,
-    time::{Duration, Instant},
+    ops::DerefMut, path::{Path, PathBuf}, time::{Duration, Instant}
 };
 
 fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent> {
@@ -20,6 +23,29 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
     let mut last_instant = Instant::now();
     let mut frame_accum: f64 = 0.0;
     let mut master_cycle_accum: f64 = 0.0;
+
+    #[cfg(feature = "plugins")]
+    let mut plugin = Plugin::load_from_file(Path::new("./plugin.lua")).unwrap();
+
+    for _ in 0..100 {
+        emu.update();
+    }
+
+    #[cfg(feature = "plugins")]
+    let emu_rc = Rc::new(RefCell::new(emu));
+
+    #[cfg(feature = "plugins")]
+    {
+        RSnes::inject_into_lua(emu_rc.clone(), &mut plugin);
+        plugin.run_init().unwrap();
+    }
+
+    #[cfg(feature = "plugins")]
+    let mut emu = emu_rc.borrow_mut();
+    #[cfg(not(feature = "plugins"))]
+    let mut emu = &mut emu;
+
+    println!("actual addr is {:?}", emu.cpu.addr_bus());
 
     let closing_ev = 'emu_loop: loop {
         // Get new delta based on current Instant::now()
@@ -53,7 +79,8 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
 
         // temporary: render full PPU frame for each GUI frame
         for y in 0..SCREEN_HEIGHT {
-            emu.ppu_renderer.render_scanline(&mut emu.ppu, y);
+            let RSnes { ppu, ppu_renderer, .. } = &mut *emu;
+            ppu_renderer.render_scanline(ppu, y);
             emu.ppu.step_scanline();
         }
         // temporary: toggle VBLANK each rendered frame
@@ -61,10 +88,10 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
 
         for state_event in gui.update(&emu.ppu_renderer.framebuffer) {
             match state_event {
-                RSnesEvent::LoadRom { path } => match rsnes::RSnes::load_rom(&path) {
-                    Ok(emu_) => emu = emu_,
-                    Err(err) => eprintln!("Error loading ROM: {}", err),
-                },
+                // RSnesEvent::LoadRom { path } => match rsnes::RSnes::load_rom(&path) {
+                //     Ok(emu_) => emu = emu_,
+                //     Err(err) => eprintln!("Error loading ROM: {}", err),
+                // },
                 RSnesEvent::Quit => break 'emu_loop Some(RSnesEvent::Quit),
                 RSnesEvent::Close => break 'emu_loop None,
                 RSnesEvent::ButtonDown => {
@@ -75,6 +102,7 @@ fn gui_emu_loop(gui: &mut gui::Gui, mut emu: rsnes::RSnes) -> Option<RSnesEvent>
                     emu.bus.io.hvbjoy = 0;
                     emu.bus.io.joy1 = 0;
                 }
+                e => println!("ignored event: {e:?}"),
             }
         }
         frame_nb += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,96 +3,21 @@ mod rsnes;
 
 use crate::{
     gui::{Gui, RSnesEvent},
-    rsnes::RSnes,
+    rsnes::{RSnesCore, RSnesEmu},
 };
 #[cfg(feature = "cli")]
 use clap::Parser;
 #[cfg(feature = "plugins")]
 use plugins::plugin::Plugin;
 use ppu::constants::SCREEN_HEIGHT;
-#[cfg(feature = "plugins")]
-use std::{cell::RefCell, rc::Rc};
 use std::{
-    ops::DerefMut,
     path::PathBuf,
     time::{Duration, Instant},
 };
 
-struct Emu {
-    #[cfg(not(feature = "plugins"))]
-    rsnes: RSnes,
-
-    #[cfg(feature = "plugins")]
-    rsnes: Rc<RefCell<RSnes>>,
-
-    #[cfg(feature = "plugins")]
-    plugin: Option<Plugin>,
-}
-
-impl Emu {
-    pub fn new(rsnes: RSnes) -> Self {
-        cfg_select! {
-            feature = "plugins" => Self {
-                rsnes: Rc::new(RefCell::new(rsnes)),
-                plugin: None,
-            },
-            _ => Self { rsnes },
-        }
-    }
-
-    #[cfg(feature = "plugins")]
-    pub fn new_with_plugin(
-        rsnes: RSnes,
-        mut plugin: Option<Plugin>,
-    ) -> Result<Self, piccolo::ExternError> {
-        let rc = Rc::new(RefCell::new(rsnes));
-
-        if let Some(plugin) = &mut plugin {
-            RSnes::inject_into_lua(&rc, plugin);
-            plugin.run_init()?;
-        }
-        Ok(Self { rsnes: rc, plugin })
-    }
-
-    pub fn rsnes_mut(&mut self) -> impl DerefMut<Target = RSnes> {
-        #[cfg(feature = "plugins")]
-        return self.rsnes.borrow_mut();
-
-        #[cfg(not(feature = "plugins"))]
-        return &mut self.rsnes;
-    }
-
-    #[cfg(feature = "plugins")]
-    pub fn plugin_mut(&mut self) -> Option<&mut Plugin> {
-        self.plugin.as_mut()
-    }
-
-    #[cfg(not(feature = "plugins"))]
-    pub fn update(&mut self) {
-        self.rsnes.update();
-    }
-
-    #[cfg(feature = "plugins")]
-    pub fn update(&mut self) -> Result<(), piccolo::ExternError> {
-        let mut rsnes_mut = self.rsnes.borrow_mut();
-
-        rsnes_mut.update();
-
-        if let Some(plugin) = self.plugin.as_mut() {
-            if let Some(opcode) = rsnes_mut.is_cpu_instr_start() {
-                let addr = *rsnes_mut.cpu.addr_bus();
-                drop(rsnes_mut);
-                return plugin.run_on_instr(opcode, addr);
-            }
-        }
-
-        Ok(())
-    }
-}
-
 fn gui_emu_loop(
     gui: &mut gui::Gui,
-    rsnes: RSnes,
+    rsnes: RSnesCore,
 
     #[cfg(feature = "plugins")]
     plugin: Option<Plugin>,
@@ -105,8 +30,8 @@ fn gui_emu_loop(
     let mut master_cycle_accum: f64 = 0.0;
 
     let mut emu = cfg_select! {
-        feature = "plugins" => Emu::new_with_plugin(rsnes, plugin).unwrap(),
-        _ => Emu::new(rsnes),
+        feature = "plugins" => RSnesEmu::new_with_plugin(rsnes, plugin).unwrap(),
+        _ => RSnesEmu::new(rsnes),
     };
 
     let closing_ev = 'emu_loop: loop {
@@ -119,17 +44,17 @@ fn gui_emu_loop(
         master_cycle_accum += delta;
 
         // sleep until we are due a cycle instead of busy-waiting
-        if master_cycle_accum < RSnes::MASTER_CYCLE_DURATION {
+        if master_cycle_accum < RSnesCore::MASTER_CYCLE_DURATION {
             // since the frequency of master cycles is orders
             // of magnitude greater than the framerate, we need
             // to sleep for master cycles, not for frames
             std::thread::sleep(Duration::from_secs_f64(
-                RSnes::MASTER_CYCLE_DURATION - master_cycle_accum,
+                RSnesCore::MASTER_CYCLE_DURATION - master_cycle_accum,
             ));
         }
 
-        while master_cycle_accum >= RSnes::MASTER_CYCLE_DURATION {
-            master_cycle_accum -= RSnes::MASTER_CYCLE_DURATION;
+        while master_cycle_accum >= RSnesCore::MASTER_CYCLE_DURATION {
+            master_cycle_accum -= RSnesCore::MASTER_CYCLE_DURATION;
 
             cfg_select! {
                 feature = "plugins" => emu.update().unwrap(),
@@ -143,11 +68,11 @@ fn gui_emu_loop(
         }
         frame_accum -= Gui::FRAME_DURATION;
 
-        let mut emu_mut = emu.rsnes_mut();
+        let mut emu_mut = emu.core_mut();
 
         // temporary: render full PPU frame for each GUI frame
         for y in 0..SCREEN_HEIGHT {
-            let RSnes {
+            let RSnesCore {
                 ppu, ppu_renderer, ..
             } = &mut *emu_mut;
             ppu_renderer.render_scanline(ppu, y);
@@ -167,12 +92,12 @@ fn gui_emu_loop(
                 RSnesEvent::Quit => break 'emu_loop Some(RSnesEvent::Quit),
                 RSnesEvent::Close => break 'emu_loop None,
                 RSnesEvent::ButtonDown => {
-                    let mut emu_mut = emu.rsnes_mut();
+                    let mut emu_mut = emu.core_mut();
                     emu_mut.bus.io.hvbjoy = 0;
                     emu_mut.bus.io.joy1 = !0;
                 }
                 RSnesEvent::ButtonUp => {
-                    let mut emu_mut = emu.rsnes_mut();
+                    let mut emu_mut = emu.core_mut();
                     emu_mut.bus.io.hvbjoy = 0;
                     emu_mut.bus.io.joy1 = 0;
                 }
@@ -204,7 +129,7 @@ fn gui_emu_loop(
 }
 
 fn gui_loop(
-    mut emu: Option<RSnes>,
+    mut rsnes_core: Option<RSnesCore>,
 
     #[cfg(feature = "plugins")]
     mut plugin: Option<Plugin>,
@@ -221,7 +146,7 @@ fn gui_loop(
         // so that we can pass by value in the emu loop,
         // guaranteeing that the `RSnes` is destructed when
         // we leave the loop
-        let ev = match emu.take() {
+        let ev = match rsnes_core.take() {
             None => Some(gui.wait_for_event()),
 
             Some(emu) => {
@@ -243,8 +168,8 @@ fn gui_loop(
             continue;
         };
         match ev {
-            RSnesEvent::LoadRom { path } => match rsnes::RSnes::load_rom(&path) {
-                Ok(some_emu) => emu = Some(some_emu),
+            RSnesEvent::LoadRom { path } => match rsnes::RSnesCore::load_rom(&path) {
+                Ok(some_emu) => rsnes_core = Some(some_emu),
                 Err(err) => println!("Error loading ROM: {}", err),
             },
             RSnesEvent::Quit | RSnesEvent::Close => break,
@@ -282,7 +207,7 @@ fn main() -> Result<(), String> {
 
     let emu = match cli.rom {
         None => None,
-        Some(rom_path) => Some(RSnes::load_rom(&rom_path).map_err(|e| e.to_string())?),
+        Some(rom_path) => Some(RSnesCore::load_rom(&rom_path).map_err(|e| e.to_string())?),
     };
 
     cfg_select! {

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -164,6 +164,14 @@ impl RSnes {
 
         self.master_cycles += 1;
     }
+
+    pub fn is_cpu_instr_start(&mut self) -> Option<u8> {
+        if self.cpu_master_cycles_to_wait != 0 || !self.cpu.is_instr_start() {
+            None
+        } else {
+            Some(self.bus.read(*self.cpu.addr_bus(), &mut self.ppu, &mut self.apu))
+        }
+    }
 }
 
 

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -1,8 +1,12 @@
+#[cfg(feature = "plugins")]
+mod rsnes_plugin;
+
 use apu::Apu;
 use bus::Bus;
 use common::snes_address::SnesAddress;
 use cpu::cpu::CPU;
 use cpu::cpu::CycleResult;
+
 use ppu::ppu::PPU;
 use std::error::Error;
 use std::path::Path;
@@ -161,6 +165,7 @@ impl RSnes {
         self.master_cycles += 1;
     }
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -187,6 +187,8 @@ impl RSnesCore {
         self.master_cycles += 1;
     }
 
+    /// Checks if the CPU is about to execute the first cycle of an instruction,
+    /// and if so, also return the opcode that is about to be read by the CPU
     pub fn is_cpu_instr_start(&mut self) -> Option<u8> {
         if self.cpu_master_cycles_to_wait != 0 || !self.cpu.is_instr_start() {
             None

--- a/src/rsnes.rs
+++ b/src/rsnes.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "plugins")]
 mod rsnes_plugin;
 
+#[cfg(feature = "plugins")]
+use plugins::plugin::Plugin;
+use std::ops::DerefMut;
+#[cfg(feature = "plugins")]
+use std::{cell::RefCell, rc::Rc};
+
 use apu::Apu;
 use bus::Bus;
 use common::snes_address::SnesAddress;
@@ -12,7 +18,10 @@ use std::error::Error;
 use std::path::Path;
 use std::path::PathBuf;
 
-pub struct RSnes {
+/// R-SNES core: struct containing all the emulated hardware components,
+/// without anything else: no GUI handles, no additional resources for
+/// plugin execution; just the hardware components.
+pub struct RSnesCore {
     pub _rom_path: PathBuf,
     pub bus: Bus,
     pub cpu: CPU,
@@ -23,7 +32,20 @@ pub struct RSnes {
     pub cpu_master_cycles_to_wait: u32,
 }
 
-impl RSnes {
+/// R-SNES core + optionally lua runtime for plugin execution (in
+/// case the feature is enabled)
+pub struct RSnesEmu {
+    #[cfg(not(feature = "plugins"))]
+    core: RSnesCore,
+
+    #[cfg(feature = "plugins")]
+    core: Rc<RefCell<RSnesCore>>,
+
+    #[cfg(feature = "plugins")]
+    plugin: Option<Plugin>,
+}
+
+impl RSnesCore {
     pub const MASTER_CLOCK_HZ: u64 = 21_477_300;
     pub const MASTER_CYCLE_DURATION: f64 = 1.0 / Self::MASTER_CLOCK_HZ as f64;
 
@@ -169,11 +191,74 @@ impl RSnes {
         if self.cpu_master_cycles_to_wait != 0 || !self.cpu.is_instr_start() {
             None
         } else {
-            Some(self.bus.read(*self.cpu.addr_bus(), &mut self.ppu, &mut self.apu))
+            let opcode = self
+                .bus
+                .read(*self.cpu.addr_bus(), &mut self.ppu, &mut self.apu);
+            Some(opcode)
         }
     }
 }
 
+impl RSnesEmu {
+    pub fn new(core: RSnesCore) -> Self {
+        cfg_select! {
+            feature = "plugins" => Self {
+                core: Rc::new(RefCell::new(core)),
+                plugin: None,
+            },
+            _ => Self { core },
+        }
+    }
+
+    #[cfg(feature = "plugins")]
+    pub fn new_with_plugin(
+        core: RSnesCore,
+        mut plugin: Option<Plugin>,
+    ) -> Result<Self, piccolo::ExternError> {
+        let rc = Rc::new(RefCell::new(core));
+
+        if let Some(plugin) = &mut plugin {
+            RSnesCore::inject_into_lua(&rc, plugin);
+            plugin.run_init()?;
+        }
+        Ok(Self { core: rc, plugin })
+    }
+
+    pub fn core_mut(&mut self) -> impl DerefMut<Target = RSnesCore> {
+        #[cfg(feature = "plugins")]
+        return self.core.borrow_mut();
+
+        #[cfg(not(feature = "plugins"))]
+        return &mut self.core;
+    }
+
+    #[cfg(feature = "plugins")]
+    pub fn plugin_mut(&mut self) -> Option<&mut Plugin> {
+        self.plugin.as_mut()
+    }
+
+    #[cfg(not(feature = "plugins"))]
+    pub fn update(&mut self) {
+        self.core.update();
+    }
+
+    #[cfg(feature = "plugins")]
+    pub fn update(&mut self) -> Result<(), piccolo::ExternError> {
+        let mut rsnes_mut = self.core.borrow_mut();
+
+        rsnes_mut.update();
+
+        if let Some(plugin) = self.plugin.as_mut() {
+            if let Some(opcode) = rsnes_mut.is_cpu_instr_start() {
+                let addr = *rsnes_mut.cpu.addr_bus();
+                drop(rsnes_mut);
+                return plugin.run_on_instr(opcode, addr);
+            }
+        }
+
+        Ok(())
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -181,14 +266,14 @@ mod tests {
     use bus::rom::test_rom::*;
     use common::snes_addr;
 
-    fn make_rsnes() -> RSnes {
+    fn make_rsnes() -> RSnesCore {
         let rom_data = create_valid_lorom(0x20000);
         let (rom_path, _dir) = create_temp_rom(&rom_data);
-        RSnes::load_rom(&rom_path).unwrap()
+        RSnesCore::load_rom(&rom_path).unwrap()
     }
 
     fn set_dma_channel(
-        rsnes: &mut RSnes,
+        rsnes: &mut RSnesCore,
         channel: usize,
         dmap: u8,
         src_bank: u8,

--- a/src/rsnes/rsnes_plugin.rs
+++ b/src/rsnes/rsnes_plugin.rs
@@ -1,0 +1,83 @@
+use super::RSnes;
+
+use cpu::cpu::CPU;
+use piccolo::Callback;
+use piccolo::Context;
+use piccolo::Table;
+use piccolo::Value;
+use plugins::plugin::Plugin;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+impl RSnes {
+    /// Injects emulator callbacks in the lua VM contained
+    /// in the Plugin parameter, taking into account the
+    /// permission table of the plugin
+    pub fn inject_into_lua(emu: Rc<RefCell<Self>>, plugin: &mut Plugin) {
+        plugin.lua.load_core();
+        plugin.lua.enter(|ctx| {
+            let rsnes = Table::new(&ctx);
+            ctx.set_global("rsnes", rsnes);
+
+            if plugin.table.perms.internal.cpu.registers {
+                rsnes.set_field(ctx, "cpu", Self::create_regs_table(ctx, emu));
+            }
+        });
+    }
+
+    /// Creates a lua table which gives read-only access to fields
+    /// of the CPU: registers and address bus.
+    ///
+    /// The returned table uses a metatable to catch read and
+    /// write "requests" instead of exposing the CPU fields direcly,
+    /// which also means this table is "always up to date", since it
+    /// dynamically reads from the CPU when a field is read from it.
+    fn create_regs_table<'gc>(ctx: Context<'gc>, emu: Rc<RefCell<Self>>) -> Table<'gc> {
+        let ret = Table::new(&ctx);
+        let mt = Table::new(&ctx);
+        ret.set_metatable(ctx.mutation(), Some(mt));
+
+        mt.set_field(ctx, "__metatable", "private CPU regs metatable");
+        mt.set_field(
+            ctx,
+            "__newindex",
+            Callback::from_fn(ctx.mutation(), |ctx, _, mut stack| {
+                let _: (Table, Value, Value) = stack.consume(ctx)?;
+                println!("user code tried to write to cpu regs");
+                Ok(piccolo::CallbackReturn::Return)
+            }),
+        );
+        mt.set_field(
+            ctx,
+            "__index",
+            Callback::from_fn(ctx.mutation(), move |ctx, _, mut stack| {
+                let (_, key): (Table, piccolo::String) = stack.consume(ctx)?;
+                let cpu: &CPU = &emu.borrow().cpu;
+
+                let val = match key.as_bytes() {
+                    b"pc" | b"PC" => Value::Integer(cpu.regs().PC.into()),
+                    b"pb" | b"PB" => Value::Integer(cpu.regs().PB.into()),
+                    b"a" | b"A" => Value::Integer(cpu.regs().A.into()),
+                    b"x" | b"X" => Value::Integer(cpu.regs().X.into()),
+                    b"y" | b"Y" => Value::Integer(cpu.regs().Y.into()),
+                    b"d" | b"D" => Value::Integer(cpu.regs().D.into()),
+                    b"db" | b"DB" => Value::Integer(cpu.regs().DB.into()),
+                    b"s" | b"S" => Value::Integer(cpu.regs().S.into()),
+                    b"p" | b"P" => Value::Integer(u8::from(cpu.regs().P).into()),
+
+                    b"e" | b"E" => Value::Boolean(cpu.regs().E),
+
+                    b"bus_addr" => Value::Integer(cpu.addr_bus().addr.into()),
+                    b"bus_bank" => Value::Integer(cpu.addr_bus().bank.into()),
+
+                    _ => Value::Nil,
+                };
+
+                stack.replace(ctx, val);
+                Ok(piccolo::CallbackReturn::Return)
+            }),
+        );
+
+        ret
+    }
+}

--- a/src/rsnes/rsnes_plugin.rs
+++ b/src/rsnes/rsnes_plugin.rs
@@ -13,14 +13,17 @@ impl RSnes {
     /// Injects emulator callbacks in the lua VM contained
     /// in the Plugin parameter, taking into account the
     /// permission table of the plugin
-    pub fn inject_into_lua(emu: Rc<RefCell<Self>>, plugin: &mut Plugin) {
+    pub fn inject_into_lua(emu: &Rc<RefCell<Self>>, plugin: &mut Plugin) {
         plugin.lua.load_core();
         plugin.lua.enter(|ctx| {
             let rsnes = Table::new(&ctx);
             ctx.set_global("rsnes", rsnes);
 
             if plugin.table.perms.internal.cpu.registers {
-                rsnes.set_field(ctx, "cpu", Self::create_regs_table(ctx, emu));
+                rsnes.set_field(ctx, "cpu", Self::create_regs_table(ctx, emu.clone()));
+            }
+            if plugin.table.perms.internal.input {
+                rsnes.set_field(ctx, "input", Self::create_input_table(ctx, emu));
             }
         });
     }
@@ -74,6 +77,38 @@ impl RSnes {
                 };
 
                 stack.replace(ctx, val);
+                Ok(piccolo::CallbackReturn::Return)
+            }),
+        );
+
+        ret
+    }
+
+    fn create_input_table<'gc>(ctx: Context<'gc>, emu: &Rc<RefCell<Self>>) -> Table<'gc> {
+        let ret = Table::new(ctx.mutation());
+
+        let clone = emu.clone();
+        ret.set_field(
+            ctx,
+            "press_a",
+            Callback::from_fn(ctx.mutation(), move |_, _, _| {
+                let mut emu = clone.borrow_mut();
+
+                emu.bus.io.hvbjoy = 0;
+                emu.bus.io.joy1 = !0;
+                Ok(piccolo::CallbackReturn::Return)
+            }),
+        );
+
+        let clone = emu.clone();
+        ret.set_field(
+            ctx,
+            "release_a",
+            Callback::from_fn(ctx.mutation(), move |_, _, _| {
+                let mut emu = clone.borrow_mut();
+
+                emu.bus.io.hvbjoy = 0;
+                emu.bus.io.joy1 = 0;
                 Ok(piccolo::CallbackReturn::Return)
             }),
         );

--- a/src/rsnes/rsnes_plugin.rs
+++ b/src/rsnes/rsnes_plugin.rs
@@ -1,4 +1,4 @@
-use super::RSnes;
+use super::RSnesCore;
 
 use cpu::cpu::CPU;
 use piccolo::Callback;
@@ -9,7 +9,7 @@ use plugins::plugin::Plugin;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-impl RSnes {
+impl RSnesCore {
     /// Injects emulator callbacks in the lua VM contained
     /// in the Plugin parameter, taking into account the
     /// permission table of the plugin


### PR DESCRIPTION
## 📝 Description

First actual integration of plugins into the main program and CPU module giving access to registers.

For now, the only way to load a plugin is via the CLI option `--load-plugin-noconfirm` which, as it names suggests, does not feature any permission confirmation whatsoever, it grants all permissions requested by the plugin without any user interaction. GUI plugin load and interactive perm confirmation is left to do later.

A nice thing the current CPU integration allows plugins to do is hook a function that will be called at the start of each CPU instruction, receiving as parameter the opcode and current address of execution (as well as all the others CPU registers), which allows plugins to detect what is happening during program execution (although this can be very very laggy, as the lua function will be called about a million times per second).
This is used in the example plugin at cpu/plugin.lua, which is able to count how many tests of the [snes-tests](https://github.com/gilyon/snes-tests) CPU test ROM.

Plugins can be disabled at compile time by disable the `plugins` feature (defined in the root Cargo.toml, and referred to across the main program, to handle whether or not the feature is enabled), to get a version of the program which does not feature any form of plugins (in case this might make some things run faster, or it can result in a smaller executable for example, for people who would like to get a custom-compiled r-snes without this feature)

## 🔍 Related Issues

Closes EpitechPromo2027/G-EIP-600-NAN-6-1-eip-florent.charpentier#68
Closes EpitechPromo2027/G-EIP-600-NAN-6-1-eip-florent.charpentier#70
Closes EpitechPromo2027/G-EIP-600-NAN-6-1-eip-florent.charpentier#63
