### PR TITLE
:sparkles: Permission request GUI

### DIFF
--- a/plugins/src/bin/main.rs
+++ b/plugins/src/bin/main.rs
@@ -1,3 +1,4 @@
+use egui::ScrollArea;
 use plugins::plugin::{
     Plugin,
     gui::PluginPermRequest,
@@ -21,8 +22,10 @@ impl<'app, 'req> PermRequestApp<'app, 'req> {
 impl eframe::App for PermRequestApp<'_, '_> {
     fn ui(&mut self, ui: &mut egui::Ui, _: &mut eframe::Frame) {
         egui::CentralPanel::default().show_inside(ui, |ui| {
-            ui.heading(&self.title);
-            self.perm_request.show_gui(ui);
+            ScrollArea::both().show(ui, |ui| {
+                ui.heading(&self.title);
+                self.perm_request.show_gui(ui);
+            });
         });
     }
 }

--- a/plugins/src/bin/main.rs
+++ b/plugins/src/bin/main.rs
@@ -1,6 +1,6 @@
 use plugins::plugin::{
     Plugin,
-    PluginPermRequest,
+    gui::PluginPermRequest,
 };
 use eframe::egui;
 

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -330,12 +330,6 @@ pub struct PluginPermRequest<'a> {
 }
 
 impl<'a> PluginPermRequest<'a> {
-    fn all() -> RichText {
-        RichText::new("all").strong()
-    }
-    fn none() -> RichText {
-        RichText::new("none").italics()
-    }
     fn perm_label(perm: &impl Permission, name: &str) -> impl Into<WidgetText> {
         let mut job = LayoutJob::default();
         job.append(name, 0.0, Default::default());
@@ -363,10 +357,7 @@ impl<'a> PluginPermRequest<'a> {
 
         job
     }
-    fn perm_collapsing_header(
-        perm: &impl Permission,
-        name: &str,
-    ) -> CollapsingHeader {
+    fn perm_collapsing_header(perm: &impl Permission, name: &str) -> CollapsingHeader {
         CollapsingHeader::new(Self::perm_label(perm, name))
     }
     fn force_show_perm_collapsible<T: Permission>(
@@ -376,11 +367,9 @@ impl<'a> PluginPermRequest<'a> {
         label: &str,
         draw_content: impl FnOnce(&mut egui::Ui, &T),
     ) {
-        self.show_perm(ui, perm, |ui, perm| {
-            Self::perm_collapsing_header(perm, label)
-                .default_open(true)
-                .show(ui, |ui| draw_content(ui, perm));
-        });
+        Self::perm_collapsing_header(perm, label)
+            .default_open(!perm.is_all() && !perm.is_none())
+            .show(ui, |ui| draw_content(ui, perm));
     }
     fn show_perm_collapsible<T: Permission>(
         &self,
@@ -390,9 +379,7 @@ impl<'a> PluginPermRequest<'a> {
         draw_content: impl FnOnce(&mut egui::Ui, &T),
     ) {
         self.show_perm(ui, perm, |ui, perm| {
-            Self::perm_collapsing_header(perm, label)
-                .default_open(!perm.is_all() && !perm.is_none())
-                .show(ui, |ui| draw_content(ui, perm));
+            Self::force_show_perm_collapsible(&self, ui, perm, label, draw_content);
         });
     }
     fn show_perm<T: Permission>(
@@ -417,64 +404,63 @@ impl<'a> PluginPermRequest<'a> {
 
         ui.separator();
 
-        ui.label(RichText::new("Requested permissions:").heading());
         let perms = &self.plugin.table.perms;
-        if perms.is_none() {
-            ui.indent((), |ui| ui.label(Self::none()));
-        } else {
-            self.force_show_perm_collapsible(ui, &perms.internal, "Internal", |ui, internal| {
-                self.show_perm_collapsible(ui, &internal.cpu, "CPU", |ui, cpu| {
-                    self.show_perm_bool(ui, cpu.registers, "Registers");
-                });
-                self.show_perm_collapsible(ui, &internal.bus, "Bus", |ui, bus| {
-                    self.show_perm_bool(ui, bus.read, "Read");
-                    self.show_perm_bool(ui, bus.write, "Write");
-                });
-                self.show_perm_collapsible(ui, &internal.ppu, "PPU", |ui, ppu| {
-                    self.show_perm_bool(ui, ppu.display, "Display");
-                });
-                self.show_perm_bool(ui, internal.input, "Input");
-                self.show_perm_collapsible(ui, &internal.control, "Control", |ui, control| {
-                    self.show_perm_bool(ui, control.pause, "Pause");
-                    self.show_perm_bool(ui, control.dialog, "Dialog");
-                });
-            });
+        ui.label(RichText::new("Requested permissions").heading());
 
-            self.force_show_perm_collapsible(ui, &perms.external, "External", |ui, external| {
-                self.show_perm_bool(ui, external.http, "HTTP");
-                self.show_perm_collapsible(ui, &external.filesystem, "Filesystem", |ui, fs| {
-                    self.show_perm_bool(ui, fs.read, "Read");
-                    self.show_perm_collapsible(ui, &fs.write, "Write", |ui, write| match write {
-                        AllOr::All => {
-                            ui.label(RichText::new("all").strong());
-                        }
-                        AllOr::Inner(files) => {
-                            for (file, options) in files.files.iter() {
-                                ui.horizontal(|ui| {
-                                    ui.spacing_mut().item_spacing.x = 0.;
-                                    ui.label(RichText::new(format!("{file:?}")).monospace());
-                                    let label = match options {
-                                        FileWriteOptions::NewOnly => "NewOnly",
-                                        FileWriteOptions::CanOverwrite { create, mode } => {
-                                            &format!(
-                                                ": {}{mode:?}",
-                                                if *create { "Create + " } else { "" }
-                                            )
-                                        }
-                                    };
-                                    ui.label(label);
-                                });
-                            }
-                        }
-                    })
-                });
+        self.force_show_perm_collapsible(ui, &perms.internal, "Internal", |ui, internal| {
+            self.show_perm_collapsible(ui, &internal.cpu, "CPU", |ui, cpu| {
+                self.show_perm_bool(ui, cpu.registers, "Registers");
             });
-        }
+            self.show_perm_collapsible(ui, &internal.bus, "Bus", |ui, bus| {
+                self.show_perm_bool(ui, bus.read, "Read");
+                self.show_perm_bool(ui, bus.write, "Write");
+            });
+            self.show_perm_collapsible(ui, &internal.ppu, "PPU", |ui, ppu| {
+                self.show_perm_bool(ui, ppu.display, "Display");
+            });
+            self.show_perm_bool(ui, internal.input, "Input");
+            self.show_perm_collapsible(ui, &internal.control, "Control", |ui, control| {
+                self.show_perm_bool(ui, control.pause, "Pause");
+                self.show_perm_bool(ui, control.dialog, "Dialog");
+            });
+        });
 
+        self.force_show_perm_collapsible(ui, &perms.external, "External", |ui, external| {
+            self.show_perm_bool(ui, external.http, "HTTP");
+            self.show_perm_collapsible(ui, &external.filesystem, "Filesystem", |ui, fs| {
+                self.show_perm_bool(ui, fs.read, "Read");
+                self.show_perm_collapsible(ui, &fs.write, "Write", |ui, write| match write {
+                    AllOr::All => {
+                        ui.label(RichText::new("all").strong());
+                    }
+                    AllOr::Inner(files) => {
+                        for (file, options) in files.files.iter() {
+                            ui.horizontal(|ui| {
+                                ui.spacing_mut().item_spacing.x = 0.;
+                                ui.label(RichText::new(format!("{file:?}")).monospace());
+                                let label = match options {
+                                    FileWriteOptions::NewOnly => "NewOnly",
+                                    FileWriteOptions::CanOverwrite { create, mode } => {
+                                        &format!(
+                                            ": {}{mode:?}",
+                                            if *create { "Create + " } else { "" }
+                                        )
+                                    }
+                                };
+                                ui.label(label);
+                            });
+                        }
+                    }
+                })
+            });
+        });
+
+        ui.add_space(8.0);
         ui.horizontal(|ui| {
             ui.checkbox(&mut self.show_none, "Show 'none' fields");
         });
 
+        ui.separator();
         ui.add_space(16.0);
 
         ui.horizontal(|ui| {

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -1,13 +1,17 @@
+use crate::perm_tree::filesystem::FileWriteOptions;
 use crate::perm_tree::{
     RSnesPermissions,
     PermTreeNode,
 };
+use crate::permission::Permission;
+use crate::permission::helpers::AllOr;
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use std::fs as fs;
 use common::snes_address::SnesAddress;
+use egui::{CollapsingHeader, RichText, WidgetText};
 use piccolo as picc;
 use piccolo::io as p_io;
 
@@ -329,10 +333,84 @@ impl<'a> PluginPermRequest<'a> {
         let close = |ui: &mut egui::Ui| {
             ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
         };
+        let none = RichText::new("none").italics();
 
-        ui.label("This is still very much a work in progress");
 
         ui.separator();
+
+        ui.label(RichText::new("Requested permissions:").heading());
+        if self.plugin.table.perms.is_none() {
+            ui.indent((), |ui| ui.label(none));
+        } else {
+            ui.label("Internal:");
+            if self.plugin.table.perms.internal.is_none() {
+                ui.label(none.clone());
+            } else {
+                ui.indent((), |ui| {
+                    if !self.plugin.table.perms.internal.bus.is_none() {
+                        ui.label("Bus");
+                    }
+                    if !self.plugin.table.perms.internal.cpu.is_none() {
+                        ui.label("CPU");
+                    }
+                    if !self.plugin.table.perms.internal.ppu.is_none() {
+                        ui.label("PPU");
+                    }
+                    if !self.plugin.table.perms.internal.input.is_none() {
+                        ui.label("Input");
+                    }
+                    if !self.plugin.table.perms.internal.control.is_none() {
+                        ui.label("Input");
+                    }
+                });
+            }
+
+            ui.label("External:");
+            if self.plugin.table.perms.external.is_none() {
+                ui.label(none.clone());
+            } else {
+                ui.indent((), |ui| {
+                    if !self.plugin.table.perms.external.http.is_none() {
+                        ui.label("HTTP");
+                    }
+                    if !self.plugin.table.perms.external.filesystem.is_none() {
+                        ui.label("Filesystem:");
+                        ui.indent((), |ui| {
+                            if self.plugin.table.perms.external.filesystem.read {
+                                ui.label("Read:");
+                            }
+                            if !self.plugin.table.perms.external.filesystem.write.is_none() {
+                                ui.label("Write:");
+                                ui.indent((), |ui| {
+                                    match &self.plugin.table.perms.external.filesystem.write {
+                                        AllOr::All => {
+                                            ui.label(RichText::new("all").italics());
+                                        }
+                                        AllOr::Inner(files) => {
+                                            for (file, options) in files.files.iter() {
+                                                ui.horizontal(|ui| {
+                                                    ui.spacing_mut().item_spacing.x = 0.;
+                                                    ui.label(RichText::new(format!("{file:?}")).monospace());
+                                                    let label = match options {
+                                                        FileWriteOptions::NewOnly => "NewOnly",
+                                                        FileWriteOptions::CanOverwrite { create, mode } => {
+                                                            &format!(": {}{mode:?}", if *create {"Create + "} else {""})
+                                                        },
+                                                    };
+                                                    ui.label(label);
+                                                });
+                                            }
+                                        }
+                                    }
+                                });
+                            }
+                        });
+                    }
+                });
+            }
+        }
+
+        ui.add_space(16.0);
 
         ui.horizontal(|ui| {
             if ui.button("Grant requested permissions").clicked() {
@@ -343,10 +421,6 @@ impl<'a> PluginPermRequest<'a> {
                 self.allow_all = false;
                 close(ui);
             }
-        });
-
-        ui.collapsing("we can even have collapsing content", |ui| {
-            ui.label("peekaboo!");
         });
     }
 }

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -1,19 +1,17 @@
 use crate::perm_tree::filesystem::FileWriteOptions;
-use crate::perm_tree::{
-    RSnesPermissions,
-    PermTreeNode,
-};
+use crate::perm_tree::{PermTreeNode, RSnesPermissions};
 use crate::permission::Permission;
 use crate::permission::helpers::AllOr;
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use std::fs as fs;
 use common::snes_address::SnesAddress;
-use egui::{CollapsingHeader, RichText, WidgetText};
+use egui::text::LayoutJob;
+use egui::{CollapsingHeader, RichText, Style, TextFormat, WidgetText};
 use piccolo as picc;
 use piccolo::io as p_io;
+use std::fs;
 
 #[derive(Debug)]
 pub enum PluginLoadError {
@@ -231,6 +229,7 @@ impl Plugin {
         PluginPermRequest {
             plugin: self,
             allow_all: false,
+            show_none: false,
         }
     }
 
@@ -326,89 +325,155 @@ impl Plugin {
 pub struct PluginPermRequest<'a> {
     pub plugin: &'a Plugin,
     pub allow_all: bool,
+
+    pub show_none: bool,
 }
 
 impl<'a> PluginPermRequest<'a> {
+    fn all() -> RichText {
+        RichText::new("all").strong()
+    }
+    fn none() -> RichText {
+        RichText::new("none").italics()
+    }
+    fn perm_label(perm: &impl Permission, name: &str) -> impl Into<WidgetText> {
+        let mut job = LayoutJob::default();
+        job.append(name, 0.0, Default::default());
+        if perm.is_none() {
+            job.append(
+                "none",
+                12.0,
+                TextFormat {
+                    italics: true,
+                    ..Default::default()
+                },
+            );
+        }
+        if perm.is_all() {
+            job.append(
+                "all",
+                12.0,
+                TextFormat {
+                    color: Style::default().visuals.strong_text_color(),
+                    italics: true,
+                    ..Default::default()
+                },
+            );
+        }
+
+        job
+    }
+    fn perm_collapsing_header(
+        perm: &impl Permission,
+        name: &str,
+    ) -> CollapsingHeader {
+        CollapsingHeader::new(Self::perm_label(perm, name))
+    }
+    fn force_show_perm_collapsible<T: Permission>(
+        &self,
+        ui: &mut egui::Ui,
+        perm: &T,
+        label: &str,
+        draw_content: impl FnOnce(&mut egui::Ui, &T),
+    ) {
+        self.show_perm(ui, perm, |ui, perm| {
+            Self::perm_collapsing_header(perm, label)
+                .default_open(true)
+                .show(ui, |ui| draw_content(ui, perm));
+        });
+    }
+    fn show_perm_collapsible<T: Permission>(
+        &self,
+        ui: &mut egui::Ui,
+        perm: &T,
+        label: &str,
+        draw_content: impl FnOnce(&mut egui::Ui, &T),
+    ) {
+        self.show_perm(ui, perm, |ui, perm| {
+            Self::perm_collapsing_header(perm, label)
+                .default_open(!perm.is_all() && !perm.is_none())
+                .show(ui, |ui| draw_content(ui, perm));
+        });
+    }
+    fn show_perm<T: Permission>(
+        &self,
+        ui: &mut egui::Ui,
+        perm: &T,
+        add_content: impl FnOnce(&mut egui::Ui, &T),
+    ) {
+        if !perm.is_none() || self.show_none {
+            add_content(ui, perm);
+        }
+    }
+    fn show_perm_bool(&self, ui: &mut egui::Ui, perm: bool, label: &str) {
+        self.show_perm(ui, &perm, |ui, perm| {
+            ui.label(Self::perm_label(perm, label));
+        });
+    }
     pub fn show_gui(&mut self, ui: &mut egui::Ui) {
         let close = |ui: &mut egui::Ui| {
             ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
         };
-        let none = RichText::new("none").italics();
-
 
         ui.separator();
 
         ui.label(RichText::new("Requested permissions:").heading());
-        if self.plugin.table.perms.is_none() {
-            ui.indent((), |ui| ui.label(none));
+        let perms = &self.plugin.table.perms;
+        if perms.is_none() {
+            ui.indent((), |ui| ui.label(Self::none()));
         } else {
-            ui.label("Internal:");
-            if self.plugin.table.perms.internal.is_none() {
-                ui.label(none.clone());
-            } else {
-                ui.indent((), |ui| {
-                    if !self.plugin.table.perms.internal.bus.is_none() {
-                        ui.label("Bus");
-                    }
-                    if !self.plugin.table.perms.internal.cpu.is_none() {
-                        ui.label("CPU");
-                    }
-                    if !self.plugin.table.perms.internal.ppu.is_none() {
-                        ui.label("PPU");
-                    }
-                    if !self.plugin.table.perms.internal.input.is_none() {
-                        ui.label("Input");
-                    }
-                    if !self.plugin.table.perms.internal.control.is_none() {
-                        ui.label("Input");
-                    }
+            self.force_show_perm_collapsible(ui, &perms.internal, "Internal", |ui, internal| {
+                self.show_perm_collapsible(ui, &internal.cpu, "CPU", |ui, cpu| {
+                    self.show_perm_bool(ui, cpu.registers, "Registers");
                 });
-            }
+                self.show_perm_collapsible(ui, &internal.bus, "Bus", |ui, bus| {
+                    self.show_perm_bool(ui, bus.read, "Read");
+                    self.show_perm_bool(ui, bus.write, "Write");
+                });
+                self.show_perm_collapsible(ui, &internal.ppu, "PPU", |ui, ppu| {
+                    self.show_perm_bool(ui, ppu.display, "Display");
+                });
+                self.show_perm_bool(ui, internal.input, "Input");
+                self.show_perm_collapsible(ui, &internal.control, "Control", |ui, control| {
+                    self.show_perm_bool(ui, control.pause, "Pause");
+                    self.show_perm_bool(ui, control.dialog, "Dialog");
+                });
+            });
 
-            ui.label("External:");
-            if self.plugin.table.perms.external.is_none() {
-                ui.label(none.clone());
-            } else {
-                ui.indent((), |ui| {
-                    if !self.plugin.table.perms.external.http.is_none() {
-                        ui.label("HTTP");
-                    }
-                    if !self.plugin.table.perms.external.filesystem.is_none() {
-                        ui.label("Filesystem:");
-                        ui.indent((), |ui| {
-                            if self.plugin.table.perms.external.filesystem.read {
-                                ui.label("Read:");
-                            }
-                            if !self.plugin.table.perms.external.filesystem.write.is_none() {
-                                ui.label("Write:");
-                                ui.indent((), |ui| {
-                                    match &self.plugin.table.perms.external.filesystem.write {
-                                        AllOr::All => {
-                                            ui.label(RichText::new("all").italics());
+            self.force_show_perm_collapsible(ui, &perms.external, "External", |ui, external| {
+                self.show_perm_bool(ui, external.http, "HTTP");
+                self.show_perm_collapsible(ui, &external.filesystem, "Filesystem", |ui, fs| {
+                    self.show_perm_bool(ui, fs.read, "Read");
+                    self.show_perm_collapsible(ui, &fs.write, "Write", |ui, write| match write {
+                        AllOr::All => {
+                            ui.label(RichText::new("all").strong());
+                        }
+                        AllOr::Inner(files) => {
+                            for (file, options) in files.files.iter() {
+                                ui.horizontal(|ui| {
+                                    ui.spacing_mut().item_spacing.x = 0.;
+                                    ui.label(RichText::new(format!("{file:?}")).monospace());
+                                    let label = match options {
+                                        FileWriteOptions::NewOnly => "NewOnly",
+                                        FileWriteOptions::CanOverwrite { create, mode } => {
+                                            &format!(
+                                                ": {}{mode:?}",
+                                                if *create { "Create + " } else { "" }
+                                            )
                                         }
-                                        AllOr::Inner(files) => {
-                                            for (file, options) in files.files.iter() {
-                                                ui.horizontal(|ui| {
-                                                    ui.spacing_mut().item_spacing.x = 0.;
-                                                    ui.label(RichText::new(format!("{file:?}")).monospace());
-                                                    let label = match options {
-                                                        FileWriteOptions::NewOnly => "NewOnly",
-                                                        FileWriteOptions::CanOverwrite { create, mode } => {
-                                                            &format!(": {}{mode:?}", if *create {"Create + "} else {""})
-                                                        },
-                                                    };
-                                                    ui.label(label);
-                                                });
-                                            }
-                                        }
-                                    }
+                                    };
+                                    ui.label(label);
                                 });
                             }
-                        });
-                    }
+                        }
+                    })
                 });
-            }
+            });
         }
+
+        ui.horizontal(|ui| {
+            ui.checkbox(&mut self.show_none, "Show 'none' fields");
+        });
 
         ui.add_space(16.0);
 

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -1,17 +1,15 @@
-use crate::perm_tree::filesystem::FileWriteOptions;
-use crate::perm_tree::{
-    BusPermissions, ControlPermissions, CpuPermissions, ExternalPermissions, FileSystemPermissions,
-    InternalPermissions, PermTreeNode, PpuPermissions, RSnesPermissions,
-};
-use crate::permission::Permission;
-use crate::permission::helpers::AllOr;
+// uncomment below if code coverage is getting too low, as
+// it would be "fine" to count GUI code towards coverage
+// #[cfg(not(tarpaulin_include))]
+pub mod gui;
+
+use crate::perm_tree::{PermTreeNode, RSnesPermissions};
+use crate::plugin::gui::PluginPermRequest;
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use common::snes_address::SnesAddress;
-use egui::text::LayoutJob;
-use egui::{CollapsingHeader, RichText, Style, TextFormat, WidgetText};
 use piccolo as picc;
 use piccolo::io as p_io;
 use std::fs;
@@ -322,179 +320,6 @@ impl Plugin {
         });
 
         lua.execute(&ex)
-    }
-}
-
-pub struct PluginPermRequest<'a> {
-    pub plugin: &'a Plugin,
-    pub allow_all: bool,
-
-    pub show_none: bool,
-}
-
-impl<'a> PluginPermRequest<'a> {
-    fn perm_label(perm: &impl Permission, name: &str) -> impl Into<WidgetText> {
-        let mut job = LayoutJob::default();
-        job.append(name, 0.0, Default::default());
-        if perm.is_none() {
-            job.append(
-                "none",
-                12.0,
-                TextFormat {
-                    italics: true,
-                    ..Default::default()
-                },
-            );
-        }
-        if perm.is_all() {
-            job.append(
-                "all",
-                12.0,
-                TextFormat {
-                    color: Style::default().visuals.strong_text_color(),
-                    italics: true,
-                    ..Default::default()
-                },
-            );
-        }
-
-        job
-    }
-    fn perm_collapsing_header(perm: &impl Permission, name: &str) -> CollapsingHeader {
-        CollapsingHeader::new(Self::perm_label(perm, name))
-    }
-    fn force_show_perm_collapsible<T: Permission>(
-        &self,
-        ui: &mut egui::Ui,
-        perm: &T,
-        label: &str,
-        draw_content: impl FnOnce(&mut egui::Ui, &T),
-    ) {
-        Self::perm_collapsing_header(perm, label)
-            .default_open(!perm.is_all() && !perm.is_none())
-            .show(ui, |ui| draw_content(ui, perm));
-    }
-    fn show_perm_collapsible<T: Permission>(
-        &self,
-        ui: &mut egui::Ui,
-        perm: &T,
-        label: &str,
-        draw_content: impl FnOnce(&mut egui::Ui, &T),
-    ) {
-        self.show_perm(ui, perm, |ui, perm| {
-            Self::force_show_perm_collapsible(&self, ui, perm, label, draw_content);
-        });
-    }
-    fn show_perm<T: Permission>(
-        &self,
-        ui: &mut egui::Ui,
-        perm: &T,
-        add_content: impl FnOnce(&mut egui::Ui, &T),
-    ) {
-        if !perm.is_none() || self.show_none {
-            add_content(ui, perm);
-        }
-    }
-    fn show_perm_bool(&self, ui: &mut egui::Ui, perm: bool, label: &str) {
-        self.show_perm(ui, &perm, |ui, perm| {
-            ui.label(Self::perm_label(perm, label));
-        });
-    }
-    pub fn show_gui(&mut self, ui: &mut egui::Ui) {
-        let close = |ui: &mut egui::Ui| {
-            ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-        };
-
-        ui.separator();
-
-        ui.label(RichText::new("Requested permissions").heading());
-        let RSnesPermissions { internal, external } = &self.plugin.table.perms;
-
-        self.force_show_perm_collapsible(ui, internal, "Internal", |ui, internal| {
-            // we intentionally destructure the stuct listing out all fields (without `..`),
-            // so that we get a compile error in case we forget to list a field in the
-            // destructure (and a warning if we write it just below but don't use it).
-            // This guarantees that we render all requested permissions in the GUI,
-            // which guarantees some security to the user (they at least know what is
-            // requested)
-            let InternalPermissions {
-                control,
-                cpu,
-                ppu,
-                bus,
-                input,
-            } = internal;
-
-            self.show_perm_collapsible(ui, cpu, "CPU", |ui, cpu| {
-                let CpuPermissions { registers } = cpu;
-                self.show_perm_bool(ui, *registers, "Registers");
-            });
-            self.show_perm_collapsible(ui, bus, "Bus", |ui, bus| {
-                let BusPermissions { read, write } = bus;
-                self.show_perm_bool(ui, *read, "Read");
-                self.show_perm_bool(ui, *write, "Write");
-            });
-            self.show_perm_collapsible(ui, ppu, "PPU", |ui, ppu| {
-                let PpuPermissions { display } = ppu;
-                self.show_perm_bool(ui, *display, "Display");
-            });
-            self.show_perm_bool(ui, *input, "Input");
-            self.show_perm_collapsible(ui, control, "Control", |ui, control| {
-                let ControlPermissions { dialog, pause } = control;
-                self.show_perm_bool(ui, *pause, "Pause");
-                self.show_perm_bool(ui, *dialog, "Dialog");
-            });
-        });
-
-        self.force_show_perm_collapsible(ui, external, "External", |ui, external| {
-            let ExternalPermissions { filesystem, http } = external;
-
-            self.show_perm_bool(ui, *http, "HTTP");
-            self.show_perm_collapsible(ui, filesystem, "Filesystem", |ui, fs| {
-                let FileSystemPermissions { read, write } = fs;
-                self.show_perm_bool(ui, *read, "Read");
-                self.show_perm_collapsible(ui, write, "Write", |ui, write| match write {
-                    AllOr::All => {
-                        ui.label(RichText::new("all").strong());
-                    }
-                    AllOr::Inner(files) => {
-                        for (file, options) in files.files.iter() {
-                            ui.horizontal(|ui| {
-                                ui.spacing_mut().item_spacing.x = 0.;
-                                ui.label(RichText::new(format!("{file:?}")).monospace());
-                                let label = match options {
-                                    FileWriteOptions::NewOnly => "NewOnly",
-                                    FileWriteOptions::CanOverwrite { create, mode } => &format!(
-                                        ": {}{mode:?}",
-                                        if *create { "Create + " } else { "" }
-                                    ),
-                                };
-                                ui.label(label);
-                            });
-                        }
-                    }
-                })
-            });
-        });
-
-        ui.add_space(8.0);
-        ui.horizontal(|ui| {
-            ui.checkbox(&mut self.show_none, "Show 'none' fields");
-        });
-
-        ui.separator();
-        ui.add_space(16.0);
-
-        ui.horizontal(|ui| {
-            if ui.button("Grant requested permissions").clicked() {
-                self.allow_all = true;
-                close(ui);
-            }
-            if ui.button("Cancel plugin execution").clicked() {
-                self.allow_all = false;
-                close(ui);
-            }
-        });
     }
 }
 

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -1,5 +1,8 @@
 use crate::perm_tree::filesystem::FileWriteOptions;
-use crate::perm_tree::{PermTreeNode, RSnesPermissions};
+use crate::perm_tree::{
+    BusPermissions, ControlPermissions, CpuPermissions, ExternalPermissions, FileSystemPermissions,
+    InternalPermissions, PermTreeNode, PpuPermissions, RSnesPermissions,
+};
 use crate::permission::Permission;
 use crate::permission::helpers::AllOr;
 
@@ -404,32 +407,47 @@ impl<'a> PluginPermRequest<'a> {
 
         ui.separator();
 
-        let perms = &self.plugin.table.perms;
         ui.label(RichText::new("Requested permissions").heading());
+        let RSnesPermissions { internal, external } = &self.plugin.table.perms;
 
-        self.force_show_perm_collapsible(ui, &perms.internal, "Internal", |ui, internal| {
-            self.show_perm_collapsible(ui, &internal.cpu, "CPU", |ui, cpu| {
-                self.show_perm_bool(ui, cpu.registers, "Registers");
+        self.force_show_perm_collapsible(ui, internal, "Internal", |ui, internal| {
+            let InternalPermissions {
+                control,
+                cpu,
+                ppu,
+                bus,
+                input,
+            } = internal;
+
+            self.show_perm_collapsible(ui, cpu, "CPU", |ui, cpu| {
+                let CpuPermissions { registers } = cpu;
+                self.show_perm_bool(ui, *registers, "Registers");
             });
-            self.show_perm_collapsible(ui, &internal.bus, "Bus", |ui, bus| {
-                self.show_perm_bool(ui, bus.read, "Read");
-                self.show_perm_bool(ui, bus.write, "Write");
+            self.show_perm_collapsible(ui, bus, "Bus", |ui, bus| {
+                let BusPermissions { read, write } = bus;
+                self.show_perm_bool(ui, *read, "Read");
+                self.show_perm_bool(ui, *write, "Write");
             });
-            self.show_perm_collapsible(ui, &internal.ppu, "PPU", |ui, ppu| {
-                self.show_perm_bool(ui, ppu.display, "Display");
+            self.show_perm_collapsible(ui, ppu, "PPU", |ui, ppu| {
+                let PpuPermissions { display } = ppu;
+                self.show_perm_bool(ui, *display, "Display");
             });
-            self.show_perm_bool(ui, internal.input, "Input");
-            self.show_perm_collapsible(ui, &internal.control, "Control", |ui, control| {
-                self.show_perm_bool(ui, control.pause, "Pause");
-                self.show_perm_bool(ui, control.dialog, "Dialog");
+            self.show_perm_bool(ui, *input, "Input");
+            self.show_perm_collapsible(ui, control, "Control", |ui, control| {
+                let ControlPermissions { dialog, pause } = control;
+                self.show_perm_bool(ui, *pause, "Pause");
+                self.show_perm_bool(ui, *dialog, "Dialog");
             });
         });
 
-        self.force_show_perm_collapsible(ui, &perms.external, "External", |ui, external| {
-            self.show_perm_bool(ui, external.http, "HTTP");
-            self.show_perm_collapsible(ui, &external.filesystem, "Filesystem", |ui, fs| {
-                self.show_perm_bool(ui, fs.read, "Read");
-                self.show_perm_collapsible(ui, &fs.write, "Write", |ui, write| match write {
+        self.force_show_perm_collapsible(ui, external, "External", |ui, external| {
+            let ExternalPermissions { filesystem, http } = external;
+
+            self.show_perm_bool(ui, *http, "HTTP");
+            self.show_perm_collapsible(ui, filesystem, "Filesystem", |ui, fs| {
+                let FileSystemPermissions { read, write } = fs;
+                self.show_perm_bool(ui, *read, "Read");
+                self.show_perm_collapsible(ui, write, "Write", |ui, write| match write {
                     AllOr::All => {
                         ui.label(RichText::new("all").strong());
                     }
@@ -440,12 +458,10 @@ impl<'a> PluginPermRequest<'a> {
                                 ui.label(RichText::new(format!("{file:?}")).monospace());
                                 let label = match options {
                                     FileWriteOptions::NewOnly => "NewOnly",
-                                    FileWriteOptions::CanOverwrite { create, mode } => {
-                                        &format!(
-                                            ": {}{mode:?}",
-                                            if *create { "Create + " } else { "" }
-                                        )
-                                    }
+                                    FileWriteOptions::CanOverwrite { create, mode } => &format!(
+                                        ": {}{mode:?}",
+                                        if *create { "Create + " } else { "" }
+                                    ),
                                 };
                                 ui.label(label);
                             });

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -411,6 +411,12 @@ impl<'a> PluginPermRequest<'a> {
         let RSnesPermissions { internal, external } = &self.plugin.table.perms;
 
         self.force_show_perm_collapsible(ui, internal, "Internal", |ui, internal| {
+            // we intentionally destructure the stuct listing out all fields (without `..`),
+            // so that we get a compile error in case we forget to list a field in the
+            // destructure (and a warning if we write it just below but don't use it).
+            // This guarantees that we render all requested permissions in the GUI,
+            // which guarantees some security to the user (they at least know what is
+            // requested)
             let InternalPermissions {
                 control,
                 cpu,

--- a/plugins/src/plugin/gui.rs
+++ b/plugins/src/plugin/gui.rs
@@ -1,0 +1,176 @@
+use egui::{CollapsingHeader, RichText, Style, TextFormat, WidgetText, text::LayoutJob};
+
+use crate::{perm_tree::{*, filesystem::*}, permission::{Permission, helpers::AllOr}, plugin::Plugin};
+
+pub struct PluginPermRequest<'a> {
+    pub plugin: &'a Plugin,
+    pub allow_all: bool,
+
+    pub show_none: bool,
+}
+
+impl<'a> PluginPermRequest<'a> {
+    fn perm_label(perm: &impl Permission, name: &str) -> impl Into<WidgetText> {
+        let mut job = LayoutJob::default();
+        job.append(name, 0.0, Default::default());
+        if perm.is_none() {
+            job.append(
+                "none",
+                12.0,
+                TextFormat {
+                    italics: true,
+                    ..Default::default()
+                },
+            );
+        }
+        if perm.is_all() {
+            job.append(
+                "all",
+                12.0,
+                TextFormat {
+                    color: Style::default().visuals.strong_text_color(),
+                    italics: true,
+                    ..Default::default()
+                },
+            );
+        }
+
+        job
+    }
+    fn perm_collapsing_header(perm: &impl Permission, name: &str) -> CollapsingHeader {
+        CollapsingHeader::new(Self::perm_label(perm, name))
+    }
+    fn force_show_perm_collapsible<T: Permission>(
+        &self,
+        ui: &mut egui::Ui,
+        perm: &T,
+        label: &str,
+        draw_content: impl FnOnce(&mut egui::Ui, &T),
+    ) {
+        Self::perm_collapsing_header(perm, label)
+            .default_open(!perm.is_all() && !perm.is_none())
+            .show(ui, |ui| draw_content(ui, perm));
+    }
+    fn show_perm_collapsible<T: Permission>(
+        &self,
+        ui: &mut egui::Ui,
+        perm: &T,
+        label: &str,
+        draw_content: impl FnOnce(&mut egui::Ui, &T),
+    ) {
+        self.show_perm(ui, perm, |ui, perm| {
+            Self::force_show_perm_collapsible(&self, ui, perm, label, draw_content);
+        });
+    }
+    fn show_perm<T: Permission>(
+        &self,
+        ui: &mut egui::Ui,
+        perm: &T,
+        add_content: impl FnOnce(&mut egui::Ui, &T),
+    ) {
+        if !perm.is_none() || self.show_none {
+            add_content(ui, perm);
+        }
+    }
+    fn show_perm_bool(&self, ui: &mut egui::Ui, perm: bool, label: &str) {
+        self.show_perm(ui, &perm, |ui, perm| {
+            ui.label(Self::perm_label(perm, label));
+        });
+    }
+    pub fn show_gui(&mut self, ui: &mut egui::Ui) {
+        let close = |ui: &mut egui::Ui| {
+            ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+        };
+
+        ui.separator();
+
+        ui.label(RichText::new("Requested permissions").heading());
+        let RSnesPermissions { internal, external } = &self.plugin.table.perms;
+
+        self.force_show_perm_collapsible(ui, internal, "Internal", |ui, internal| {
+            // we intentionally destructure the stuct listing out all fields (without `..`),
+            // so that we get a compile error in case we forget to list a field in the
+            // destructure (and a warning if we write it just below but don't use it).
+            // This guarantees that we render all requested permissions in the GUI,
+            // which guarantees some security to the user (they at least know what is
+            // requested)
+            let InternalPermissions {
+                control,
+                cpu,
+                ppu,
+                bus,
+                input,
+            } = internal;
+
+            self.show_perm_collapsible(ui, cpu, "CPU", |ui, cpu| {
+                let CpuPermissions { registers } = cpu;
+                self.show_perm_bool(ui, *registers, "Registers");
+            });
+            self.show_perm_collapsible(ui, bus, "Bus", |ui, bus| {
+                let BusPermissions { read, write } = bus;
+                self.show_perm_bool(ui, *read, "Read");
+                self.show_perm_bool(ui, *write, "Write");
+            });
+            self.show_perm_collapsible(ui, ppu, "PPU", |ui, ppu| {
+                let PpuPermissions { display } = ppu;
+                self.show_perm_bool(ui, *display, "Display");
+            });
+            self.show_perm_bool(ui, *input, "Input");
+            self.show_perm_collapsible(ui, control, "Control", |ui, control| {
+                let ControlPermissions { dialog, pause } = control;
+                self.show_perm_bool(ui, *pause, "Pause");
+                self.show_perm_bool(ui, *dialog, "Dialog");
+            });
+        });
+
+        self.force_show_perm_collapsible(ui, external, "External", |ui, external| {
+            let ExternalPermissions { filesystem, http } = external;
+
+            self.show_perm_bool(ui, *http, "HTTP");
+            self.show_perm_collapsible(ui, filesystem, "Filesystem", |ui, fs| {
+                let FileSystemPermissions { read, write } = fs;
+                self.show_perm_bool(ui, *read, "Read");
+                self.show_perm_collapsible(ui, write, "Write", |ui, write| match write {
+                    AllOr::All => {
+                        ui.label(RichText::new("all").strong());
+                    }
+                    AllOr::Inner(files) => {
+                        for (file, options) in files.files.iter() {
+                            ui.horizontal(|ui| {
+                                ui.spacing_mut().item_spacing.x = 0.;
+                                ui.label(RichText::new(format!("{file:?}")).monospace());
+                                let label = match options {
+                                    FileWriteOptions::NewOnly => "NewOnly",
+                                    FileWriteOptions::CanOverwrite { create, mode } => &format!(
+                                        ": {}{mode:?}",
+                                        if *create { "Create + " } else { "" }
+                                    ),
+                                };
+                                ui.label(label);
+                            });
+                        }
+                    }
+                })
+            });
+        });
+
+        ui.add_space(8.0);
+        ui.horizontal(|ui| {
+            ui.checkbox(&mut self.show_none, "Show 'none' fields");
+        });
+
+        ui.separator();
+        ui.add_space(16.0);
+
+        ui.horizontal(|ui| {
+            if ui.button("Grant requested permissions").clicked() {
+                self.allow_all = true;
+                close(ui);
+            }
+            if ui.button("Cancel plugin execution").clicked() {
+                self.allow_all = false;
+                close(ui);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## 📝 Description

This PR implements a clean GUI which allows a user to see what permissions a plugin is requesting.
This is not yet linked to the main program, this will have to be linked later.

Since there are no unit tests for this (because I don't even know how I would write UI tests and I don't want to research that now), it would be great if you could try to run the GUI on your machines to see if things look right (`cd plugins; cargo r --features=example`, just be aware that you might get crashes if you press "accept" depending on what the plugin is trying to do, because it is not going to actually receive any of the permissions it requested in this example program).
