### PR TITLE
PPU OAM

### DIFF
--- a/ppu/src/lib.rs
+++ b/ppu/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ppu;
 pub mod registers;
 pub mod vram;
 pub mod write_twice;
+pub mod oam;
 
 pub mod rendering;
 

--- a/ppu/src/lib.rs
+++ b/ppu/src/lib.rs
@@ -5,6 +5,7 @@ pub mod registers;
 pub mod vram;
 pub mod write_twice;
 pub mod oam;
+pub mod sprites;
 
 pub mod rendering;
 

--- a/ppu/src/lib.rs
+++ b/ppu/src/lib.rs
@@ -1,11 +1,11 @@
 pub mod cgram;
 pub mod constants;
+pub mod oam;
 pub mod ppu;
 pub mod registers;
+pub mod sprites;
 pub mod vram;
 pub mod write_twice;
-pub mod oam;
-pub mod sprites;
 
 pub mod rendering;
 

--- a/ppu/src/main.rs
+++ b/ppu/src/main.rs
@@ -115,8 +115,8 @@ fn main() {
     // Table 1: X=100, Y=108, tile=0, attr = priority 2 (0x20), palette 0.
     ppu.write(0x2102, 0x00);
     ppu.write(0x2103, 0x00);
-    ppu.write(0x2104, 100);  // X    -> latched
-    ppu.write(0x2104, 108);  // Y    -> commits word (X, Y)
+    ppu.write(0x2104, 100); // X    -> latched
+    ppu.write(0x2104, 108); // Y    -> commits word (X, Y)
     ppu.write(0x2104, 0x00); // tile -> latched
     ppu.write(0x2104, 0x20); // attr = priority 2, palette 0 (red)
 
@@ -125,8 +125,8 @@ fn main() {
     // attr layout vhoopppN: priority 2 = 0x20, palette 1 = (1 << 1) = 0x02 -> 0x22.
     ppu.write(0x2102, 0x02);
     ppu.write(0x2103, 0x00);
-    ppu.write(0x2104, 140);  // X    -> latched
-    ppu.write(0x2104, 104);  // Y    -> commits word (X, Y)
+    ppu.write(0x2104, 140); // X    -> latched
+    ppu.write(0x2104, 104); // Y    -> commits word (X, Y)
     ppu.write(0x2104, 0x02); // tile -> latched (tile 2)
     ppu.write(0x2104, 0x22); // attr = priority 2, palette 1 (green)
 
@@ -154,7 +154,7 @@ fn main() {
     let video = sdl_context.video().unwrap();
 
     let window = video
-        .window("SNES PPU - sprite test", SCREEN_WIDTH as u32, SCREEN_HEIGHT as u32)
+        .window("SNES PPU", SCREEN_WIDTH as u32, SCREEN_HEIGHT as u32)
         .position_centered()
         .build()
         .unwrap();

--- a/ppu/src/main.rs
+++ b/ppu/src/main.rs
@@ -17,11 +17,15 @@ fn main() {
         ppu.write(0x2122, 0x00);
     }
 
-    // Sprite palette 0, color index 1 -> CGRAM entry 128 + 0*16 + 1 = 129.
-    // Override it with bright red so the sprite stands out from the gradient.
+    // Sprite palette 0, color index 1 -> CGRAM entry 128 + 0*16 + 1 = 129 (red).
     ppu.write(0x2121, 129);
     ppu.write(0x2122, 0x1F); // low byte  (R = 31)
-    ppu.write(0x2122, 0x00); // high byte -> CGRAM[129] = 0x001F
+    ppu.write(0x2122, 0x00); // high byte -> CGRAM[129] = 0x001F (red)
+
+    // Sprite palette 1, color index 1 -> CGRAM entry 128 + 1*16 + 1 = 145 (green).
+    ppu.write(0x2121, 145);
+    ppu.write(0x2122, 0xE0); // low byte  (G low bits)
+    ppu.write(0x2122, 0x03); // high byte -> CGRAM[145] = 0x03E0 (green)
 
     // ============================================================
     // VRAM setup
@@ -71,19 +75,26 @@ fn main() {
         }
     }
 
-    // ---- Sprite CHR: one solid 8x8 tile (all pixels color index 1) ----
+    // ---- Sprite CHR ----
     // OBJSEL name base 1 -> sprite CHR base = 1 << 13 = word 0x2000.
-    // Tile 0 lives at 0x2000 (16 words). 4bpp: plane 0 all set = color 1.
+    // Each 4bpp tile is 16 words; a tile at tile-number N sits at 0x2000 + N*16.
+    // We fill a set of tiles with a solid color-index-1 pattern (plane 0 all set).
+    //  - tile 0        -> the 8x8 sprite
+    //  - tiles 2,3,0x12,0x13 -> the four quadrants of the 16x16 sprite
     let sprite_chr_base: u16 = 0x2000;
-    ppu.write(0x2116, (sprite_chr_base & 0xFF) as u8);
-    ppu.write(0x2117, (sprite_chr_base >> 8) as u8);
-    for _row in 0..8 {
-        ppu.write(0x2118, 0xFF); // plane 0 (low)  -> bit 0 set on every pixel
-        ppu.write(0x2119, 0x00); // plane 1 (high)
-    }
-    for _row in 0..8 {
-        ppu.write(0x2118, 0x00); // plane 2
-        ppu.write(0x2119, 0x00); // plane 3
+    let solid_tiles: [u16; 5] = [0, 2, 3, 0x12, 0x13];
+    for &tile_num in solid_tiles.iter() {
+        let base = sprite_chr_base + tile_num * 16;
+        ppu.write(0x2116, (base & 0xFF) as u8);
+        ppu.write(0x2117, (base >> 8) as u8);
+        for _row in 0..8 {
+            ppu.write(0x2118, 0xFF); // plane 0 (low)  -> color index 1
+            ppu.write(0x2119, 0x00); // plane 1 (high)
+        }
+        for _row in 0..8 {
+            ppu.write(0x2118, 0x00); // plane 2
+            ppu.write(0x2119, 0x00); // plane 3
+        }
     }
 
     // ============================================================
@@ -91,28 +102,46 @@ fn main() {
     // ============================================================
     // Park all 128 sprites off-screen (Y = 0xE0) so the zeroed OAM doesn't
     // draw a block of tile-0 sprites at the top-left corner.
+    // OAMADD is a WORD address: sprite i's table-1 entry is word i*2.
     for i in 0u16..128 {
-        let addr = i * 4;
-        ppu.write(0x2102, (addr & 0xFF) as u8);
-        ppu.write(0x2103, ((addr >> 8) & 0x01) as u8);
+        let word = i * 2;
+        ppu.write(0x2102, (word & 0xFF) as u8);
+        ppu.write(0x2103, ((word >> 8) & 0x01) as u8);
         ppu.write(0x2104, 0x00); // X lo -> latched
         ppu.write(0x2104, 0xE0); // Y    -> commits (X=0, Y=0xE0)
     }
 
-    // Sprite 0: visible 8x8 sprite near the center.
-    // Table 1: X=124, Y=108, tile=0, attr = priority 2 (0x20), palette 0, name 0.
+    // Sprite 0: 8x8 red sprite (word address 0).
+    // Table 1: X=100, Y=108, tile=0, attr = priority 2 (0x20), palette 0.
     ppu.write(0x2102, 0x00);
     ppu.write(0x2103, 0x00);
-    ppu.write(0x2104, 124);  // X    -> latched
+    ppu.write(0x2104, 100);  // X    -> latched
     ppu.write(0x2104, 108);  // Y    -> commits word (X, Y)
     ppu.write(0x2104, 0x00); // tile -> latched
-    ppu.write(0x2104, 0x20); // attr -> commits word (tile, attr)
+    ppu.write(0x2104, 0x20); // attr = priority 2, palette 0 (red)
+
+    // Sprite 1: 16x16 green sprite (word address 2 = sprite 1's table-1 entry).
+    // Table 1: X=140, Y=104, tile=2, attr = priority 2, palette 1.
+    // attr layout vhoopppN: priority 2 = 0x20, palette 1 = (1 << 1) = 0x02 -> 0x22.
+    ppu.write(0x2102, 0x02);
+    ppu.write(0x2103, 0x00);
+    ppu.write(0x2104, 140);  // X    -> latched
+    ppu.write(0x2104, 104);  // Y    -> commits word (X, Y)
+    ppu.write(0x2104, 0x02); // tile -> latched (tile 2)
+    ppu.write(0x2104, 0x22); // attr = priority 2, palette 1 (green)
+
+    // Sprite 1's large bit lives in OAM table 2. Sprite 1 occupies bits 3:2 of
+    // the first table-2 byte (byte 512, word address 256). large = bit 3.
+    // Now reachable thanks to word-based addressing.
+    ppu.write(0x2102, 0x00);
+    ppu.write(0x2103, 0x01); // word 256 -> byte 512 (table 2 start)
+    ppu.write(0x2104, 0b0000_1000); // sprite1 large = 1 (bits 3:2), sprite0 = 00
 
     // ============================================================
     // PPU registers
     // ============================================================
     ppu.write(0x2100, 0x0F); // INIDISP: display on, full brightness
-    ppu.write(0x2101, 0x01); // OBJSEL:  size 8x8/16x16, sprite CHR base = 0x2000
+    ppu.write(0x2101, 0x01); // OBJSEL:  size mode 0 (small 8x8 / large 16x16), CHR base 0x2000
     ppu.write(0x2105, 0x01); // BGMODE:  mode 1
     ppu.write(0x2107, 0x04); // BG1SC:   tilemap at word 0x0400, 32x32
     ppu.write(0x212C, 0x11); // TM:      BG1 (0x01) + OBJ (0x10) enabled

--- a/ppu/src/main.rs
+++ b/ppu/src/main.rs
@@ -8,20 +8,30 @@ fn main() {
     let mut ppu = PPU::new();
     let mut renderer = Renderer::new();
 
-    // Fill CGRAM with test gradient
+    // ============================================================
+    // CGRAM: test gradient (BG colors) + one bright sprite color
+    // ============================================================
     for i in 0u8..=255 {
         ppu.write(0x2121, i);
         ppu.write(0x2122, i);
         ppu.write(0x2122, 0x00);
     }
 
-    // Fill VRAM
-    ppu.write(0x2115, 0x80);
+    // Sprite palette 0, color index 1 -> CGRAM entry 128 + 0*16 + 1 = 129.
+    // Override it with bright red so the sprite stands out from the gradient.
+    ppu.write(0x2121, 129);
+    ppu.write(0x2122, 0x1F); // low byte  (R = 31)
+    ppu.write(0x2122, 0x00); // high byte -> CGRAM[129] = 0x001F
 
+    // ============================================================
+    // VRAM setup
+    // ============================================================
+    ppu.write(0x2115, 0x80); // VMAIN: increment after high byte, step 1
+
+    // ---- BG1 tiles (16 color bands), CHR at word 0 ----
     for tile in 0u16..16 {
         let tile_word_base = tile * 16; // 32 bytes = 16 words per tile
 
-        // Plane 0: low/high bitplane
         for row in 0u16..8 {
             let word_addr = tile_word_base + row;
             ppu.write(0x2116, (word_addr & 0xFF) as u8);
@@ -30,11 +40,10 @@ fn main() {
             let p0_low: u8 = if tile & 1 != 0 { 0xFF } else { 0x00 };
             let p0_high: u8 = if tile & 2 != 0 { 0xFF } else { 0x00 };
 
-            ppu.write(0x2118, p0_low); // VMDATAL
-            ppu.write(0x2119, p0_high); // VMDATAH
+            ppu.write(0x2118, p0_low);
+            ppu.write(0x2119, p0_high);
         }
 
-        // Plane 1: offset +8 words
         for row in 0u16..8 {
             let word_addr = tile_word_base + 8 + row;
             ppu.write(0x2116, (word_addr & 0xFF) as u8);
@@ -48,37 +57,75 @@ fn main() {
         }
     }
 
+    // ---- BG1 tilemap at word 0x0400 (16 vertical color bands) ----
     let tilemap_word_base: u16 = 0x0400;
-
     for row in 0u16..32 {
         for col in 0u16..32 {
             let word_addr = tilemap_word_base + row * 32 + col;
             ppu.write(0x2116, (word_addr & 0xFF) as u8);
             ppu.write(0x2117, (word_addr >> 8) as u8);
 
-            // 2 tile columns per color band, 16 bands total
             let tile_index: u16 = (col / 2) % 16;
-
-            let entry_low = (tile_index & 0xFF) as u8;
-            let entry_high = ((tile_index >> 8) & 0x03) as u8;
-
-            ppu.write(0x2118, entry_low);
-            ppu.write(0x2119, entry_high);
+            ppu.write(0x2118, (tile_index & 0xFF) as u8);
+            ppu.write(0x2119, ((tile_index >> 8) & 0x03) as u8);
         }
     }
 
-    // PPU registers
-    ppu.write(0x2100, 0x0F); // INIDISP (display on, max brightness)
-    ppu.write(0x2105, 0x01); // BGMODE (Mode 1)
-    ppu.write(0x2107, 0x04); // BG1SC (tilemap -> word 0x0400, 32x32)
-    ppu.write(0x212C, 0x01); // TM (BG1 enabled)
+    // ---- Sprite CHR: one solid 8x8 tile (all pixels color index 1) ----
+    // OBJSEL name base 1 -> sprite CHR base = 1 << 13 = word 0x2000.
+    // Tile 0 lives at 0x2000 (16 words). 4bpp: plane 0 all set = color 1.
+    let sprite_chr_base: u16 = 0x2000;
+    ppu.write(0x2116, (sprite_chr_base & 0xFF) as u8);
+    ppu.write(0x2117, (sprite_chr_base >> 8) as u8);
+    for _row in 0..8 {
+        ppu.write(0x2118, 0xFF); // plane 0 (low)  -> bit 0 set on every pixel
+        ppu.write(0x2119, 0x00); // plane 1 (high)
+    }
+    for _row in 0..8 {
+        ppu.write(0x2118, 0x00); // plane 2
+        ppu.write(0x2119, 0x00); // plane 3
+    }
 
-    // SDL2 initialization
+    // ============================================================
+    // OAM setup
+    // ============================================================
+    // Park all 128 sprites off-screen (Y = 0xE0) so the zeroed OAM doesn't
+    // draw a block of tile-0 sprites at the top-left corner.
+    for i in 0u16..128 {
+        let addr = i * 4;
+        ppu.write(0x2102, (addr & 0xFF) as u8);
+        ppu.write(0x2103, ((addr >> 8) & 0x01) as u8);
+        ppu.write(0x2104, 0x00); // X lo -> latched
+        ppu.write(0x2104, 0xE0); // Y    -> commits (X=0, Y=0xE0)
+    }
+
+    // Sprite 0: visible 8x8 sprite near the center.
+    // Table 1: X=124, Y=108, tile=0, attr = priority 2 (0x20), palette 0, name 0.
+    ppu.write(0x2102, 0x00);
+    ppu.write(0x2103, 0x00);
+    ppu.write(0x2104, 124);  // X    -> latched
+    ppu.write(0x2104, 108);  // Y    -> commits word (X, Y)
+    ppu.write(0x2104, 0x00); // tile -> latched
+    ppu.write(0x2104, 0x20); // attr -> commits word (tile, attr)
+
+    // ============================================================
+    // PPU registers
+    // ============================================================
+    ppu.write(0x2100, 0x0F); // INIDISP: display on, full brightness
+    ppu.write(0x2101, 0x01); // OBJSEL:  size 8x8/16x16, sprite CHR base = 0x2000
+    ppu.write(0x2105, 0x01); // BGMODE:  mode 1
+    ppu.write(0x2107, 0x04); // BG1SC:   tilemap at word 0x0400, 32x32
+    ppu.write(0x212C, 0x11); // TM:      BG1 (0x01) + OBJ (0x10) enabled
+    // ppu.write(0x212C, 0x01); // TM:      BG1 only (OBJ disabled)
+
+    // ============================================================
+    // SDL2
+    // ============================================================
     let sdl_context = sdl2::init().unwrap();
     let video = sdl_context.video().unwrap();
 
     let window = video
-        .window("SNES PPU", SCREEN_WIDTH as u32, SCREEN_HEIGHT as u32)
+        .window("SNES PPU - sprite test", SCREEN_WIDTH as u32, SCREEN_HEIGHT as u32)
         .position_centered()
         .build()
         .unwrap();

--- a/ppu/src/oam.rs
+++ b/ppu/src/oam.rs
@@ -321,6 +321,9 @@ impl OAM {
 mod tests {
     use super::*;
 
+    // (objsel, small size, large size) for sprite_size cases
+    type SizeCase = (u8, (u8, u8), (u8, u8));
+
     fn make_oam() -> OAM {
         let mut oam = OAM::new();
         // Park every sprite off-screen (y=240) by default, so evaluation
@@ -451,7 +454,7 @@ mod tests {
     // sprite_size returns correct dimensions for all 6 documented size modes.
     #[test]
     fn test_sprite_size() {
-        let cases: &[(u8, (u8, u8), (u8, u8))] = &[
+        let cases: &[SizeCase] = &[
             (0 << 5, (8, 8), (16, 16)),
             (1 << 5, (8, 8), (32, 32)),
             (2 << 5, (8, 8), (64, 64)),

--- a/ppu/src/oam.rs
+++ b/ppu/src/oam.rs
@@ -5,6 +5,33 @@ const OAM_TABLE1_SIZE: usize = 512;
 const OAM_TABLE2_SIZE: usize = 32;
 const OAM_SIZE: usize = OAM_TABLE1_SIZE + OAM_TABLE2_SIZE;
 
+/// Decoded sprite attributes from OAM.
+#[derive(Debug, Clone, Copy)]
+pub struct Sprite {
+    /// X position (9-bit signed: sprites past 255 wrap to the left of the screen)
+    pub x: i16,
+    /// Y position (top edge of the sprite)
+    pub y: u8,
+    /// Raw tile number (0-255) from OAM. The final VRAM address is
+    /// `chr_base + tile * 16`, with multi-tile sprites wrapping the low nibble
+    /// (horizontal) and high nibble (vertical) independently.
+    pub tile: u8,
+    /// Base CHR word address for this sprite, with name-table selection applied.
+    pub chr_base: u16,
+    /// Name-table select bit (from table 1 attribute byte)
+    pub name_table: u8,
+    /// Palette number (0-7); sprites use CGRAM entries 128-255
+    pub palette: u8,
+    /// Priority (0-3)
+    pub priority: u8,
+    /// Horizontal flip
+    pub flip_x: bool,
+    /// Vertical flip
+    pub flip_y: bool,
+    /// Large size bit (the actual size comes from OBJSEL)
+    pub large: bool,
+}
+
 pub struct OAM {
     /// Raw OAM data: 512 bytes table 1 + 32 bytes table 2.
     data: [u8; OAM_SIZE],
@@ -92,6 +119,197 @@ impl OAM {
         let value = self.data[addr];
         self.word_addr = (self.word_addr + 1) % OAM_SIZE as u16;
         value
+    }
+
+    // ============================================================
+    // Sprite decoding
+    // ============================================================
+
+    /// Decode sprite `index` (0-127) from OAM
+    pub fn get_sprite(&self, index: u8, objsel: u8) -> Sprite {
+        let i = index as usize;
+
+        // Table 1: 4 bytes per sprite
+        let x_lo = self.data[i * 4];
+        let y = self.data[i * 4 + 1];
+        let tile_lo = self.data[i * 4 + 2];
+        let attr = self.data[i * 4 + 3]; // vhoopppN
+        let flip_y = (attr & 0x80) != 0;
+        let flip_x = (attr & 0x40) != 0;
+        let priority = (attr >> 4) & 0x03;
+        let palette = (attr >> 1) & 0x07;
+        let name_table = attr & 0x01;
+
+        // Table 2: 2 bits per sprite, packed 4 per byte
+        let t2_byte = self.data[OAM_TABLE1_SIZE + i / 4];
+        let t2_bits = (t2_byte >> ((i % 4) * 2)) & 0x03;
+        let x_hi = t2_bits & 0x01; // bit 8 of X
+        let large = (t2_bits & 0x02) != 0;
+
+        // Reconstruct 9-bit X (256-511 => -256 to -1)
+        let x_raw = ((x_hi as u16) << 8) | x_lo as u16;
+        let x = if x_hi != 0 { x_raw as i16 - 512 } else { x_raw as i16 };
+
+        // CHR base address from OBJSEL, plus name-table selection.
+        // OBJSEL bits 2:0 = name base address (in 0x2000-word steps),
+        // bits 4:3 = secondary name select (offset for name_table == 1).
+        let name_base = (objsel & 0x07) as u16;
+        let name_select = ((objsel >> 3) & 0x03) as u16;
+        let chr_base = if name_table == 0 {
+            name_base << 13
+        } else {
+            (name_base << 13).wrapping_add((name_select + 1) << 12)
+        };
+
+        Sprite {
+            x,
+            y,
+            tile: tile_lo,
+            chr_base,
+            name_table,
+            palette,
+            priority,
+            flip_x,
+            flip_y,
+            large,
+        }
+    }
+
+    /// Return the sprite size (width, height) in pixels for a given sprite,
+    /// according to the size mode encoded in OBJSEL bits 7:5.
+    pub fn sprite_size(objsel: u8, large: bool) -> (u8, u8) {
+        match (objsel >> 5) & 0x07 {
+            0 => if large { (16, 16) } else { (8, 8) },
+            1 => if large { (32, 32) } else { (8, 8) },
+            2 => if large { (64, 64) } else { (8, 8) },
+            3 => if large { (32, 32) } else { (16, 16) },
+            4 => if large { (64, 64) } else { (16, 16) },
+            5 => if large { (64, 64) } else { (32, 32) },
+            // can't find documentation for 6 and 7, treating them as 8x8 / 16x16 for now
+            _ => if large { (16, 16) } else { (8, 8) },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_oam() -> OAM {
+        OAM::new()
+    }
+
+    // ============================================================
+    // Register access
+    // ============================================================
+
+    // A freshly created OAM is fully zeroed.
+    #[test]
+    fn test_new_zeroed() {
+        let oam = make_oam();
+        assert!(oam.data.iter().all(|&b| b == 0));
+        assert_eq!(oam.word_addr, 0);
+    }
+
+    // write_addr sets the byte address (masked to 9 bits) and resets the latch.
+    #[test]
+    fn test_write_addr() {
+        let mut oam = make_oam();
+        oam.write_phase_high = true;
+        oam.write_addr(0xFFFF);
+        assert_eq!(oam.word_addr, 0x01FF);
+        assert!(!oam.write_phase_high);
+    }
+
+    // Table 1: first write latches, second commits lo+hi and advances by 2.
+    #[test]
+    fn test_write_data_table1_write_twice() {
+        let mut oam = make_oam();
+        oam.write_addr(0x0000);
+
+        oam.write_data(0xCD); // lo latched
+        assert_eq!(oam.data[0], 0x00);
+        assert!(oam.write_phase_high);
+        assert_eq!(oam.write_latch, 0xCD);
+
+        oam.write_data(0xEF); // commit
+        assert_eq!(oam.data[0], 0xCD);
+        assert_eq!(oam.data[1], 0xEF);
+        assert_eq!(oam.word_addr, 2);
+        assert!(!oam.write_phase_high);
+    }
+
+    // Table 2: writes commit immediately, one byte at a time.
+    #[test]
+    fn test_write_data_table2_immediate() {
+        let mut oam = make_oam();
+        oam.write_addr(OAM_TABLE1_SIZE as u16);
+        oam.write_data(0b10110001);
+        assert_eq!(oam.data[OAM_TABLE1_SIZE], 0b10110001);
+    }
+
+    // read_data returns bytes in order and advances the address.
+    #[test]
+    fn test_read_data_advances_address() {
+        let mut oam = make_oam();
+        oam.data[0] = 0xAA;
+        oam.data[1] = 0xBB;
+        oam.write_addr(0x0000);
+        assert_eq!(oam.read_data(), 0xAA);
+        assert_eq!(oam.word_addr, 1);
+        assert_eq!(oam.read_data(), 0xBB);
+        assert_eq!(oam.word_addr, 2);
+    }
+
+    // ============================================================
+    // Sprite decoding
+    // ============================================================
+
+    // get_sprite decodes all fields, including 9-bit signed X and large bit.
+    #[test]
+    fn test_get_sprite_decodes_fields() {
+        let mut oam = make_oam();
+        // x=100, y=50, tile=5, attr=vhoopppN=0b11001110
+        oam.data[0] = 100;
+        oam.data[1] = 50;
+        oam.data[2] = 5;
+        oam.data[3] = 0b11001110;
+        // table 2 sprite 0: x_hi=1, large=0
+        oam.data[OAM_TABLE1_SIZE] = 0b01;
+
+        let s = oam.get_sprite(0, 0x00);
+        assert_eq!(s.x, -156); // (1<<8 | 100) = 356 -> 356-512 = -156
+        assert_eq!(s.y, 50);
+        assert_eq!(s.tile, 5);
+        assert!(s.flip_x);
+        assert!(s.flip_y);
+        assert_eq!(s.palette, 7);
+        assert_eq!(s.priority, 0);
+        assert_eq!(s.name_table, 0);
+        assert!(!s.large);
+
+        // large bit set
+        oam.data[OAM_TABLE1_SIZE] = 0b10;
+        let s = oam.get_sprite(0, 0x00);
+        assert!(s.large);
+        assert_eq!(s.x, 0);
+    }
+
+    // sprite_size returns correct dimensions for all 6 documented size modes.
+    #[test]
+    fn test_sprite_size() {
+        let cases: &[(u8, (u8, u8), (u8, u8))] = &[
+            (0 << 5, (8, 8), (16, 16)),
+            (1 << 5, (8, 8), (32, 32)),
+            (2 << 5, (8, 8), (64, 64)),
+            (3 << 5, (16, 16), (32, 32)),
+            (4 << 5, (16, 16), (64, 64)),
+            (5 << 5, (32, 32), (64, 64)),
+        ];
+        for &(objsel, small, large) in cases {
+            assert_eq!(OAM::sprite_size(objsel, false), small, "objsel={objsel:#04X} small");
+            assert_eq!(OAM::sprite_size(objsel, true), large, "objsel={objsel:#04X} large");
+        }
     }
 }
 

--- a/ppu/src/oam.rs
+++ b/ppu/src/oam.rs
@@ -1,0 +1,151 @@
+// OAM layout:
+// Table 1 ($000-$1FF): 128 sprites * 4 bytes
+// Table 2 ($200-$21F): 128 sprites * 2 bits (packed, 4 sprites per byte)
+const OAM_TABLE1_SIZE: usize = 512;
+const OAM_TABLE2_SIZE: usize = 32;
+const OAM_SIZE: usize = OAM_TABLE1_SIZE + OAM_TABLE2_SIZE;
+
+pub struct OAM {
+    /// Raw OAM data: 512 bytes table 1 + 32 bytes table 2.
+    data: [u8; OAM_SIZE],
+
+    /// Internal byte address (0-543 range, masked to 9 bits on write).
+    /// Set by OAMADDL/H ($2102/$2103).
+    word_addr: u16,
+
+    /// Low-byte write buffer for table 1 (write-twice mechanism).
+    /// Table 1 writes commit in pairs: first write latches lo, second commits lo+hi.
+    write_latch: u8,
+
+    /// True when the next OAMDATA write is the high byte of a table 1 pair.
+    write_phase_high: bool,
+}
+
+impl Default for OAM {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OAM {
+    pub fn new() -> Self {
+        Self {
+            data: [0; OAM_SIZE],
+            word_addr: 0,
+            write_latch: 0,
+            write_phase_high: false,
+        }
+    }
+
+    // ============================================================
+    // $2102/$2103 - OAMADDL/OAMADDH
+    // ============================================================
+
+    /// Set the OAM byte address from the OAMADDL/H register pair (9-bit).
+    /// Resets the write-twice latch.
+    pub fn write_addr(&mut self, oamadd: u16) {
+        self.word_addr = oamadd & 0x01FF;
+        self.write_phase_high = false;
+    }
+
+    // ============================================================
+    // $2104 - OAMDATA (write)
+    // ============================================================
+
+    /// Write one byte to OAM via the data port.
+    ///
+    /// Table 1 ($000-$1FF): buffered in pairs. The first write latches the
+    /// low byte; the second commits both bytes and advances the address by 2.
+    /// Table 2 ($200-$21F): committed immediately, one byte at a time.
+    pub fn write_data(&mut self, value: u8) {
+        let addr = self.word_addr as usize;
+
+        if addr < OAM_TABLE1_SIZE {
+            // Table 1: write-twice (lo then hi)
+            if !self.write_phase_high {
+                self.write_latch = value;
+                self.write_phase_high = true;
+            } else {
+                let byte_addr = addr & !1; // align to even
+                self.data[byte_addr] = self.write_latch;
+                self.data[byte_addr + 1] = value;
+                self.write_phase_high = false;
+                self.word_addr = (self.word_addr + 2) & 0x01FF;
+            }
+        } else {
+            // Table 2: single-byte write, committed immediately
+            let byte_addr = OAM_TABLE1_SIZE + (addr - OAM_TABLE1_SIZE) % OAM_TABLE2_SIZE;
+            self.data[byte_addr] = value;
+            self.word_addr = OAM_TABLE1_SIZE as u16
+                + ((self.word_addr - OAM_TABLE1_SIZE as u16 + 1) % OAM_TABLE2_SIZE as u16);
+        }
+    }
+
+    // ============================================================
+    // $2138 - OAMDATAREAD (read)
+    // ============================================================
+
+    /// Read one byte from OAM via the data port.
+    /// Reads are single-byte and advance the address by 1.
+    pub fn read_data(&mut self) -> u8 {
+        let addr = self.word_addr as usize % OAM_SIZE;
+        let value = self.data[addr];
+        self.word_addr = (self.word_addr + 1) % OAM_SIZE as u16;
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // write_addr sets the byte address (masked to 9 bits) and resets the latch.
+    #[test]
+    fn test_write_addr() {
+        let mut oam = OAM::new();
+        oam.write_phase_high = true;
+        oam.write_addr(0xFFFF);
+        assert_eq!(oam.word_addr, 0x01FF);
+        assert!(!oam.write_phase_high);
+    }
+
+    // Table 1: first write latches, second commits lo+hi and advances by 2.
+    #[test]
+    fn test_write_data_table1_write_twice() {
+        let mut oam = OAM::new();
+        oam.write_addr(0x0000);
+
+        oam.write_data(0xCD); // lo latched
+        assert_eq!(oam.data[0], 0x00);
+        assert!(oam.write_phase_high);
+        assert_eq!(oam.write_latch, 0xCD);
+
+        oam.write_data(0xEF); // commit
+        assert_eq!(oam.data[0], 0xCD);
+        assert_eq!(oam.data[1], 0xEF);
+        assert_eq!(oam.word_addr, 2);
+        assert!(!oam.write_phase_high);
+    }
+
+    // Table 2: writes commit immediately, one byte at a time.
+    #[test]
+    fn test_write_data_table2_immediate() {
+        let mut oam = OAM::new();
+        oam.write_addr(OAM_TABLE1_SIZE as u16);
+        oam.write_data(0b10110001);
+        assert_eq!(oam.data[OAM_TABLE1_SIZE], 0b10110001);
+    }
+
+    // read_data returns bytes in order and advances the address.
+    #[test]
+    fn test_read_data_advances_address() {
+        let mut oam = OAM::new();
+        oam.data[0] = 0xAA;
+        oam.data[1] = 0xBB;
+        oam.write_addr(0x0000);
+        assert_eq!(oam.read_data(), 0xAA);
+        assert_eq!(oam.word_addr, 1);
+        assert_eq!(oam.read_data(), 0xBB);
+        assert_eq!(oam.word_addr, 2);
+    }
+}

--- a/ppu/src/oam.rs
+++ b/ppu/src/oam.rs
@@ -46,6 +46,14 @@ pub struct OAM {
 
     /// True when the next OAMDATA write is the high byte of a table 1 pair.
     write_phase_high: bool,
+
+    /// STAT77 bit 7: set when more than 32 sprites were found on a scanline.
+    /// Latched via set_flags; read through $213E.
+    pub time_over: bool,
+
+    /// STAT77 bit 6: set when more than 34 sprite tiles were found on a scanline.
+    /// Latched via set_flags; read through $213E.
+    pub range_over: bool,
 }
 
 impl Default for OAM {
@@ -61,6 +69,8 @@ impl OAM {
             word_addr: 0,
             write_latch: 0,
             write_phase_high: false,
+            time_over: false,
+            range_over: false,
         }
     }
 
@@ -200,8 +210,11 @@ impl OAM {
     ///   index (OAMADDH bit 7 enables it, OAMADDL >> 1 gives the start sprite),
     ///   wrapping around all 128 sprites.
     /// - At most 32 sprites per scanline are kept; a 33rd sets `time_over`.
-    /// - Returns (visible sprites, time_over).
-    pub fn eval_sprites_for_scanline( &self, y: usize, objsel: u8, oamadd: u16) -> (Vec<(u8, Sprite)>, bool) {
+    /// - At most 34 sprite tiles (8-pixel slices) fit on a scanline; beyond
+    ///   that, `range_over` is set.
+    /// - Returns (visible sprites, time_over, range_over). The flags are not
+    ///   stored here (this borrows &self); call `set_flags` to latch them.
+    pub fn eval_sprites_for_scanline(&self, y: usize, objsel: u8, oamadd: u16) -> (Vec<(u8, Sprite)>, bool, bool) {
         let priority_rotation = (oamadd >> 8) & 0x01 != 0;
         let start = if priority_rotation {
             ((oamadd & 0xFF) >> 1) as usize & 0x7F
@@ -211,11 +224,13 @@ impl OAM {
 
         let mut visible: Vec<(u8, Sprite)> = Vec::with_capacity(32);
         let mut time_over = false;
+        let mut range_over = false;
+        let mut tile_count: u16 = 0;
 
         for i in 0..128usize {
             let idx = (start + i) & 0x7F;
             let sprite = self.get_sprite(idx as u8, objsel);
-            let (_, height) = Self::sprite_size(objsel, sprite.large);
+            let (width, height) = Self::sprite_size(objsel, sprite.large);
 
             // Y range check in wrapping u8 arithmetic (matches hardware).
             let dy = (y as u8).wrapping_sub(sprite.y);
@@ -228,10 +243,22 @@ impl OAM {
                 break;
             }
 
+            // Each visible sprite contributes width/8 tiles on this scanline.
+            tile_count += (width as u16) / 8;
+            if tile_count > 34 {
+                range_over = true;
+            }
+
             visible.push((idx as u8, sprite));
         }
 
-        (visible, time_over)
+        (visible, time_over, range_over)
+    }
+
+    /// Latch the time_over / range_over flags for STAT77 ($213E).
+    pub fn set_flags(&mut self, time_over: bool, range_over: bool) {
+        self.time_over = time_over;
+        self.range_over = range_over;
     }
 }
 
@@ -397,7 +424,7 @@ mod tests {
         let mut oam = make_oam();
         make_sprite_entry(&mut oam, 0, 0, 10, 0, 0, 0); // y=10, 8x8 -> rows 10-17
 
-        let (visible, over) = oam.eval_sprites_for_scanline(10, OBJSEL_8_16, 0);
+        let (visible, over, _) = oam.eval_sprites_for_scanline(10, OBJSEL_8_16, 0);
         assert_eq!(visible.len(), 1);
         assert_eq!(visible[0].0, 0);
         assert!(!over);
@@ -414,7 +441,7 @@ mod tests {
         for i in 0..33u8 {
             make_sprite_entry(&mut oam, i, 0, 0, 0, 0, 0);
         }
-        let (visible, over) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, 0);
+        let (visible, over, _) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, 0);
         assert_eq!(visible.len(), 32);
         assert!(over);
 
@@ -422,7 +449,7 @@ mod tests {
         for i in 0..32u8 {
             make_sprite_entry(&mut oam, i, 0, 0, 0, 0, 0);
         }
-        let (visible, over) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, 0);
+        let (visible, over, _) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, 0);
         assert_eq!(visible.len(), 32);
         assert!(!over);
     }
@@ -433,7 +460,7 @@ mod tests {
         let mut oam = make_oam();
         make_sprite_entry(&mut oam, 10, 0, 0, 0, 0, 0);
         let oamadd: u16 = (1 << 8) | 20; // enable + start sprite 10 (20 >> 1)
-        let (visible, _) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, oamadd);
+        let (visible, _, _) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, oamadd);
         assert_eq!(visible.len(), 1);
         assert_eq!(visible[0].0, 10);
     }
@@ -454,9 +481,48 @@ mod tests {
         make_sprite_entry(&mut oam, 0, 0, 0, 0, 0, 0);
         make_sprite_entry(&mut oam, 5, 0, 0, 0, 0, 0);
         make_sprite_entry(&mut oam, 2, 0, 0, 0, 0, 0);
-        let (visible, _) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, 0);
+        let (visible, _, _) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, 0);
         assert_eq!(visible[0].0, 0);
         assert_eq!(visible[1].0, 2);
         assert_eq!(visible[2].0, 5);
+    }
+
+    // range_over is set when more than 34 tiles (8px slices) fall on a line.
+    // Small 8x8 sprites can't trigger it (the 32-sprite time_over limit hits
+    // first), so use large 64px-wide sprites: 5 * 8 = 40 tiles > 34, with only
+    // 5 sprites. OBJSEL mode 2 gives large = 64x64.
+    #[test]
+    fn test_eval_range_over() {
+        const OBJSEL_8_64: u8 = 2 << 5; // small 8x8, large 64x64
+
+        let mut oam = make_oam();
+        for i in 0..5u8 {
+            make_sprite_entry(&mut oam, i, 0, 0, 0, 0, 0b10); // large bit set
+        }
+        let (_, time_over, range_over) = oam.eval_sprites_for_scanline(0, OBJSEL_8_64, 0);
+        assert!(!time_over);
+        assert!(range_over);
+
+        // 4 large sprites = 32 tiles, not over.
+        let mut oam = make_oam();
+        for i in 0..4u8 {
+            make_sprite_entry(&mut oam, i, 0, 0, 0, 0, 0b10);
+        }
+        let (_, _, range_over) = oam.eval_sprites_for_scanline(0, OBJSEL_8_64, 0);
+        assert!(!range_over);
+    }
+
+    // set_flags latches the STAT77 flags.
+    #[test]
+    fn test_set_flags() {
+        let mut oam = make_oam();
+        assert!(!oam.time_over);
+        assert!(!oam.range_over);
+        oam.set_flags(true, true);
+        assert!(oam.time_over);
+        assert!(oam.range_over);
+        oam.set_flags(false, false);
+        assert!(!oam.time_over);
+        assert!(!oam.range_over);
     }
 }

--- a/ppu/src/oam.rs
+++ b/ppu/src/oam.rs
@@ -162,7 +162,11 @@ impl OAM {
 
         // Reconstruct 9-bit X (256-511 => -256 to -1)
         let x_raw = ((x_hi as u16) << 8) | x_lo as u16;
-        let x = if x_hi != 0 { x_raw as i16 - 512 } else { x_raw as i16 };
+        let x = if x_hi != 0 {
+            x_raw as i16 - 512
+        } else {
+            x_raw as i16
+        };
 
         // CHR base address from OBJSEL, plus name-table selection.
         // OBJSEL bits 2:0 = name base address (in 0x2000-word steps),
@@ -193,14 +197,56 @@ impl OAM {
     /// according to the size mode encoded in OBJSEL bits 7:5.
     pub fn sprite_size(objsel: u8, large: bool) -> (u8, u8) {
         match (objsel >> 5) & 0x07 {
-            0 => if large { (16, 16) } else { (8, 8) },
-            1 => if large { (32, 32) } else { (8, 8) },
-            2 => if large { (64, 64) } else { (8, 8) },
-            3 => if large { (32, 32) } else { (16, 16) },
-            4 => if large { (64, 64) } else { (16, 16) },
-            5 => if large { (64, 64) } else { (32, 32) },
+            0 => {
+                if large {
+                    (16, 16)
+                } else {
+                    (8, 8)
+                }
+            }
+            1 => {
+                if large {
+                    (32, 32)
+                } else {
+                    (8, 8)
+                }
+            }
+            2 => {
+                if large {
+                    (64, 64)
+                } else {
+                    (8, 8)
+                }
+            }
+            3 => {
+                if large {
+                    (32, 32)
+                } else {
+                    (16, 16)
+                }
+            }
+            4 => {
+                if large {
+                    (64, 64)
+                } else {
+                    (16, 16)
+                }
+            }
+            5 => {
+                if large {
+                    (64, 64)
+                } else {
+                    (32, 32)
+                }
+            }
             // can't find documentation for 6 and 7, treating them as 8x8 / 16x16 for now
-            _ => if large { (16, 16) } else { (8, 8) },
+            _ => {
+                if large {
+                    (16, 16)
+                } else {
+                    (8, 8)
+                }
+            }
         }
     }
 
@@ -218,7 +264,12 @@ impl OAM {
     ///   that, `range_over` is set.
     /// - Returns (visible sprites, time_over, range_over). The flags are not
     ///   stored here (this borrows &self); call `set_flags` to latch them.
-    pub fn eval_sprites_for_scanline(&self, y: usize, objsel: u8, oamadd: u16) -> (Vec<(u8, Sprite)>, bool, bool) {
+    pub fn eval_sprites_for_scanline(
+        &self,
+        y: usize,
+        objsel: u8,
+        oamadd: u16,
+    ) -> (Vec<(u8, Sprite)>, bool, bool) {
         let priority_rotation = (oamadd >> 8) & 0x01 != 0;
         let start = if priority_rotation {
             ((oamadd & 0xFF) >> 1) as usize & 0x7F
@@ -409,8 +460,16 @@ mod tests {
             (5 << 5, (32, 32), (64, 64)),
         ];
         for &(objsel, small, large) in cases {
-            assert_eq!(OAM::sprite_size(objsel, false), small, "objsel={objsel:#04X} small");
-            assert_eq!(OAM::sprite_size(objsel, true), large, "objsel={objsel:#04X} large");
+            assert_eq!(
+                OAM::sprite_size(objsel, false),
+                small,
+                "objsel={objsel:#04X} small"
+            );
+            assert_eq!(
+                OAM::sprite_size(objsel, true),
+                large,
+                "objsel={objsel:#04X} large"
+            );
         }
     }
 
@@ -470,8 +529,14 @@ mod tests {
     fn test_eval_y_wrap() {
         let mut oam = make_oam();
         make_sprite_entry(&mut oam, 0, 0, 250, 0, 0, 0); // y=250, 8x8
-        assert_eq!(oam.eval_sprites_for_scanline(255, OBJSEL_8_16, 0).0.len(), 1);
-        assert_eq!(oam.eval_sprites_for_scanline(249, OBJSEL_8_16, 0).0.len(), 0);
+        assert_eq!(
+            oam.eval_sprites_for_scanline(255, OBJSEL_8_16, 0).0.len(),
+            1
+        );
+        assert_eq!(
+            oam.eval_sprites_for_scanline(249, OBJSEL_8_16, 0).0.len(),
+            0
+        )
     }
 
     // Without rotation, sprites come back in ascending index order.

--- a/ppu/src/oam.rs
+++ b/ppu/src/oam.rs
@@ -36,16 +36,14 @@ pub struct OAM {
     /// Raw OAM data: 512 bytes table 1 + 32 bytes table 2.
     data: [u8; OAM_SIZE],
 
-    /// Internal byte address (0-543 range, masked to 9 bits on write).
-    /// Set by OAMADDL/H ($2102/$2103).
-    word_addr: u16,
+    /// Internal 10-bit byte pointer into OAM. OAMADD ($2102/$2103) holds a
+    /// 9-bit *word* address; the internal byte pointer is word << 1. This is
+    /// how the hardware reaches both the low table (words 0-255 = bytes
+    /// 0-511) and the high table (words 256-271 = bytes 512-543).
+    address: u16,
 
-    /// Low-byte write buffer for table 1 (write-twice mechanism).
-    /// Table 1 writes commit in pairs: first write latches lo, second commits lo+hi.
+    /// Low-byte latch for the table-1 write-twice mechanism.
     write_latch: u8,
-
-    /// True when the next OAMDATA write is the high byte of a table 1 pair.
-    write_phase_high: bool,
 
     /// STAT77 bit 7: set when more than 32 sprites were found on a scanline.
     /// Latched via set_flags; read through $213E.
@@ -66,9 +64,8 @@ impl OAM {
     pub fn new() -> Self {
         Self {
             data: [0; OAM_SIZE],
-            word_addr: 0,
+            address: 0,
             write_latch: 0,
-            write_phase_high: false,
             time_over: false,
             range_over: false,
         }
@@ -78,56 +75,63 @@ impl OAM {
     // $2102/$2103 - OAMADDL/OAMADDH
     // ============================================================
 
-    /// Set the OAM byte address from the OAMADDL/H register pair, covering
-    /// both tables (0-543). Resets the write-twice latch.
+    /// Set the OAM address from the OAMADDL/H register pair.
+    ///
+    /// OAMADD is a 9-bit *word* address (0-511). The internal pointer is a
+    /// byte address (word << 1, 10-bit), which is how the hardware reaches
+    /// the low table (words 0-255) and the high table (words 256-271).
     pub fn write_addr(&mut self, oamadd: u16) {
-        self.word_addr = (oamadd as usize % OAM_SIZE) as u16;
-        self.write_phase_high = false;
+        self.address = (oamadd & 0x01FF) << 1;
     }
 
     // ============================================================
     // $2104 - OAMDATA (write)
     // ============================================================
 
-    /// Write one byte to OAM via the data port.
+    /// Write one byte to OAM via the data port ($2104).
     ///
-    /// Table 1 ($000-$1FF): buffered in pairs. The first write latches the
-    /// low byte; the second commits both bytes and advances the address by 2.
-    /// Table 2 ($200-$21F): committed immediately, one byte at a time.
+    /// Low table (bytes 0-511): write-twice. An even byte address latches the
+    /// value; the following odd byte writes the full word (latched low byte +
+    /// current high byte). This is the hardware's word-granular write.
+    /// High table (bytes 512-543): each byte is written immediately, mirrored
+    /// every 32 bytes.
+    /// The pointer advances by one byte per write and wraps at 10 bits.
     pub fn write_data(&mut self, value: u8) {
-        let addr = self.word_addr as usize;
+        let addr = self.address as usize;
 
         if addr < OAM_TABLE1_SIZE {
-            // Table 1: write-twice (lo then hi)
-            if !self.write_phase_high {
+            // Low table: even byte latches, odd byte commits the word.
+            if addr & 1 == 0 {
                 self.write_latch = value;
-                self.write_phase_high = true;
             } else {
-                let byte_addr = addr & !1; // align to even
-                self.data[byte_addr] = self.write_latch;
-                self.data[byte_addr + 1] = value;
-                self.write_phase_high = false;
-                self.word_addr = (self.word_addr + 2) & 0x01FF;
+                self.data[addr - 1] = self.write_latch;
+                self.data[addr] = value;
             }
         } else {
-            // Table 2: single-byte write, committed immediately
-            let byte_addr = OAM_TABLE1_SIZE + (addr - OAM_TABLE1_SIZE) % OAM_TABLE2_SIZE;
-            self.data[byte_addr] = value;
-            self.word_addr = OAM_TABLE1_SIZE as u16
-                + ((self.word_addr - OAM_TABLE1_SIZE as u16 + 1) % OAM_TABLE2_SIZE as u16);
+            // High table: immediate byte write, mirrored every 32 bytes.
+            let byte = OAM_TABLE1_SIZE + ((addr - OAM_TABLE1_SIZE) & (OAM_TABLE2_SIZE - 1));
+            self.data[byte] = value;
         }
+
+        self.address = (self.address + 1) & 0x03FF;
     }
 
     // ============================================================
     // $2138 - OAMDATAREAD (read)
     // ============================================================
 
-    /// Read one byte from OAM via the data port.
-    /// Reads are single-byte and advance the address by 1.
+    /// Read one byte from OAM via the data port ($2138).
+    /// Single-byte read; the pointer advances by one byte and wraps at 10 bits.
+    /// High-table addresses mirror every 32 bytes.
     pub fn read_data(&mut self) -> u8 {
-        let addr = self.word_addr as usize % OAM_SIZE;
-        let value = self.data[addr];
-        self.word_addr = (self.word_addr + 1) % OAM_SIZE as u16;
+        let addr = self.address as usize;
+        let byte = if addr < OAM_TABLE1_SIZE {
+            addr
+        } else {
+            OAM_TABLE1_SIZE + ((addr - OAM_TABLE1_SIZE) & (OAM_TABLE2_SIZE - 1))
+        };
+        let value = self.data[byte];
+        self.address = (self.address + 1) & 0x03FF;
         value
     }
 
@@ -300,52 +304,48 @@ mod tests {
     fn test_new_zeroed() {
         let oam = OAM::new();
         assert!(oam.data.iter().all(|&b| b == 0));
-        assert_eq!(oam.word_addr, 0);
+        assert_eq!(oam.address, 0);
     }
 
-    // write_addr sets the byte address (covering both tables) and resets the latch.
+    // write_addr converts the 9-bit word address to a byte pointer (word << 1).
     #[test]
     fn test_write_addr() {
         let mut oam = make_oam();
-        oam.write_phase_high = true;
 
-        // Table 1 address
+        // Word 0x10 -> byte 0x20.
         oam.write_addr(0x0010);
-        assert_eq!(oam.word_addr, 0x0010);
-        assert!(!oam.write_phase_high);
+        assert_eq!(oam.address, 0x0020);
 
-        // Table 2 start address
-        oam.write_addr(OAM_TABLE1_SIZE as u16);
-        assert_eq!(oam.word_addr, OAM_TABLE1_SIZE as u16);
+        // Word 256 selects the start of the high table (byte 512).
+        oam.write_addr(256);
+        assert_eq!(oam.address, OAM_TABLE1_SIZE as u16);
 
-        // Out-of-range addresses wrap within the 544-byte OAM
-        oam.write_addr(OAM_SIZE as u16);
-        assert_eq!(oam.word_addr, 0);
+        // Only the low 9 bits of the word address are used.
+        oam.write_addr(0xFFFF);
+        assert_eq!(oam.address, 0x01FF << 1);
     }
 
-    // Table 1: first write latches, second commits lo+hi and advances by 2.
+    // Table 1: even byte latches, odd byte commits the word and advances by 2.
     #[test]
     fn test_write_data_table1_write_twice() {
         let mut oam = make_oam();
         oam.write_addr(0x0000);
 
-        oam.write_data(0xCD); // lo latched
+        oam.write_data(0xCD); // even byte -> latched, not committed
         assert_eq!(oam.data[0], 0x00);
-        assert!(oam.write_phase_high);
         assert_eq!(oam.write_latch, 0xCD);
 
-        oam.write_data(0xEF); // commit
+        oam.write_data(0xEF); // odd byte -> commits the word
         assert_eq!(oam.data[0], 0xCD);
         assert_eq!(oam.data[1], 0xEF);
-        assert_eq!(oam.word_addr, 2);
-        assert!(!oam.write_phase_high);
+        assert_eq!(oam.address, 2);
     }
 
     // Table 2: writes commit immediately, one byte at a time.
     #[test]
     fn test_write_data_table2_immediate() {
         let mut oam = make_oam();
-        oam.write_addr(OAM_TABLE1_SIZE as u16);
+        oam.write_addr(256); // word 256 -> byte 512 (high table start)
         oam.write_data(0b10110001);
         assert_eq!(oam.data[OAM_TABLE1_SIZE], 0b10110001);
     }
@@ -358,9 +358,9 @@ mod tests {
         oam.data[1] = 0xBB;
         oam.write_addr(0x0000);
         assert_eq!(oam.read_data(), 0xAA);
-        assert_eq!(oam.word_addr, 1);
+        assert_eq!(oam.address, 1);
         assert_eq!(oam.read_data(), 0xBB);
-        assert_eq!(oam.word_addr, 2);
+        assert_eq!(oam.address, 2);
     }
 
     // ============================================================

--- a/ppu/src/oam.rs
+++ b/ppu/src/oam.rs
@@ -68,10 +68,10 @@ impl OAM {
     // $2102/$2103 - OAMADDL/OAMADDH
     // ============================================================
 
-    /// Set the OAM byte address from the OAMADDL/H register pair (9-bit).
-    /// Resets the write-twice latch.
+    /// Set the OAM byte address from the OAMADDL/H register pair, covering
+    /// both tables (0-543). Resets the write-twice latch.
     pub fn write_addr(&mut self, oamadd: u16) {
-        self.word_addr = oamadd & 0x01FF;
+        self.word_addr = (oamadd as usize % OAM_SIZE) as u16;
         self.write_phase_high = false;
     }
 
@@ -189,6 +189,50 @@ impl OAM {
             _ => if large { (16, 16) } else { (8, 8) },
         }
     }
+
+    // ============================================================
+    // Per-scanline evaluation
+    // ============================================================
+
+    /// Evaluate which sprites are visible on scanline `y`.
+    ///
+    /// - Sprites are evaluated in order, starting from the priority-rotation
+    ///   index (OAMADDH bit 7 enables it, OAMADDL >> 1 gives the start sprite),
+    ///   wrapping around all 128 sprites.
+    /// - At most 32 sprites per scanline are kept; a 33rd sets `time_over`.
+    /// - Returns (visible sprites, time_over).
+    pub fn eval_sprites_for_scanline( &self, y: usize, objsel: u8, oamadd: u16) -> (Vec<(u8, Sprite)>, bool) {
+        let priority_rotation = (oamadd >> 8) & 0x01 != 0;
+        let start = if priority_rotation {
+            ((oamadd & 0xFF) >> 1) as usize & 0x7F
+        } else {
+            0
+        };
+
+        let mut visible: Vec<(u8, Sprite)> = Vec::with_capacity(32);
+        let mut time_over = false;
+
+        for i in 0..128usize {
+            let idx = (start + i) & 0x7F;
+            let sprite = self.get_sprite(idx as u8, objsel);
+            let (_, height) = Self::sprite_size(objsel, sprite.large);
+
+            // Y range check in wrapping u8 arithmetic (matches hardware).
+            let dy = (y as u8).wrapping_sub(sprite.y);
+            if dy >= height {
+                continue;
+            }
+
+            if visible.len() >= 32 {
+                time_over = true;
+                break;
+            }
+
+            visible.push((idx as u8, sprite));
+        }
+
+        (visible, time_over)
+    }
 }
 
 #[cfg(test)]
@@ -196,8 +240,29 @@ mod tests {
     use super::*;
 
     fn make_oam() -> OAM {
-        OAM::new()
+        let mut oam = OAM::new();
+        // Park every sprite off-screen (y=240) by default, so evaluation
+        // tests only see the sprites they explicitly place.
+        for i in 0..128 {
+            oam.data[i * 4 + 1] = 240;
+        }
+        oam
     }
+
+    fn make_sprite_entry(oam: &mut OAM, index: u8, x: u8, y: u8, tile: u8, attr: u8, t2_bits: u8) {
+        let i = index as usize;
+        oam.data[i * 4] = x;
+        oam.data[i * 4 + 1] = y;
+        oam.data[i * 4 + 2] = tile;
+        oam.data[i * 4 + 3] = attr;
+        let byte_idx = OAM_TABLE1_SIZE + i / 4;
+        let shift = (i % 4) * 2;
+        oam.data[byte_idx] &= !(0x03 << shift);
+        oam.data[byte_idx] |= (t2_bits & 0x03) << shift;
+    }
+
+    // objsel = 0x00 -> small=8x8, large=16x16
+    const OBJSEL_8_16: u8 = 0x00;
 
     // ============================================================
     // Register access
@@ -206,19 +271,29 @@ mod tests {
     // A freshly created OAM is fully zeroed.
     #[test]
     fn test_new_zeroed() {
-        let oam = make_oam();
+        let oam = OAM::new();
         assert!(oam.data.iter().all(|&b| b == 0));
         assert_eq!(oam.word_addr, 0);
     }
 
-    // write_addr sets the byte address (masked to 9 bits) and resets the latch.
+    // write_addr sets the byte address (covering both tables) and resets the latch.
     #[test]
     fn test_write_addr() {
         let mut oam = make_oam();
         oam.write_phase_high = true;
-        oam.write_addr(0xFFFF);
-        assert_eq!(oam.word_addr, 0x01FF);
+
+        // Table 1 address
+        oam.write_addr(0x0010);
+        assert_eq!(oam.word_addr, 0x0010);
         assert!(!oam.write_phase_high);
+
+        // Table 2 start address
+        oam.write_addr(OAM_TABLE1_SIZE as u16);
+        assert_eq!(oam.word_addr, OAM_TABLE1_SIZE as u16);
+
+        // Out-of-range addresses wrap within the 544-byte OAM
+        oam.write_addr(OAM_SIZE as u16);
+        assert_eq!(oam.word_addr, 0);
     }
 
     // Table 1: first write latches, second commits lo+hi and advances by 2.
@@ -288,11 +363,11 @@ mod tests {
         assert_eq!(s.name_table, 0);
         assert!(!s.large);
 
-        // large bit set
+        // large bit set (x_hi=0 here, so x = x_lo = 100)
         oam.data[OAM_TABLE1_SIZE] = 0b10;
         let s = oam.get_sprite(0, 0x00);
         assert!(s.large);
-        assert_eq!(s.x, 0);
+        assert_eq!(s.x, 100);
     }
 
     // sprite_size returns correct dimensions for all 6 documented size modes.
@@ -311,59 +386,77 @@ mod tests {
             assert_eq!(OAM::sprite_size(objsel, true), large, "objsel={objsel:#04X} large");
         }
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+    // ============================================================
+    // Per-scanline evaluation
+    // ============================================================
 
-    // write_addr sets the byte address (masked to 9 bits) and resets the latch.
+    // A sprite covering the scanline appears; outside its Y range it does not.
     #[test]
-    fn test_write_addr() {
-        let mut oam = OAM::new();
-        oam.write_phase_high = true;
-        oam.write_addr(0xFFFF);
-        assert_eq!(oam.word_addr, 0x01FF);
-        assert!(!oam.write_phase_high);
+    fn test_eval_sprite_range() {
+        let mut oam = make_oam();
+        make_sprite_entry(&mut oam, 0, 0, 10, 0, 0, 0); // y=10, 8x8 -> rows 10-17
+
+        let (visible, over) = oam.eval_sprites_for_scanline(10, OBJSEL_8_16, 0);
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].0, 0);
+        assert!(!over);
+
+        assert_eq!(oam.eval_sprites_for_scanline(17, OBJSEL_8_16, 0).0.len(), 1);
+        assert_eq!(oam.eval_sprites_for_scanline(18, OBJSEL_8_16, 0).0.len(), 0);
+        assert_eq!(oam.eval_sprites_for_scanline(9, OBJSEL_8_16, 0).0.len(), 0);
     }
 
-    // Table 1: first write latches, second commits lo+hi and advances by 2.
+    // 33 sprites on one scanline: only 32 kept, time_over set; exactly 32 is fine.
     #[test]
-    fn test_write_data_table1_write_twice() {
-        let mut oam = OAM::new();
-        oam.write_addr(0x0000);
+    fn test_eval_time_over() {
+        let mut oam = make_oam();
+        for i in 0..33u8 {
+            make_sprite_entry(&mut oam, i, 0, 0, 0, 0, 0);
+        }
+        let (visible, over) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, 0);
+        assert_eq!(visible.len(), 32);
+        assert!(over);
 
-        oam.write_data(0xCD); // lo latched
-        assert_eq!(oam.data[0], 0x00);
-        assert!(oam.write_phase_high);
-        assert_eq!(oam.write_latch, 0xCD);
-
-        oam.write_data(0xEF); // commit
-        assert_eq!(oam.data[0], 0xCD);
-        assert_eq!(oam.data[1], 0xEF);
-        assert_eq!(oam.word_addr, 2);
-        assert!(!oam.write_phase_high);
+        let mut oam = make_oam();
+        for i in 0..32u8 {
+            make_sprite_entry(&mut oam, i, 0, 0, 0, 0, 0);
+        }
+        let (visible, over) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, 0);
+        assert_eq!(visible.len(), 32);
+        assert!(!over);
     }
 
-    // Table 2: writes commit immediately, one byte at a time.
+    // Priority rotation starts evaluation at the sprite given by OAMADDL >> 1.
     #[test]
-    fn test_write_data_table2_immediate() {
-        let mut oam = OAM::new();
-        oam.write_addr(OAM_TABLE1_SIZE as u16);
-        oam.write_data(0b10110001);
-        assert_eq!(oam.data[OAM_TABLE1_SIZE], 0b10110001);
+    fn test_eval_priority_rotation() {
+        let mut oam = make_oam();
+        make_sprite_entry(&mut oam, 10, 0, 0, 0, 0, 0);
+        let oamadd: u16 = (1 << 8) | 20; // enable + start sprite 10 (20 >> 1)
+        let (visible, _) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, oamadd);
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].0, 10);
     }
 
-    // read_data returns bytes in order and advances the address.
+    // Y wraps in u8: a sprite at y=250 covers scanline 255 but not 249.
     #[test]
-    fn test_read_data_advances_address() {
-        let mut oam = OAM::new();
-        oam.data[0] = 0xAA;
-        oam.data[1] = 0xBB;
-        oam.write_addr(0x0000);
-        assert_eq!(oam.read_data(), 0xAA);
-        assert_eq!(oam.word_addr, 1);
-        assert_eq!(oam.read_data(), 0xBB);
-        assert_eq!(oam.word_addr, 2);
+    fn test_eval_y_wrap() {
+        let mut oam = make_oam();
+        make_sprite_entry(&mut oam, 0, 0, 250, 0, 0, 0); // y=250, 8x8
+        assert_eq!(oam.eval_sprites_for_scanline(255, OBJSEL_8_16, 0).0.len(), 1);
+        assert_eq!(oam.eval_sprites_for_scanline(249, OBJSEL_8_16, 0).0.len(), 0);
+    }
+
+    // Without rotation, sprites come back in ascending index order.
+    #[test]
+    fn test_eval_order() {
+        let mut oam = make_oam();
+        make_sprite_entry(&mut oam, 0, 0, 0, 0, 0, 0);
+        make_sprite_entry(&mut oam, 5, 0, 0, 0, 0, 0);
+        make_sprite_entry(&mut oam, 2, 0, 0, 0, 0, 0);
+        let (visible, _) = oam.eval_sprites_for_scanline(0, OBJSEL_8_16, 0);
+        assert_eq!(visible[0].0, 0);
+        assert_eq!(visible[1].0, 2);
+        assert_eq!(visible[2].0, 5);
     }
 }

--- a/ppu/src/ppu.rs
+++ b/ppu/src/ppu.rs
@@ -1,5 +1,6 @@
 use crate::cgram::CGRAM;
 use crate::constants::SCANLINES_PER_FRAME;
+use crate::oam::OAM;
 use crate::registers::PPURegisters;
 use crate::vram::VRAM;
 use common::u16_split::U16Split;
@@ -8,6 +9,7 @@ pub struct PPU {
     pub regs: PPURegisters,
     pub vram: VRAM,
     pub cgram: CGRAM,
+    pub oam: OAM,
 
     // Timing
     pub scanline: u16,
@@ -26,6 +28,7 @@ impl PPU {
             regs: PPURegisters::new(),
             vram: VRAM::new(),
             cgram: CGRAM::new(),
+            oam: OAM::new(),
             scanline: 0,
             frame_ready: false,
         }
@@ -42,10 +45,16 @@ impl PPU {
             // ==========================
             // OAM
             // ==========================
-            0x2101 => self.regs.objsel = value,           // TODO
-            0x2102 => *self.regs.oamadd.lo_mut() = value, // TODO
-            0x2103 => *self.regs.oamadd.hi_mut() = value & 0x01, // TODO
-            0x2104 => self.regs.oamdata = value,          // TODO
+            0x2101 => self.regs.objsel = value,
+            0x2102 => {
+                *self.regs.oamadd.lo_mut() = value;
+                self.oam.write_addr(self.regs.oamadd);
+            }
+            0x2103 => {
+                *self.regs.oamadd.hi_mut() = value & 0x01;
+                self.oam.write_addr(self.regs.oamadd);
+            }
+            0x2104 => self.oam.write_data(value),
 
             // ==========================
             // BACKGROUNDS
@@ -256,7 +265,7 @@ impl PPU {
             // ==========================
             // OAM
             // ==========================
-            0x2138 => Self::unimplemented_read_only(addr), // TODO
+            0x2138 => self.oam.read_data(),
 
             // ==========================
             // VRAM

--- a/ppu/src/ppu.rs
+++ b/ppu/src/ppu.rs
@@ -288,7 +288,16 @@ impl PPU {
             // ==========================
             // Status
             // ==========================
-            0x213E => Self::unimplemented_read_only(addr), // TODO
+            0x213E => {
+                let mut val: u8 = 0x01; // PPU1 version
+                if self.oam.time_over {
+                    val |= 0x80;
+                }
+                if self.oam.range_over {
+                    val |= 0x40;
+                }
+                val
+            }
             0x213F => Self::unimplemented_read_only(addr), // TODO
 
             _ => {
@@ -302,6 +311,14 @@ impl PPU {
     }
 
     pub fn step_scanline(&mut self) {
+        // Update STAT77 sprite flags for the current line.
+        let objsel = self.regs.objsel;
+        let oamadd = self.regs.oamadd;
+        let (_, time_over, range_over) =
+            self.oam
+                .eval_sprites_for_scanline(self.scanline as usize, objsel, oamadd);
+        self.oam.set_flags(time_over, range_over);
+
         self.scanline += 1;
 
         if self.scanline >= SCANLINES_PER_FRAME {

--- a/ppu/src/ppu.rs
+++ b/ppu/src/ppu.rs
@@ -370,10 +370,9 @@ mod tests {
     // $2101–$2104 - OAM
     // ============================================================
 
-    /// Writing $2101 must update objsel.
-    /// Writing $2102 must update the low byte of oamadd.
-    /// Writing $2103 must update the high byte of oamadd (only bit 0 is valid).
-    /// Writing $2104 must update oamdata.
+    // Writing $2101 must update objsel.
+    // Writing $2102/$2103 must update oamadd (only bit 0 of the high byte is valid).
+    // Writing $2104 twice must commit a table-1 word, readable back via $2138.
     #[test]
     fn test_write_oam_registers() {
         let mut ppu = PPU::new();
@@ -387,8 +386,18 @@ mod tests {
         ppu.write(0x2103, 0x01);
         assert_eq!(*ppu.regs.oamadd.hi(), 0x01);
 
-        ppu.write(0x2104, 0xBE);
-        assert_eq!(ppu.regs.oamdata, 0xBE);
+        // Point at OAM address 0 and write a full table-1 word (write-twice:
+        // low byte latched, high byte commits both). Then read it back.
+        ppu.write(0x2102, 0x00);
+        ppu.write(0x2103, 0x00);
+        ppu.write(0x2104, 0xBE); // low byte -> latched
+        ppu.write(0x2104, 0xEF); // high byte -> commits (0xBE, 0xEF)
+
+        // Reset the read address to 0 and read the two bytes back.
+        ppu.write(0x2102, 0x00);
+        ppu.write(0x2103, 0x00);
+        assert_eq!(ppu.read(0x2138), 0xBE);
+        assert_eq!(ppu.read(0x2138), 0xEF);
     }
 
     // ============================================================

--- a/ppu/src/rendering/mode_0.rs
+++ b/ppu/src/rendering/mode_0.rs
@@ -202,28 +202,29 @@ mod tests {
     #[test]
     fn test_render_mode0_backdrop_and_transparency() {
         let mut renderer = make_renderer();
-        let mut ppu = make_ppu_mode0();
+        let ppu = make_ppu_mode0();
 
         // Default CGRAM[0] = 0x0000 -> black backdrop
-        renderer.render_scanline_mode0(&ppu, 0);
+        renderer.render_scanline(&ppu, 0);
         for x in 0..SCREEN_WIDTH {
             assert_eq!(pixel(&renderer, x, 0), (0, 0, 0), "x={}", x);
         }
 
         // Set backdrop to white, all tiles transparent -> full white scanline
+        let mut ppu = make_ppu_mode0();
         set_cgram_white(&mut ppu, 0);
         ppu.vram.memory[0] = 0x0000;
-        renderer.render_scanline_mode0(&ppu, 0);
+        renderer.render_scanline(&ppu, 0);
         let (br, bg, bb) = Renderer::apply_brightness(ppu.cgram.read(0), 15);
         for x in 0..SCREEN_WIDTH {
             assert_eq!(pixel(&renderer, x, 0), (br, bg, bb), "x={}", x);
         }
 
-        // Tile with CHR all zero (color index 0) -> still shows backdrop even with opaque tile entry
+        // Tile with CHR all zero (color index 0) -> still shows backdrop
         let mut ppu2 = make_ppu_mode0();
         set_cgram_white(&mut ppu2, 0);
         ppu2.vram.memory[0] = 0x0001; // tile 1, CHR stays all zero
-        renderer.render_scanline_mode0(&ppu2, 0);
+        renderer.render_scanline(&ppu2, 0);
         let (br, bg, bb) = Renderer::apply_brightness(ppu2.cgram.read(0), 15);
         for x in 0..SCREEN_WIDTH {
             assert_eq!(pixel(&renderer, x, 0), (br, bg, bb), "x={}", x);

--- a/ppu/src/rendering/mode_0.rs
+++ b/ppu/src/rendering/mode_0.rs
@@ -1,6 +1,6 @@
 use crate::constants::*;
 use crate::ppu::PPU;
-use crate::rendering::renderer::Renderer;
+use crate::rendering::renderer::{Renderer, Z_BG1_HIGH, Z_BG1_LOW};
 use crate::vram::RawVRAM;
 
 impl Renderer {
@@ -12,12 +12,6 @@ impl Renderer {
         // BG1 scroll registers
         let scroll_x = ppu.regs.bg1hofs as usize;
         let scroll_y = ppu.regs.bg1vofs as usize;
-
-        let backdrop = ppu.cgram.read(0);
-        let (br, bg, bb) = Self::apply_brightness(backdrop, self.current_brightness as u16);
-        for x in 0..SCREEN_WIDTH {
-            self.set_pixel(x, y, br, bg, bb);
-        }
 
         for x in 0..SCREEN_WIDTH {
             // ============================================================
@@ -39,7 +33,7 @@ impl Renderer {
 
             let tile_index = entry & 0x03FF; // bits 9:0
             let palette_num = (entry >> 10) & 0x07; // bits 12:10
-            let _priority = (entry & 0x2000) != 0; // bit 13
+            let priority = (entry & 0x2000) != 0; // bit 13
             let flip_x = (entry & 0x4000) != 0; // bit 14
             let flip_y = (entry & 0x8000) != 0; // bit 15
 
@@ -63,7 +57,8 @@ impl Renderer {
             let color = ppu.cgram.read(palette_entry);
 
             let (r, g, b) = Self::apply_brightness(color, self.current_brightness as u16);
-            self.set_pixel(x, y, r, g, b);
+            let z = if priority { Z_BG1_HIGH } else { Z_BG1_LOW };
+            self.set_pixel_z(x, y, r, g, b, z);
         }
     }
 

--- a/ppu/src/rendering/mode_1.rs
+++ b/ppu/src/rendering/mode_1.rs
@@ -62,7 +62,12 @@ impl Renderer {
         }
     }
 
-    pub fn decode_4bpp_tile_pixel_from(vram: &RawVRAM, tile_word_base: usize, x: usize, y: usize) -> u8 {
+    pub fn decode_4bpp_tile_pixel_from(
+        vram: &RawVRAM,
+        tile_word_base: usize,
+        x: usize,
+        y: usize,
+    ) -> u8 {
         // Planes 0+1: p0 = low byte, p1 = high byte
         let [p0, p1] = vram[tile_word_base + y].to_le_bytes();
 
@@ -224,7 +229,7 @@ mod tests {
     // render_scanline_mode1 - transparent pixels
     // ============================================================
 
-        /// A fully transparent tile must leave pixels showing the backdrop color.
+    /// A fully transparent tile must leave pixels showing the backdrop color.
     #[test]
     fn test_render_mode1_transparent_tile_leaves_framebuffer() {
         let mut renderer = Renderer::new();

--- a/ppu/src/rendering/mode_1.rs
+++ b/ppu/src/rendering/mode_1.rs
@@ -67,12 +67,7 @@ impl Renderer {
         }
     }
 
-    fn decode_4bpp_tile_pixel_from(
-        vram: &RawVRAM,
-        tile_word_base: usize,
-        x: usize,
-        y: usize,
-    ) -> u8 {
+    pub fn decode_4bpp_tile_pixel_from(vram: &RawVRAM, tile_word_base: usize, x: usize, y: usize) -> u8 {
         // Planes 0+1: p0 = low byte, p1 = high byte
         let [p0, p1] = vram[tile_word_base + y].to_le_bytes();
 

--- a/ppu/src/rendering/mode_1.rs
+++ b/ppu/src/rendering/mode_1.rs
@@ -224,23 +224,19 @@ mod tests {
     // render_scanline_mode1 - transparent pixels
     // ============================================================
 
-    /// A fully transparent tile must leave pixels filled with the backdrop color (CGRAM entry 0).
+        /// A fully transparent tile must leave pixels showing the backdrop color.
     #[test]
     fn test_render_mode1_transparent_tile_leaves_framebuffer() {
         let mut renderer = Renderer::new();
         renderer.current_brightness = 15;
-        // Pre-fill framebuffer with a sentinel value
-        for b in renderer.framebuffer.iter_mut() {
-            *b = 0xAA;
-        }
 
         let mut ppu = make_ppu_mode1();
-        // Tilemap entry at (0,0): tile 0, palette 0 - CHR data is all zero -> transparent
+        // Tilemap entry at (0,0): tile 0, all-zero CHR -> transparent
         ppu.vram.memory[0] = 0x0000;
 
-        renderer.render_scanline_mode1(&ppu, 0);
+        // Use the full render_scanline so the backdrop is drawn.
+        renderer.render_scanline(&ppu, 0);
 
-        // All pixels on scanline 0 must be the backdrop color
         let (br, bg, bb) = Renderer::apply_brightness(ppu.cgram.read(0), 15);
         for x in 0..SCREEN_WIDTH {
             let idx = x * 3;

--- a/ppu/src/rendering/mode_1.rs
+++ b/ppu/src/rendering/mode_1.rs
@@ -1,6 +1,6 @@
 use crate::constants::*;
 use crate::ppu::PPU;
-use crate::rendering::renderer::Renderer;
+use crate::rendering::renderer::{Renderer, Z_BG1_HIGH, Z_BG1_LOW};
 use crate::vram::RawVRAM;
 
 impl Renderer {
@@ -12,12 +12,6 @@ impl Renderer {
         // BG1 scroll registers
         let scroll_x = ppu.regs.bg1hofs as usize;
         let scroll_y = ppu.regs.bg1vofs as usize;
-
-        let backdrop = ppu.cgram.read(0);
-        let (br, bg, bb) = Self::apply_brightness(backdrop, self.current_brightness as u16);
-        for x in 0..SCREEN_WIDTH {
-            self.set_pixel(x, y, br, bg, bb);
-        }
 
         for x in 0..SCREEN_WIDTH {
             // ============================================================
@@ -39,7 +33,7 @@ impl Renderer {
 
             let tile_index = entry & 0x03FF; // bits 9:0
             let palette_num = (entry >> 10) & 0x07; // bits 12:10
-            let _priority = (entry & 0x2000) != 0; // bit 13
+            let priority = (entry & 0x2000) != 0; // bit 13
             let flip_x = (entry & 0x4000) != 0; // bit 14
             let flip_y = (entry & 0x8000) != 0; // bit 15
 
@@ -63,7 +57,8 @@ impl Renderer {
             let color = ppu.cgram.read(palette_entry);
 
             let (r, g, b) = Self::apply_brightness(color, self.current_brightness as u16);
-            self.set_pixel(x, y, r, g, b);
+            let z = if priority { Z_BG1_HIGH } else { Z_BG1_LOW };
+            self.set_pixel_z(x, y, r, g, b, z);
         }
     }
 

--- a/ppu/src/rendering/renderer.rs
+++ b/ppu/src/rendering/renderer.rs
@@ -71,6 +71,11 @@ impl Renderer {
                 println!("PPU mode {} not implemented", mode);
             }
         }
+
+        // Sprites, if OBJ is enabled on the main screen (TM bit 4)
+        if ppu.regs.tm & 0x10 != 0 {
+            self.render_sprites(ppu, y);
+        }
     }
 
     fn update_brightness(&mut self, target: u8) {

--- a/ppu/src/rendering/renderer.rs
+++ b/ppu/src/rendering/renderer.rs
@@ -4,9 +4,32 @@ use crate::ppu::PPU;
 /// Raw byte array of the framebuffer in RGB888
 pub type RawFramebuffer = [u8; SCREEN_WIDTH * SCREEN_HEIGHT * 3];
 
+// ============================================================
+// Z-order (priority) values, mode 1 (BG1 + OBJ subset).
+// Higher = closer to the front. A pixel is only overwritten when the
+// incoming z is >= the z already stored for that column.
+//
+// Full mode-1 order (front to back), for reference:
+//   OBJ.3 > BG1.1 > BG2.1 > OBJ.2 > BG1.0 > BG2.0 > OBJ.1 >
+//   BG3.1 > BG4.1 > OBJ.0 > BG3.0 > BG4.0 > backdrop
+// Only BG1 and OBJ are rendered for now; the values are spaced so the other
+// layers slot in later without renumbering.
+// ============================================================
+pub const Z_BACKDROP: u8 = 0;
+pub const Z_OBJ0: u8 = 3;
+pub const Z_OBJ1: u8 = 6;
+pub const Z_BG1_LOW: u8 = 8;
+pub const Z_OBJ2: u8 = 9;
+pub const Z_BG1_HIGH: u8 = 11;
+pub const Z_OBJ3: u8 = 12;
+
 pub struct Renderer {
     pub framebuffer: Box<RawFramebuffer>,
     pub current_brightness: u8,
+
+    /// Per-column z-order of the pixel currently written on the scanline
+    /// being rendered. Reset to Z_BACKDROP at the start of each scanline.
+    priority: Box<[u8; SCREEN_WIDTH]>,
 
     brightness_delay: u8,
 }
@@ -22,6 +45,7 @@ impl Renderer {
         Self {
             framebuffer: Box::new([0; SCREEN_WIDTH * SCREEN_HEIGHT * 3]),
             current_brightness: 15, // full brightness
+            priority: Box::new([Z_BACKDROP; SCREEN_WIDTH]),
             brightness_delay: 0,
         }
     }
@@ -35,6 +59,9 @@ impl Renderer {
 
         // Update brightness
         self.update_brightness(ppu.brightness());
+
+        // Reset per-column priorities for this scanline.
+        self.priority.fill(Z_BACKDROP);
 
         match ppu.regs.bg_mode() {
             0 => self.render_scanline_mode0(ppu, y),
@@ -86,6 +113,15 @@ impl Renderer {
         self.framebuffer[index] = r;
         self.framebuffer[index + 1] = g;
         self.framebuffer[index + 2] = b;
+    }
+
+    /// Write a pixel only if its z-order is at least the one already stored
+    /// for this column. On success, updates the stored z-order.
+    pub fn set_pixel_z(&mut self, x: usize, y: usize, r: u8, g: u8, b: u8, z: u8) {
+        if z >= self.priority[x] {
+            self.set_pixel(x, y, r, g, b);
+            self.priority[x] = z;
+        }
     }
 
     fn render_full_black(&mut self, y: usize) {

--- a/ppu/src/rendering/renderer.rs
+++ b/ppu/src/rendering/renderer.rs
@@ -60,9 +60,15 @@ impl Renderer {
         // Update brightness
         self.update_brightness(ppu.brightness());
 
-        // Reset per-column priorities for this scanline.
+        // Reset priorities and fill with the backdrop
         self.priority.fill(Z_BACKDROP);
+        let backdrop = ppu.cgram.read(0);
+        let (br, bg, bb) = Self::apply_brightness(backdrop, self.current_brightness as u16);
+        for x in 0..SCREEN_WIDTH {
+            self.set_pixel(x, y, br, bg, bb);
+        }
 
+        // Background layer
         match ppu.regs.bg_mode() {
             0 => self.render_scanline_mode0(ppu, y),
             1 => self.render_scanline_mode1(ppu, y),

--- a/ppu/src/sprites.rs
+++ b/ppu/src/sprites.rs
@@ -41,11 +41,7 @@ impl Renderer {
                 }
 
                 // Column within the sprite, with H flip.
-                let sx = if sprite.flip_x {
-                    w - 1 - col
-                } else {
-                    col
-                };
+                let sx = if sprite.flip_x { w - 1 - col } else { col };
 
                 // Locate the tile inside the sprite and the pixel inside the tile.
                 let tile_col = sx / 8;

--- a/ppu/src/sprites.rs
+++ b/ppu/src/sprites.rs
@@ -1,0 +1,83 @@
+use crate::constants::*;
+use crate::oam::OAM;
+use crate::ppu::PPU;
+use crate::rendering::renderer::{Renderer, Z_OBJ0, Z_OBJ1, Z_OBJ2, Z_OBJ3};
+
+// VRAM is 32768 words, sprite CHR addresses wrap within it.
+const VRAM_WORD_MASK: usize = (VRAM_SIZE / 2) - 1;
+
+impl Renderer {
+    /// Render all visible sprites on scanline `y`
+    pub fn render_sprites(&mut self, ppu: &PPU, y: usize) {
+        let objsel = ppu.regs.objsel;
+        let oamadd = ppu.regs.oamadd;
+
+        let (sprites, _time_over, _range_over) =
+            ppu.oam.eval_sprites_for_scanline(y, objsel, oamadd);
+
+        // Draw from the last evaluated sprite to the first
+        for &(_idx, sprite) in sprites.iter().rev() {
+            let (w, h) = OAM::sprite_size(objsel, sprite.large);
+            let w = w as usize;
+            let h = h as usize;
+
+            // Row within the sprite for this scanline (0..h), with V flip.
+            let mut sy = (y as u8).wrapping_sub(sprite.y) as usize;
+            if sprite.flip_y {
+                sy = h - 1 - sy;
+            }
+
+            let z = match sprite.priority {
+                0 => Z_OBJ0,
+                1 => Z_OBJ1,
+                2 => Z_OBJ2,
+                _ => Z_OBJ3,
+            };
+
+            for col in 0..w {
+                let screen_x = sprite.x + col as i16;
+                if screen_x < 0 || screen_x >= SCREEN_WIDTH as i16 {
+                    continue;
+                }
+
+                // Column within the sprite, with H flip.
+                let sx = if sprite.flip_x {
+                    w - 1 - col
+                } else {
+                    col
+                };
+
+                // Locate the tile inside the sprite and the pixel inside the tile.
+                let tile_col = sx / 8;
+                let tile_row = sy / 8;
+                let fine_x = sx % 8;
+                let fine_y = sy % 8;
+
+                // Multi-tile sprites wrap the low nibble (X) and high nibble (Y) of the tile number independently.
+                let base = sprite.tile as usize;
+                let tx = (base & 0x0F).wrapping_add(tile_col) & 0x0F;
+                let ty = (base & 0xF0).wrapping_add(tile_row * 0x10) & 0xF0;
+                let tile_num = ty | tx;
+
+                let tile_word_base = (sprite.chr_base as usize + tile_num * 16) & VRAM_WORD_MASK;
+
+                let color_index = Self::decode_4bpp_tile_pixel_from(
+                    &ppu.vram.memory,
+                    tile_word_base,
+                    fine_x,
+                    fine_y,
+                );
+
+                if color_index == 0 {
+                    continue;
+                }
+
+                let palette_entry = 128 + sprite.palette * 16 + color_index;
+                let color = ppu.cgram.read(palette_entry);
+
+                let (r, g, b) = Self::apply_brightness(color, self.current_brightness as u16);
+                self.set_pixel_z(screen_x as usize, y, r, g, b, z);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Description

This PR implements the OAM (Object Attribute Memory) subsystem and sprite rendering for the PPU.

What's included:

- OAM struct with register access (word-based addressing, write-twice for the low table, immediate writes for the high table)
- Sprite decoding: position, tile, palette, priority, flips, and size
- Per-scanline evaluation with the 32-sprite limit, priority rotation, and STAT77 time-over / range-over flags
- Per-pixel priority buffer for correct z-ordering between backgrounds and sprites
- Sprite rendering: multi-tile sprites (8x8 up to 64x64), flips, sprite palettes, transparency
- Unit tests and a visual example in main (cf. image)


Visual example: BG1 (gradient background) with an 8x8 red sprite and a 16x16 green sprite rendered on top
<img width="281" height="270" alt="image" src="https://github.com/user-attachments/assets/0caf8e3f-b43d-43c2-b524-01fe89a0c37b" />


## 🔍 Related Issues

Closes EpitechPromo2027/G-EIP-600-NAN-6-1-eip-florent.charpentier#85
