### PR TITLE
:sparkles: Add plugin pop-up window in idle loop

### DIFF
--- a/plugins/src/bin/main.rs
+++ b/plugins/src/bin/main.rs
@@ -1,6 +1,6 @@
 use eframe::egui;
 use egui::ScrollArea;
-use plugins::plugin::{Plugin, gui::PluginPermRequest};
+use plugins::plugin::{Plugin, gui::PermOutcome, gui::PluginPermRequest};
 
 struct PermRequestApp<'app, 'req> {
     title: String,
@@ -56,7 +56,7 @@ fn main() -> eframe::Result {
         Box::new(|_| Ok(Box::new(PermRequestApp::new(&mut perm_request, title)))),
     )?;
 
-    if perm_request.allow_all {
+    if perm_request.outcome == PermOutcome::Granted {
         println!("\x1B[1;32m✔\x1B[0m permissions granted");
     } else {
         println!("\x1B[1;31m✘\x1B[0m permission denied, exiting");

--- a/plugins/src/plugin.rs
+++ b/plugins/src/plugin.rs
@@ -265,11 +265,11 @@ impl Plugin {
         Ok(Self { lua, table, path })
     }
 
-    pub fn perm_request<'a>(&'a self) -> PluginPermRequest<'a> {
+    pub fn perm_request(&self) -> PluginPermRequest<'_> {
         PluginPermRequest {
             plugin: self,
-            allow_all: false,
             show_none: false,
+            outcome: gui::PermOutcome::Pending,
         }
     }
 
@@ -356,6 +356,31 @@ impl Plugin {
         });
 
         lua.execute(&ex)
+    }
+}
+
+impl std::fmt::Display for PluginLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            PluginLoadError::OpenError(e) => write!(f, "failed to open plugin file: {e}"),
+            PluginLoadError::BufCreationError(e) => write!(f, "failed to create read buffer: {e}"),
+            PluginLoadError::ReadError(e) => write!(f, "failed to read plugin file: {e}"),
+            PluginLoadError::LuaError(e) => write!(f, "lua error while loading plugin: {e}"),
+            PluginLoadError::PluginTabError(e) => write!(f, "error reading plugin table: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for PluginLoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            PluginLoadError::OpenError(e)
+            | PluginLoadError::BufCreationError(e)
+            | PluginLoadError::ReadError(e) => Some(e),
+            // ExternError isn't guaranteed to impl Error; keep it in the Display
+            // message above rather than exposing it as a source.
+            _ => None,
+        }
     }
 }
 

--- a/plugins/src/plugin/gui.rs
+++ b/plugins/src/plugin/gui.rs
@@ -6,11 +6,20 @@ use crate::{
     plugin::Plugin,
 };
 
+/// The user's decision on a permission request. `Pending` until a button is
+/// clicked; the host reads this after each frame to know what to do.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum PermOutcome {
+    #[default]
+    Pending,
+    Granted,
+    Denied,
+}
+
 pub struct PluginPermRequest<'a> {
     pub plugin: &'a Plugin,
-    pub allow_all: bool,
-
     pub show_none: bool,
+    pub outcome: PermOutcome,
 }
 
 impl<'a> PluginPermRequest<'a> {
@@ -81,18 +90,15 @@ impl<'a> PluginPermRequest<'a> {
             ui.label(Self::perm_label(perm, label));
         });
     }
