### PR TITLE
:sparkles: Show runtime errors in GUI instead of panic!ing

### DIFF
--- a/demo_minimal.lua
+++ b/demo_minimal.lua
@@ -1,0 +1,6 @@
+return {
+    permissions = "none",
+    init = function()
+        print("Hello world")
+    end,
+}

--- a/plugin_examples/error_default.lua
+++ b/plugin_examples/error_default.lua
@@ -1,0 +1,8 @@
+return {
+    permissions = "none",
+    actions = {
+        default = function()
+            rsnes.input.press_a()
+        end
+    }
+}

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,6 +1,7 @@
 pub mod state;
 pub mod widgets;
 
+use std::error::Error;
 use std::path::PathBuf;
 
 use egui_sdl2::canvas::EguiCanvas;
@@ -249,6 +250,7 @@ impl Gui {
     /// one line here plus one field in `GuiState` — nothing in `main.rs`.
     fn draw_overlays(state: &mut GuiState, data: &GuiFrameData, ctx: &egui::Context) {
         widgets::rom_info(ctx, &mut state.show_rom_info, data.rom_info);
+        widgets::error_box(ctx, &mut state.error_popup)
     }
 
     /// One frame: poll input, blit the framebuffer, draw overlays, present.
@@ -272,5 +274,19 @@ impl Gui {
         self.egui_canvas.present();
 
         events
+    }
+
+    pub fn pass_error(&mut self, err: Box<dyn Error>) {
+        self.state.error_popup = Some(err);
+    }
+
+    pub fn unwrap_result<T: Default, E: Error + 'static>(&mut self, res: Result<T, E>) -> T {
+        match res {
+            Ok(x) => x,
+            Err(e) => {
+                self.pass_error(Box::new(e));
+                Default::default()
+            }
+        }
     }
 }

--- a/src/gui/state.rs
+++ b/src/gui/state.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 /// Which overlay windows are currently open.
 ///
 /// This lives in `Gui` and persists across frames — egui is immediate-mode,
@@ -6,6 +8,7 @@
 #[derive(Default)]
 pub struct GuiState {
     pub show_rom_info: bool,
+    pub error_popup: Option<Box<dyn Error>>,
 }
 
 impl GuiState {
@@ -15,10 +18,11 @@ impl GuiState {
     pub fn close_all(&mut self) -> bool {
         let was_open = self.any_open();
         self.show_rom_info = false;
+        self.error_popup = None;
         was_open
     }
 
     pub fn any_open(&self) -> bool {
-        self.show_rom_info
+        self.show_rom_info || self.error_popup.is_some()
     }
 }

--- a/src/gui/widgets.rs
+++ b/src/gui/widgets.rs
@@ -1,5 +1,7 @@
+use std::error::Error;
+
 use bus::rom::header::RomHeader;
-use egui_sdl2::egui;
+use egui_sdl2::egui::{self, RichText};
 
 use crate::rsnes::RomInfo;
 
@@ -159,4 +161,47 @@ pub fn rom_info(ctx: &egui::Context, open: &mut bool, info: Option<&RomInfo>) {
                     ui.add(egui::Label::new(path.display().to_string()).wrap());
                 });
         });
+}
+
+/// Renders a window showing any runtime error
+pub fn error_box(ctx: &egui::Context, error: &mut Option<Box<dyn Error>>) {
+    let mut open = error.is_some();
+    let window = egui::Window::new("Error")
+        .open(&mut open)
+        .resizable(true)
+        .collapsible(false)
+        .default_width(250.0)
+        .default_height(100.0)
+        .vscroll(true);
+
+    window.show(ctx, |ui| {
+        let Some(e) = error else {
+            ui.centered_and_justified(|ui| {
+                ui.label("No error");
+                ui.label("how did you even get this window to open?");
+            });
+            return;
+        };
+        ui.label(RichText::new("Encountered error:").heading());
+        ui.indent((), |ui| {
+            show_error(ui, e.as_ref());
+        });
+    });
+
+    if !open {
+        *error = None;
+    }
+}
+
+/// Recursively show errors and their sources
+fn show_error(ui: &mut egui::Ui, err: &dyn Error) {
+    ui.label(err.to_string());
+    if let Some(source) = err.source() {
+        ui.collapsing("Caused by:", |ui| {
+            show_error(ui, source);
+        });
+    }
+    ui.collapsing("Debug representation:", |ui| {
+        ui.label(format!("{err:?}"));
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,13 @@ fn gui_emu_loop(
     gui.set_rom_title(if title.is_empty() { None } else { Some(title) });
 
     let mut emu = cfg_select! {
-        feature = "plugins" => RSnesEmu::new_with_plugin(rsnes, plugin).unwrap(),
+        feature = "plugins" => match RSnesEmu::new_with_plugin(rsnes, plugin) {
+            Ok(emu) => emu,
+            Err(e) => {
+                gui.pass_error(Box::new(e));
+                return None;
+            }
+        },
         _ => RSnesEmu::new(rsnes),
     };
 
@@ -62,7 +68,7 @@ fn gui_emu_loop(
             master_cycle_accum -= RSnesCore::MASTER_CYCLE_DURATION;
 
             cfg_select! {
-                feature = "plugins" => emu.update().unwrap(),
+                feature = "plugins" => gui.unwrap_result(emu.update()),
                 _ => emu.update(),
             }
         }
@@ -112,7 +118,7 @@ fn gui_emu_loop(
                 #[cfg(feature = "plugins")]
                 RSnesEvent::RunPluginDefault => {
                     if let Some(p) = emu.plugin_mut() {
-                        p.run_default().unwrap();
+                        gui.unwrap_result(p.run_default())
                     }
                 }
 
@@ -124,7 +130,7 @@ fn gui_emu_loop(
 
     #[cfg(feature = "plugins")]
     if let Some(p) = emu.plugin_mut() {
-        p.run_exit().unwrap();
+        gui.unwrap_result(p.run_exit())
     }
 
     let time = Instant::now();
@@ -151,6 +157,7 @@ fn gui_idle_loop(
         for event in events {
             match event {
                 RSnesEvent::Quit => return RSnesEvent::Quit,
+                RSnesEvent::Close => return RSnesEvent::Close,
                 RSnesEvent::LoadRom { path } => return RSnesEvent::LoadRom { path },
                 _ => {}
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn gui_loop(
         match ev {
             RSnesEvent::LoadRom { path } => match rsnes::RSnesCore::load_rom(&path) {
                 Ok(some_emu) => rsnes_core = Some(some_emu),
-                Err(err) => println!("Error loading ROM: {}", err),
+                Err(err) => gui.pass_error(err),
             },
             RSnesEvent::Quit | RSnesEvent::Close => break,
             _ => {}


### PR DESCRIPTION
## 📝 Description

Previously, the program would just crash as soon as any error occured (invalid ROM, plugin error, etc.)
Now that we have egui to render things, we can at least catch the error and display it to the user (not in the best way but that's still way better than hard crashing)

## 🔍 Related Issues

Closes EpitechPromo2027/G-EIP-600-NAN-6-1-eip-florent.charpentier#<issue-number>
<!-- Replace <issue-number> with the relevant issue ID -->