-    pub fn show_gui(&mut self, ui: &mut egui::Ui) {
-        let close = |ui: &mut egui::Ui| {
-            ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-        };
 
+    pub fn show_gui(&mut self, ui: &mut egui::Ui) {
         ui.separator();
 
         ui.label(RichText::new("Requested permissions").heading());
         let RSnesPermissions { internal, external } = &self.plugin.table.perms;
 
         self.force_show_perm_collapsible(ui, internal, "Internal", |ui, internal| {
-            // we intentionally destructure the stuct listing out all fields (without `..`),
+            // we intentionally destructure the struct listing out all fields (without `..`),
             // so that we get a compile error in case we forget to list a field in the
             // destructure (and a warning if we write it just below but don't use it).
             // This guarantees that we render all requested permissions in the GUI,
@@ -168,12 +174,10 @@ impl<'a> PluginPermRequest<'a> {
 
         ui.horizontal(|ui| {
             if ui.button("Grant requested permissions").clicked() {
-                self.allow_all = true;
-                close(ui);
+                self.outcome = PermOutcome::Granted;
             }
             if ui.button("Cancel plugin execution").clicked() {
-                self.allow_all = false;
-                close(ui);
+                self.outcome = PermOutcome::Denied;
             }
         });
     }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -16,6 +16,11 @@ use ppu::constants::{SCREEN_HEIGHT, SCREEN_WIDTH};
 use crate::rsnes::RomInfo;
 use state::GuiState;
 
+#[cfg(feature = "plugins")]
+use plugins::plugin::Plugin;
+#[cfg(feature = "plugins")]
+use state::PendingPlugin;
+
 pub struct Gui {
     _sdl_ctx: sdl2::Sdl,
     egui_canvas: EguiCanvas,
@@ -30,6 +35,11 @@ pub struct Gui {
     framebuffer_texture: Option<Texture>,
     /// Persistent overlay state — survives across frames.
     state: GuiState,
+    /// Whether Ctrl+P is allowed to open the plugin picker. Only the idle
+    /// loop enables it, since injection needs a running emu (handled by the
+    /// emu loop, not here).
+    #[cfg(feature = "plugins")]
+    plugin_loading_enabled: bool,
 }
 
 /// Everything the GUI might need to display, handed in fresh each frame.
@@ -68,6 +78,8 @@ pub enum RSnesEvent {
 enum GuiAction {
     ToggleRomInfo,
     CloseOverlays,
+    #[cfg(feature = "plugins")]
+    LoadPlugin,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -106,6 +118,8 @@ impl Gui {
             audio_queue,
             framebuffer_texture: None,
             state: GuiState::default(),
+            #[cfg(feature = "plugins")]
+            plugin_loading_enabled: false,
         })
     }
 
@@ -126,6 +140,37 @@ impl Gui {
             .set_title(&window_title);
     }
 
+    /// Enables/disables Ctrl+P plugin loading. Idle loop enables, emu loop disables.
+    #[cfg(feature = "plugins")]
+    pub fn set_plugin_loading(&mut self, enabled: bool) {
+        self.plugin_loading_enabled = enabled;
+    }
+
+    /// Takes the plugin the user granted this idle session, if any, and
+    /// abandons any still-undecided prompt. Called when the idle loop exits.
+    #[cfg(feature = "plugins")]
+    pub fn take_granted_plugin(&mut self) -> Option<Plugin> {
+        self.state.pending_plugin = None;
+        self.state.granted_plugin.take()
+    }
+
+    /// Opens a .lua file picker; on success the plugin becomes pending (its
+    /// permission prompt opens next frame), on failure it surfaces as an error.
+    #[cfg(feature = "plugins")]
+    fn load_plugin_dialog(&mut self) {
+        let Some(path) = rfd::FileDialog::new()
+            .add_filter("Lua plugin", &["lua"])
+            .pick_file()
+        else {
+            return;
+        };
+
+        match Plugin::load_from_file(&path) {
+            Ok(plugin) => self.state.pending_plugin = Some(PendingPlugin::new(plugin)),
+            Err(e) => self.pass_error(Box::new(e)),
+        }
+    }
+
     /// Maps an SDL event to a GUI-only action (toggling overlays).
     fn map_gui_action(event: &SdlEvent) -> Option<GuiAction> {
         match event {
@@ -134,6 +179,18 @@ impl Gui {
                 repeat: false,
                 ..
             } => Some(GuiAction::ToggleRomInfo),
+
+            #[cfg(feature = "plugins")]
+            SdlEvent::KeyDown {
+                keycode: Some(Keycode::P),
+                keymod,
+                repeat: false,
+                ..
+            } if keymod
+                .intersects(sdl2::keyboard::Mod::LCTRLMOD | sdl2::keyboard::Mod::RCTRLMOD) =>
+            {
+                Some(GuiAction::LoadPlugin)
+            }
 
             SdlEvent::KeyDown {
                 keycode: Some(Keycode::Escape),
@@ -246,6 +303,14 @@ impl Gui {
                         self.state.show_rom_info = !self.state.show_rom_info;
                         continue;
                     }
+                    #[cfg(feature = "plugins")]
+                    GuiAction::LoadPlugin => {
+                        // Idle-loop only: injection needs a running emu.
+                        if self.plugin_loading_enabled {
+                            self.load_plugin_dialog();
+                        }
+                        continue;
+                    }
                     GuiAction::CloseOverlays => {
                         if self.state.close_all() {
                             continue; // an overlay was open; Escape consumed by GUI
@@ -295,7 +360,9 @@ impl Gui {
     /// one line here plus one field in `GuiState` — nothing in `main.rs`.
     fn draw_overlays(state: &mut GuiState, data: &GuiFrameData, ctx: &egui::Context) {
         widgets::rom_info(ctx, &mut state.show_rom_info, data.rom_info);
-        widgets::error_box(ctx, &mut state.error_popup)
+        widgets::error_box(ctx, &mut state.error_popup);
+        #[cfg(feature = "plugins")]
+        widgets::plugin_perm_request(ctx, &mut state.pending_plugin, &mut state.granted_plugin);
     }
 
     /// One frame: poll input, blit the framebuffer, draw overlays, present.

--- a/src/gui/state.rs
+++ b/src/gui/state.rs
@@ -1,5 +1,26 @@
 use std::error::Error;
 
+#[cfg(feature = "plugins")]
+use plugins::plugin::Plugin;
+
+/// A plugin loaded and awaiting the user's grant/deny decision, plus the
+/// transient UI state of its permission window (persisted across frames).
+#[cfg(feature = "plugins")]
+pub struct PendingPlugin {
+    pub plugin: Plugin,
+    pub show_none: bool,
+}
+
+#[cfg(feature = "plugins")]
+impl PendingPlugin {
+    pub fn new(plugin: Plugin) -> Self {
+        Self {
+            plugin,
+            show_none: false,
+        }
+    }
+}
+
 /// Which overlay windows are currently open.
 ///
 /// This lives in `Gui` and persists across frames — egui is immediate-mode,
@@ -9,20 +30,40 @@ use std::error::Error;
 pub struct GuiState {
     pub show_rom_info: bool,
     pub error_popup: Option<Box<dyn Error>>,
+
+    /// A plugin loaded and awaiting the user's grant/deny decision.
+    #[cfg(feature = "plugins")]
+    pub pending_plugin: Option<PendingPlugin>,
+
+    /// A plugin the user granted, waiting to be handed back to `gui_loop`
+    /// when the idle loop exits.
+    #[cfg(feature = "plugins")]
+    pub granted_plugin: Option<Plugin>,
 }
 
 impl GuiState {
     /// Closes every open overlay. Bound to Escape.
     /// Returns true if anything was actually closed, so the caller can
     /// distinguish "Escape closed a window" from "Escape should close the ROM".
+    ///
+    /// Dismissing a pending permission prompt this way counts as a denial.
     pub fn close_all(&mut self) -> bool {
         let was_open = self.any_open();
         self.show_rom_info = false;
         self.error_popup = None;
+        #[cfg(feature = "plugins")]
+        {
+            self.pending_plugin = None;
+        }
         was_open
     }
 
     pub fn any_open(&self) -> bool {
-        self.show_rom_info || self.error_popup.is_some()
+        let mut open = self.show_rom_info || self.error_popup.is_some();
+        #[cfg(feature = "plugins")]
+        {
+            open = open || self.pending_plugin.is_some();
+        }
+        open
     }
 }

--- a/src/gui/widgets.rs
+++ b/src/gui/widgets.rs
@@ -5,6 +5,12 @@ use egui_sdl2::egui::{self, RichText};
 
 use crate::rsnes::RomInfo;
 
+#[cfg(feature = "plugins")]
+use plugins::plugin::{Plugin, gui::PermOutcome};
+
+#[cfg(feature = "plugins")]
+use super::state::PendingPlugin;
+
 /// Decodes a SNES header size exponent into KB. `0` means "none".
 fn decode_size_kb(exponent: u8) -> Option<usize> {
     if exponent == 0 {
@@ -204,4 +210,67 @@ fn show_error(ui: &mut egui::Ui, err: &dyn Error) {
     ui.collapsing("Debug representation:", |ui| {
         ui.label(format!("{err:?}"));
     });
+}
+
+/// Plugin permission prompt. Rendered only while a plugin is awaiting a
+/// decision. Granting moves the plugin into `granted` for the host to inject;
+/// denying (buttons, [x], or Escape) drops it.
+#[cfg(feature = "plugins")]
+pub fn plugin_perm_request(
+    ctx: &egui::Context,
+    pending: &mut Option<PendingPlugin>,
+    granted: &mut Option<Plugin>,
+) {
+    if pending.is_none() {
+        return;
+    }
+
+    let mut window_open = true;
+
+    // Borrow the pending plugin to render its request, then pull the outcome
+    // and checkbox state out so the borrow ends before we mutate `pending`.
+    let (outcome, show_none) = {
+        let p = pending.as_ref().unwrap();
+        let mut req = p.plugin.perm_request();
+        req.show_none = p.show_none;
+
+        egui::Window::new("Plugin Permissions")
+            .open(&mut window_open)
+            .collapsible(false)
+            .resizable(true)
+            .default_width(320.0)
+            .default_height(400.0)
+            .vscroll(true)
+            .show(ctx, |ui| {
+                let name = p
+                    .plugin
+                    .path
+                    .as_ref()
+                    .and_then(|path| path.file_name())
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "<in-memory plugin>".to_owned());
+                ui.label(RichText::new(name).monospace());
+                req.show_gui(ui);
+            });
+
+        (req.outcome, req.show_none)
+    };
+
+    if let Some(p) = pending.as_mut() {
+        p.show_none = show_none;
+    }
+
+    match outcome {
+        PermOutcome::Granted => {
+            let taken = pending.take().unwrap();
+            *granted = Some(taken.plugin);
+        }
+        PermOutcome::Denied => *pending = None,
+        // [x] or Escape while undecided : deny.
+        PermOutcome::Pending => {
+            if !window_open {
+                *pending = None;
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,11 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(feature = "plugins")]
+type IdleExit = (RSnesEvent, Option<Plugin>);
+#[cfg(not(feature = "plugins"))]
+type IdleExit = RSnesEvent;
+
 fn gui_emu_loop(
     gui: &mut gui::Gui,
     rsnes: RSnesCore,
@@ -33,6 +38,8 @@ fn gui_emu_loop(
     let rom_info = rsnes.rom_info();
     let title = rom_info.header.title.trim();
     gui.set_rom_title(if title.is_empty() { None } else { Some(title) });
+    #[cfg(feature = "plugins")]
+    gui.set_plugin_loading(false);
 
     let mut emu = cfg_select! {
         feature = "plugins" => match RSnesEmu::new_with_plugin(rsnes, plugin) {
@@ -149,10 +156,7 @@ fn gui_emu_loop(
 /// Returns the first event the outer loop cares about. Input-only events
 /// (buttons, plugin actions) are meaningless without a game and are
 /// swallowed here.
-fn gui_idle_loop(
-    gui: &mut Gui,
-    default_framebuffer: &ppu::rendering::RawFramebuffer,
-) -> RSnesEvent {
+fn gui_idle_loop(gui: &mut Gui, default_framebuffer: &ppu::rendering::RawFramebuffer) -> IdleExit {
     use apu::jingle::IdleJingle;
 
     /// Silence on the logo screen before the music starts.
@@ -165,12 +169,14 @@ fn gui_idle_loop(
     const CHUNK_FRAMES: usize = 1_024;
 
     gui.set_rom_title(None);
+    #[cfg(feature = "plugins")]
+    gui.set_plugin_loading(true);
 
     let idle_start = Instant::now();
     let mut jingle: Option<IdleJingle> = None;
     let mut jingle_failed = false;
 
-    loop {
+    let ev = loop {
         let frame_start = Instant::now();
 
         // Render the logo + overlays; this also polls input (routed
@@ -178,20 +184,17 @@ fn gui_idle_loop(
         // the overlay will say so if the user opens it.
         let events = gui.update(default_framebuffer, GuiFrameData::default());
 
+        let mut terminal = None;
         for event in events {
             match event {
-                // Input-only events are meaningless without a game loaded.
-                RSnesEvent::ButtonDown | RSnesEvent::ButtonUp => {}
-                #[cfg(feature = "plugins")]
-                RSnesEvent::RunPluginDefault => {}
-                // Everything the outer loop cares about (Quit, Close,
-                // LoadRom, ...) ends the idle state; stop the jingle
-                // stream before handing the event back.
-                ev => {
-                    gui.audio_stop();
-                    return ev;
-                }
+                RSnesEvent::Quit => terminal = Some(RSnesEvent::Quit),
+                RSnesEvent::Close => terminal = Some(RSnesEvent::Close),
+                RSnesEvent::LoadRom { path } => terminal = Some(RSnesEvent::LoadRom { path }),
+                _ => {}
             }
+        }
+        if let Some(ev) = terminal {
+            break ev;
         }
 
         // Boot the jingle APU once the delay has passed. A boot failure
@@ -233,6 +236,13 @@ fn gui_idle_loop(
         if elapsed < Gui::FRAME_DURATION {
             std::thread::sleep(Duration::from_secs_f64(Gui::FRAME_DURATION - elapsed));
         }
+    };
+
+    // Carry any granted plugin back to `gui_loop` alongside the exit event.
+    gui.audio_stop();
+    cfg_select! {
+        feature = "plugins" => (ev, gui.take_granted_plugin()),
+        _ => ev,
     }
 }
 
@@ -251,7 +261,21 @@ fn gui_loop(
         // guaranteeing that the `RSnes` is destructed when
         // we leave the loop
         let ev = match rsnes_core.take() {
-            None => gui_idle_loop(&mut gui, DEFAULT_FRAMEBUFFER),
+            None => {
+                let idle_exit = gui_idle_loop(&mut gui, DEFAULT_FRAMEBUFFER);
+                cfg_select! {
+                    feature = "plugins" => {
+                        let (ev, new_plugin) = idle_exit;
+                        // A freshly granted plugin replaces whatever we were holding;
+                        // neither has been injected/init'd yet, so nothing to run_exit.
+                        if new_plugin.is_some() {
+                            plugin = new_plugin;
+                        }
+                        ev
+                    },
+                    _ => idle_exit,
+                }
+            }
 
             Some(emu) => {
                 let ret_ev = cfg_select! {


### PR DESCRIPTION
## 📝 Description

This pull requests implements a pop-up window to load plugins with the GUI. To make the pop-up appear, you have to be at the menu screen and press `ctrl + P`. It will open the file picker and you will have to choose a `.lua` file. Once you selected one it will either crash if it's an invalid plugin or open a permission grant/cancel window : 

<img width="811" height="724" alt="image" src="https://github.com/user-attachments/assets/f14c1341-4f8a-45a3-b813-b900d6e77f43" />

The user can refuse or accept to grant the permissions and then the plugin is loaded or not. You can then load a rom and if a plugin is loaded it will be launched alongside it.